### PR TITLE
Python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 sudo: true
 language: python
 python:
-  - "2.7"
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
 install:
   - pip install --upgrade pip
   - pip install -r dev-requirements.txt

--- a/Dockerfile.python3
+++ b/Dockerfile.python3
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python
 
 WORKDIR /usr/src/databricks-cli
 

--- a/databricks_cli/cli.py
+++ b/databricks_cli/cli.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/cli.py
+++ b/databricks_cli/cli.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,6 +25,9 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import click
 
 from databricks_cli.version import print_version_callback, version

--- a/databricks_cli/click_types.py
+++ b/databricks_cli/click_types.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,6 +25,9 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from click import ParamType
 
 

--- a/databricks_cli/click_types.py
+++ b/databricks_cli/click_types.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/clusters/api.py
+++ b/databricks_cli/clusters/api.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/clusters/api.py
+++ b/databricks_cli/clusters/api.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,6 +25,9 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from databricks_cli.configure.config import get_clusters_client
 
 

--- a/databricks_cli/clusters/cli.py
+++ b/databricks_cli/clusters/cli.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/clusters/cli.py
+++ b/databricks_cli/clusters/cli.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,6 +25,9 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import click
 from tabulate import tabulate
 

--- a/databricks_cli/configure/cli.py
+++ b/databricks_cli/configure/cli.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,6 +25,9 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import click
 
 from click import ParamType

--- a/databricks_cli/configure/cli.py
+++ b/databricks_cli/configure/cli.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/configure/config.py
+++ b/databricks_cli/configure/config.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/configure/config.py
+++ b/databricks_cli/configure/config.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,7 +25,11 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ConfigParser
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
+import configparser
 import sys
 import os
 
@@ -83,7 +90,7 @@ class DatabricksConfig(object):
     home = expanduser('~')
 
     def __init__(self):
-        self._config = ConfigParser.RawConfigParser()
+        self._config = configparser.RawConfigParser()
 
     def overwrite(self):
         config_path = self.get_path()

--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,6 +25,10 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
 from base64 import b64encode, b64decode
 
 import os

--- a/databricks_cli/dbfs/cli.py
+++ b/databricks_cli/dbfs/cli.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,6 +25,9 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import os
 import click
 from tabulate import tabulate

--- a/databricks_cli/dbfs/cli.py
+++ b/databricks_cli/dbfs/cli.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/dbfs/dbfs_path.py
+++ b/databricks_cli/dbfs/dbfs_path.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/dbfs/dbfs_path.py
+++ b/databricks_cli/dbfs/dbfs_path.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,6 +25,10 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
 import os
 import click
 

--- a/databricks_cli/dbfs/exceptions.py
+++ b/databricks_cli/dbfs/exceptions.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/dbfs/exceptions.py
+++ b/databricks_cli/dbfs/exceptions.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -23,5 +26,8 @@ from __future__ import unicode_literals
 # limitations under the License.
 
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 class LocalFileExistsException(Exception):
     pass

--- a/databricks_cli/jobs/api.py
+++ b/databricks_cli/jobs/api.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,6 +25,9 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from databricks_cli.configure.config import get_jobs_client
 
 

--- a/databricks_cli/jobs/api.py
+++ b/databricks_cli/jobs/api.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/jobs/cli.py
+++ b/databricks_cli/jobs/cli.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,6 +25,9 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from json import loads as json_loads
 
 import click

--- a/databricks_cli/jobs/cli.py
+++ b/databricks_cli/jobs/cli.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/runs/api.py
+++ b/databricks_cli/runs/api.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,6 +25,9 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from databricks_cli.configure.config import get_jobs_client
 
 

--- a/databricks_cli/runs/api.py
+++ b/databricks_cli/runs/api.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,6 +25,9 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import click
 from tabulate import tabulate
 

--- a/databricks_cli/sdk/__init__.py
+++ b/databricks_cli/sdk/__init__.py
@@ -51,5 +51,6 @@ To get started, below is an example usage of the Python API client.
   # To examine the jobs API:
   help(JobsService)
 """
+from __future__ import unicode_literals
 from .service import *
 from .api_client import ApiClient

--- a/databricks_cli/sdk/__init__.py
+++ b/databricks_cli/sdk/__init__.py
@@ -52,5 +52,11 @@ To get started, below is an example usage of the Python API client.
   help(JobsService)
 """
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 from .service import *
 from .api_client import ApiClient

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -29,7 +29,14 @@ A common class to be used by client of different APIs
 """
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import *
+from builtins import object
 import base64
 import json
 import warnings
@@ -89,7 +96,7 @@ class ApiClient(object):
         else:
             auth = {}
         user_agent = {'user-agent': 'databricks-cli-{v}'.format(v=databricks_cli_version)}
-        self.default_headers = dict(auth.items() + default_headers.items() + user_agent.items())
+        self.default_headers = dict(list(auth.items()) + list(default_headers.items()) + list(user_agent.items()))
         self.verify = verify
 
     def close(self):

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -27,6 +27,8 @@
 """
 A common class to be used by client of different APIs
 """
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import base64
 import json
@@ -34,7 +36,7 @@ import warnings
 import requests
 import ssl
 
-import version
+from . import version
 
 from requests.adapters import HTTPAdapter
 
@@ -108,7 +110,7 @@ class ApiClient(object):
 
         try:
             resp.raise_for_status()
-        except requests.exceptions.HTTPError, e:
+        except requests.exceptions.HTTPError as e:
             raise e
         return resp.json()
 

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,8 +25,12 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
 import base64
-import StringIO
+import io
 
 class JobsService(object):
     def __init__(self, client):
@@ -439,8 +446,8 @@ class DbfsService(object):
         """Uploads the input string into DBFS to the dbfs path provided."""
         result = self.create(dbfs_path, overwrite)
         handle = result['handle']
-        import StringIO
-        input_string = StringIO.StringIO(string)
+        import io
+        input_string = io.StringIO(string)
         while True:
             block = input_string.read(1024 * 1024)
             if block == '':

--- a/databricks_cli/sdk/version.py
+++ b/databricks_cli/sdk/version.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/sdk/version.py
+++ b/databricks_cli/sdk/version.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,4 +25,7 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 API_VERSION=2.0

--- a/databricks_cli/utils.py
+++ b/databricks_cli/utils.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,6 +25,10 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import *
 import sys
 from json import dumps as json_dumps, loads as json_loads
 

--- a/databricks_cli/utils.py
+++ b/databricks_cli/utils.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/version.py
+++ b/databricks_cli/version.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/version.py
+++ b/databricks_cli/version.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,6 +25,9 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 version = '0.4.2.dev0' #  NOQA
 
 

--- a/databricks_cli/workspace/api.py
+++ b/databricks_cli/workspace/api.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/workspace/api.py
+++ b/databricks_cli/workspace/api.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,6 +25,10 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
 import os
 from base64 import b64encode, b64decode
 

--- a/databricks_cli/workspace/cli.py
+++ b/databricks_cli/workspace/cli.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,6 +25,9 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import os
 import click
 from tabulate import tabulate

--- a/databricks_cli/workspace/cli.py
+++ b/databricks_cli/workspace/cli.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/workspace/types.py
+++ b/databricks_cli/workspace/types.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #

--- a/databricks_cli/workspace/types.py
+++ b/databricks_cli/workspace/types.py
@@ -1,4 +1,7 @@
 from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,6 +25,10 @@ from __future__ import unicode_literals
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
 from click import ParamType
 
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     packages=find_packages(exclude=['tests', 'tests.*']),
     install_requires=[
         'click>=6.7',
+        'future>=0.16.0',
         'requests>=2.17.3',
         'tabulate>=0.7.7',
         'six>=1.10.0',

--- a/tests/clusters/test_cli.py
+++ b/tests/clusters/test_cli.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -21,6 +25,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import json
 import mock
 from tabulate import tabulate

--- a/tests/configure/test_config.py
+++ b/tests/configure/test_config.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -23,6 +27,11 @@
 
 # pylint:disable=protected-access
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import *
+from builtins import object
 import mock
 
 import databricks_cli.configure.config as config

--- a/tests/dbfs/test_api.py
+++ b/tests/dbfs/test_api.py
@@ -43,7 +43,10 @@ TEST_FILE_INFO = api.FileInfo(TEST_DBFS_PATH, False, 1)
 
 def get_resource_does_not_exist_exception():
     response = requests.Response()
-    response._content = '{"error_code": "' + api.DbfsErrorCodes.RESOURCE_DOES_NOT_EXIST + '"}' #  NOQA
+    # Response._content is bytes not string, see
+    # http://docs.python-requests.org/en/master/api/#requests.Response.cookies
+    _content = '{"error_code": "' + api.DbfsErrorCodes.RESOURCE_DOES_NOT_EXIST + '"}' #  NOQA
+    response._content = _content.encode()
     return requests.exceptions.HTTPError(response=response)
 
 

--- a/tests/dbfs/test_api.py
+++ b/tests/dbfs/test_api.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -21,6 +25,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
 from base64 import b64encode
 
 import os

--- a/tests/dbfs/test_dbfs_path.py
+++ b/tests/dbfs/test_dbfs_path.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -21,6 +25,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
 import mock
 from databricks_cli.dbfs.dbfs_path import DbfsPath
 

--- a/tests/jobs/test_cli.py
+++ b/tests/jobs/test_cli.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -21,6 +25,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import json
 import mock
 from tabulate import tabulate

--- a/tests/runs/test_cli.py
+++ b/tests/runs/test_cli.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -21,6 +25,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import json
 import mock
 from tabulate import tabulate

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -21,6 +25,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import pytest
 import mock
 from requests import Response

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -22,6 +26,9 @@
 # limitations under the License.
 
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 def get_callback(command):
     """
     Convenience function to reach into a Command object's callback and

--- a/tests/workspace/test_api.py
+++ b/tests/workspace/test_api.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -21,6 +25,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import object
 import os
 import mock
 from base64 import b64encode

--- a/tests/workspace/test_cli.py
+++ b/tests/workspace/test_cli.py
@@ -1,3 +1,7 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 # Databricks CLI
 # Copyright 2017 Databricks, Inc.
 #
@@ -21,6 +25,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import os
 import mock
 


### PR DESCRIPTION
Mostly boring stuff. The hardest part was figuring out the test suite was causing havoc in the request package by creating a `Request` object with a string as `_content` rather than bytes. Included Dockerfile for Python 3. Test suite passes both in Python 2/3 🍻 

Fixes #2.

PS: I left in a change of the Dockerfile that allows caching the requirements. Let me know if you want me to pull that out.