### PR TITLE
Make databricks jobs reset match design.

### DIFF
--- a/databricks_cli/jobs/cli.py
+++ b/databricks_cli/jobs/cli.py
@@ -47,10 +47,25 @@ def create_cli(json_file, json):
 @click.option('--json-file', default=None,
               help='File containing json to POST to /jobs/create.')
 @click.option('--json', default=None, help='Displays absolute paths.')
+@click.option('--job-id', required=True, help='The job_id to reset')
 @require_config
 @eat_exceptions
-def reset_cli(json_file, json):
-    json_cli_base(json_file, json, reset_job)
+def reset_cli(json_file, json, job_id):
+    if not bool(json_file) ^ bool(json):
+        raise RuntimeError('Either --json-file or --json should be provided')
+    if json_file:
+        with open(json_file, 'r') as f:
+            json = f.read()
+    deser_json = json_loads(json)
+    if 'job_id' in deser_json:
+        raise RuntimeError('job_id should not be provided in the json spec. The json spec should ' +
+                           'be of the format ' +
+                           'https://docs.databricks.com/api/latest/jobs.html#jobsjobsettings')
+    request_body = {
+        'job_id': job_id,
+        'new_settings': deser_json
+    }
+    reset_job(request_body)
 
 
 def _jobs_to_table(jobs_json):

--- a/databricks_cli/jobs/cli.py
+++ b/databricks_cli/jobs/cli.py
@@ -57,10 +57,6 @@ def reset_cli(json_file, json, job_id):
         with open(json_file, 'r') as f:
             json = f.read()
     deser_json = json_loads(json)
-    if 'job_id' in deser_json:
-        raise RuntimeError('job_id should not be provided in the json spec. The json spec should ' +
-                           'be of the format ' +
-                           'https://docs.databricks.com/api/latest/jobs.html#jobsjobsettings')
     request_body = {
         'job_id': job_id,
         'new_settings': deser_json

--- a/tests/jobs/test_cli.py
+++ b/tests/jobs/test_cli.py
@@ -23,7 +23,6 @@
 
 import json
 import mock
-import pytest
 from tabulate import tabulate
 
 import databricks_cli.jobs.cli as cli

--- a/tests/jobs/test_cli.py
+++ b/tests/jobs/test_cli.py
@@ -23,6 +23,7 @@
 
 import json
 import mock
+import pytest
 from tabulate import tabulate
 
 import databricks_cli.jobs.cli as cli
@@ -54,13 +55,25 @@ def test_create_cli_json_file(tmpdir):
             assert echo_mock.call_args[0][0] == pretty_format(CREATE_RETURN)
 
 
+RESET_JSON = '{"job_name": "test_job"}'
+
+
 def test_reset_cli_json():
     with mock.patch('databricks_cli.jobs.cli.reset_job') as reset_job_mock:
-        with mock.patch('databricks_cli.jobs.cli.click.echo') as echo_mock:
-            reset_job_mock.return_value = CREATE_RETURN
-            get_callback(cli.reset_cli)(None, CREATE_JSON)
-            assert reset_job_mock.call_args[0][0] == json.loads(CREATE_JSON)
-            assert echo_mock.call_args[0][0] == pretty_format(CREATE_RETURN)
+        get_callback(cli.reset_cli)(None, RESET_JSON, 1)
+        assert reset_job_mock.call_args[0][0] == {
+            'job_id': 1,
+            'new_settings': json.loads(RESET_JSON)
+        }
+
+
+RESET_JSON_WITH_JOB_ID = '{"job_id": 5, "job_name": "test_job"}'
+
+
+def test_reset_cli_json_with_job_id():
+    get_callback(cli.reset_cli)(None, RESET_JSON, 1)
+    with pytest.raises(RuntimeError):
+        get_callback(cli.reset_cli)(None, RESET_JSON_WITH_JOB_ID, 1)
 
 
 LIST_RETURN = {

--- a/tests/jobs/test_cli.py
+++ b/tests/jobs/test_cli.py
@@ -71,7 +71,6 @@ RESET_JSON_WITH_JOB_ID = '{"job_id": 5, "job_name": "test_job"}'
 
 
 def test_reset_cli_json_with_job_id():
-    get_callback(cli.reset_cli)(None, RESET_JSON, 1)
     with pytest.raises(RuntimeError):
         get_callback(cli.reset_cli)(None, RESET_JSON_WITH_JOB_ID, 1)
 

--- a/tests/jobs/test_cli.py
+++ b/tests/jobs/test_cli.py
@@ -67,14 +67,6 @@ def test_reset_cli_json():
         }
 
 
-RESET_JSON_WITH_JOB_ID = '{"job_id": 5, "job_name": "test_job"}'
-
-
-def test_reset_cli_json_with_job_id():
-    with pytest.raises(RuntimeError):
-        get_callback(cli.reset_cli)(None, RESET_JSON_WITH_JOB_ID, 1)
-
-
 LIST_RETURN = {
     'jobs': [{
         'job_id': 1,


### PR DESCRIPTION
`databricks jobs reset` should take two parameters --json and --job-id. Then it should materialize the request body sent to the reset endpoint with
```
{
  "job_id": job_id,
  "new_settings": json
}
```