### PR TITLE
Recognize Jupyter notebooks when using import_dir

### DIFF
--- a/databricks_cli/workspace/cli.py
+++ b/databricks_cli/workspace/cli.py
@@ -195,8 +195,8 @@ def _import_dir_helper(source_path, target_path, overwrite):
             ext = WorkspaceLanguage.get_extension(cur_src)
             if ext != '':
                 cur_dst = cur_dst[:-len(ext)]
-                language = WorkspaceLanguage.to_language(cur_src)
-                import_workspace(cur_src, cur_dst, language, WorkspaceFormat.SOURCE, overwrite)
+                (language, format) = WorkspaceLanguage.to_language_and_format(cur_src)
+                import_workspace(cur_src, cur_dst, language, format, overwrite)
                 click.echo('{} -> {}'.format(cur_src, cur_dst))
             else:
                 extensions = ', '.join(WorkspaceLanguage.EXTENSIONS)

--- a/databricks_cli/workspace/cli.py
+++ b/databricks_cli/workspace/cli.py
@@ -195,8 +195,8 @@ def _import_dir_helper(source_path, target_path, overwrite):
             ext = WorkspaceLanguage.get_extension(cur_src)
             if ext != '':
                 cur_dst = cur_dst[:-len(ext)]
-                (language, format) = WorkspaceLanguage.to_language_and_format(cur_src)
-                import_workspace(cur_src, cur_dst, language, format, overwrite)
+                (language, file_format) = WorkspaceLanguage.to_language_and_format(cur_src)
+                import_workspace(cur_src, cur_dst, language, file_format, overwrite)
                 click.echo('{} -> {}'.format(cur_src, cur_dst))
             else:
                 extensions = ', '.join(WorkspaceLanguage.EXTENSIONS)

--- a/databricks_cli/workspace/cli.py
+++ b/databricks_cli/workspace/cli.py
@@ -215,7 +215,7 @@ def import_dir_cli(source_path, target_path, overwrite):
     """
     Recursively imports a directory from local to the Databricks workspace.
 
-    Only directories and files with the extensions .scala, .py, .sql, .r, .R are imported.
+    Only directories and files with the extensions .scala, .py, .sql, .r, .R, .ipynb are imported.
     When imported, these extensions will be stripped off the name of the notebook.
     """
     _import_dir_helper(source_path, target_path, overwrite)

--- a/databricks_cli/workspace/types.py
+++ b/databricks_cli/workspace/types.py
@@ -30,23 +30,25 @@ class WorkspaceLanguage(object):
     SQL = 'SQL'
     R = 'R'
     ALL = [SCALA, PYTHON, SQL, R]
-    EXTENSIONS = ['.scala', '.py', '.sql', '.SQL', '.r', '.R']
+    EXTENSIONS = ['.scala', '.py', '.sql', '.SQL', '.r', '.R', '.ipynb']
 
     @classmethod
-    def to_language(cls, path):
+    def to_language_and_format(cls, path):
         ext = cls.get_extension(path)
         if ext == '.scala':
-            return cls.SCALA
+            return (cls.SCALA, WorkspaceFormat.SOURCE)
         elif ext == '.py':
-            return cls.PYTHON
+            return (cls.PYTHON, WorkspaceFormat.SOURCE)
         elif ext == '.sql':
-            return cls.SQL
+            return (cls.SQL, WorkspaceFormat.SOURCE)
         elif ext == '.SQL':
-            return cls.SQL
+            return (cls.SQL, WorkspaceFormat.SOURCE)
         elif ext == '.r':
-            return cls.R
+            return (cls.R, WorkspaceFormat.SOURCE)
         elif ext == '.R':
-            return cls.R
+            return (cls.R, WorkspaceFormat.SOURCE)
+        elif ext == '.ipynb':
+            return (cls.PYTHON, WorkspaceFormat.JUPYTER)
 
     @classmethod
     def to_extension(cls, language):

--- a/databricks_cli/workspace/types.py
+++ b/databricks_cli/workspace/types.py
@@ -34,18 +34,14 @@ class WorkspaceLanguage(object):
 
     @classmethod
     def to_language_and_format(cls, path):
-        ext = cls.get_extension(path)
+        ext = cls.get_extension(path).lower()
         if ext == '.scala':
             return (cls.SCALA, WorkspaceFormat.SOURCE)
         elif ext == '.py':
             return (cls.PYTHON, WorkspaceFormat.SOURCE)
         elif ext == '.sql':
             return (cls.SQL, WorkspaceFormat.SOURCE)
-        elif ext == '.SQL':
-            return (cls.SQL, WorkspaceFormat.SOURCE)
         elif ext == '.r':
-            return (cls.R, WorkspaceFormat.SOURCE)
-        elif ext == '.R':
             return (cls.R, WorkspaceFormat.SOURCE)
         elif ext == '.ipynb':
             return (cls.PYTHON, WorkspaceFormat.JUPYTER)


### PR DESCRIPTION
This is to handle import_dir with Jupyter notebooks, #59  For export_dir I wonder if we should let users decide what format to use for Python notebooks?