### PR TITLE
Make job ids left aligned.

### DIFF
--- a/databricks_cli/jobs/cli.py
+++ b/databricks_cli/jobs/cli.py
@@ -116,7 +116,7 @@ def list_cli(output):
     if OutputClickType.is_json(output):
         click.echo(pretty_format(jobs_json))
     else:
-        click.echo(tabulate(_jobs_to_table(jobs_json), tablefmt='plain'))
+        click.echo(tabulate(_jobs_to_table(jobs_json), tablefmt='plain', disable_numparse=True))
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,

--- a/tests/jobs/test_cli.py
+++ b/tests/jobs/test_cli.py
@@ -78,7 +78,7 @@ LIST_RETURN = {
             'name': 'a'
         }
     }, {
-        'job_id': 3,
+        'job_id': 30,
         'settings': {
             # Normally 'C' < 'a' < 'b' -- we should do case insensitive sorting though.
             'name': 'C'
@@ -93,8 +93,9 @@ def test_list_jobs():
             list_jobs_mock.return_value = LIST_RETURN
             get_callback(cli.list_cli)(None)
             # Output should be sorted here.
-            rows = [(2, 'a'), (1, 'b'), (3, 'C')]
-            assert echo_mock.call_args[0][0] == tabulate(rows, tablefmt='plain')
+            rows = [(2, 'a'), (1, 'b'), (30, 'C')]
+            assert echo_mock.call_args[0][0] == \
+                tabulate(rows, tablefmt='plain', disable_numparse=True)
 
 
 def test_list_jobs_output_json():


### PR DESCRIPTION
Make it so it looks like this
```
192     apple job
31899   banana job
```

instead of
```
  192   apple job
31899   banana job
```
