### PR TITLE
Add support for write only configuration profiles.

### DIFF
--- a/databricks_cli/configure/cli.py
+++ b/databricks_cli/configure/cli.py
@@ -41,8 +41,8 @@ def _configure_cli_token(profile):
     config = get_config_for_profile(profile)
     host = click.prompt(PROMPT_HOST, default=config.host, type=_DbfsHost())
     token = click.prompt(PROMPT_TOKEN, default=config.token)
-    new_config = DatabricksConfig.from_token(profile, host, token)
-    update_and_persist_config(new_config)
+    new_config = DatabricksConfig.from_token(host, token)
+    update_and_persist_config(profile, new_config)
 
 
 def _configure_cli_password(profile):
@@ -57,8 +57,8 @@ def _configure_cli_password(profile):
                             confirmation_prompt=True)
     if password == default_password:
         password = config.password
-    new_config = DatabricksConfig.from_password(profile, host, username, password)
-    update_and_persist_config(new_config)
+    new_config = DatabricksConfig.from_password(host, username, password)
+    update_and_persist_config(profile, new_config)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,

--- a/databricks_cli/configure/config.py
+++ b/databricks_cli/configure/config.py
@@ -76,6 +76,6 @@ def get_clusters_client(profile=DEFAULT_SECTION):
     return ClusterService(api_client)
 
 
-def get_libraries_client():
-    api_client = _get_api_client()
+def get_libraries_client(profile=DEFAULT_SECTION):
+    api_client = _get_api_client(profile)
     return ManagedLibraryService(api_client)

--- a/databricks_cli/configure/config.py
+++ b/databricks_cli/configure/config.py
@@ -21,29 +21,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ConfigParser
 import sys
-import os
-
-from os.path import expanduser, join
 
 import click
 import six
 
+from databricks_cli.configure.provider import DEFAULT_SECTION, get_config_for_profile
 from databricks_cli.utils import error_and_quit
 from databricks_cli.sdk import ApiClient, DbfsService, WorkspaceService, JobsService, ClusterService
-
-DEFAULT_SECTION = 'DEFAULT'
-HOST = 'host'
-USERNAME = 'username'
-PASSWORD = 'password' #  NOQA
-TOKEN = 'token'
 
 
 def require_config(function):
     @six.wraps(function)
     def decorator(*args, **kwargs):
-        config = DatabricksConfig.fetch_from_fs()
+        config = get_config_for_profile(DEFAULT_SECTION)
         if not config.is_valid:
             error_and_quit(('You haven\'t configured the CLI yet! '
                             'Please configure by entering `{} configure`').format(sys.argv[0]))
@@ -57,11 +48,11 @@ def profile_option(f):
 
 
 def _get_api_client(profile):
-    conf = DatabricksConfig.fetch_from_fs()
-    if conf.is_valid_with_token:
-        return ApiClient(host=conf.host(profile), token=conf.token(profile))
-    return ApiClient(user=conf.username(profile), password=conf.password(profile),
-                     host=conf.host(profile))
+    config = get_config_for_profile(profile)
+    if config.is_valid_with_token:
+        return ApiClient(host=config.host, token=config.token)
+    return ApiClient(user=config.username, password=config.password,
+                     host=config.host)
 
 
 def get_dbfs_client(profile=DEFAULT_SECTION):
@@ -82,67 +73,3 @@ def get_jobs_client(profile=DEFAULT_SECTION):
 def get_clusters_client(profile=DEFAULT_SECTION):
     api_client = _get_api_client(profile)
     return ClusterService(api_client)
-
-
-class DatabricksConfig(object):
-    home = expanduser('~')
-
-    def __init__(self):
-        self._config = ConfigParser.RawConfigParser()
-
-    def overwrite(self):
-        config_path = self.get_path()
-        with open(config_path, 'wb') as cfg:
-            self._config.write(cfg)
-        os.chmod(config_path, 0o600)
-
-    def is_valid(self, profile):
-        return self.is_valid_with_password(profile) or self.is_valid_with_token(profile)
-
-    def is_valid_with_password(self, profile):
-        return self._config.has_option(profile, USERNAME) and \
-            self._config.has_option(profile, PASSWORD) and \
-            self._config.has_option(profile, HOST)
-
-    def is_valid_with_token(self, profile):
-        return self._config.has_option(profile, TOKEN) and \
-            self._config.has_option(profile, HOST)
-
-    def host(self, profile):
-        return self._config.get(profile, HOST) if self.is_valid(profile) else None
-
-    def username(self, profile):
-        return self._config.get(profile, USERNAME) if self.is_valid_with_password(profile) else None
-
-    def password(self, profile):
-        return self._config.get(profile, PASSWORD) if self.is_valid_with_password(profile) else None
-
-    def token(self, profile):
-        return self._config.get(profile, TOKEN) if self.is_valid_with_token(profile) else None
-
-    @classmethod
-    def fetch_from_fs(cls):
-        databricks_config = cls()
-        databricks_config._config.read(cls.get_path())
-        return databricks_config
-
-    def _create_section_if_absent(self, profile):
-        if not self._config.has_section(profile) and profile != DEFAULT_SECTION:
-            self._config.add_section(profile)
-
-    def update_with_password(self, profile, host, username, password):
-        self._create_section_if_absent(profile)
-        self._config.set(profile, HOST, host)
-        self._config.set(profile, USERNAME, username)
-        self._config.set(profile, PASSWORD, password)
-        return self
-
-    def update_with_token(self, profile, host, token):
-        self._create_section_if_absent(profile)
-        self._config.set(profile, HOST, host)
-        self._config.set(profile, TOKEN, token)
-        return self
-
-    @classmethod
-    def get_path(cls):
-        return join(cls.home, '.databrickscfg')

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -1,0 +1,127 @@
+# Databricks CLI
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"), except
+# that the use of services to which certain application programming
+# interfaces (each, an "API") connect requires that the user first obtain
+# a license for the use of the APIs from Databricks, Inc. ("Databricks"),
+# by creating an account at www.databricks.com and agreeing to either (a)
+# the Community Edition Terms of Service, (b) the Databricks Terms of
+# Service, or (c) another written agreement between Licensee and Databricks
+# for the use of the APIs.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import ConfigParser
+from os.path import expanduser, join
+
+import os
+
+_home = expanduser('~')
+HOST = 'host'
+USERNAME = 'username'
+PASSWORD = 'password' # NOQA
+TOKEN = 'token'
+DEFAULT_SECTION = 'DEFAULT'
+
+
+def _get_path():
+    return join(_home, '.databrickscfg')
+
+
+def _fetch_from_fs():
+    raw_config = ConfigParser.RawConfigParser()
+    raw_config.read(_get_path())
+    return raw_config
+
+
+def _create_section_if_absent(raw_config, profile):
+    if not raw_config.has_section(profile) and profile != DEFAULT_SECTION:
+        raw_config.add_section(profile)
+
+
+def _get_option_if_exists(raw_config, profile, option):
+    return raw_config.get(profile, option) if raw_config.has_option(profile, option) else None
+
+
+def _set_option(raw_config, profile, option, value):
+    if value:
+        raw_config.set(profile, option, value)
+    else:
+        raw_config.remove_option(profile, option)
+
+
+def _overwrite_config(raw_config):
+    config_path = _get_path()
+    with open(config_path, 'wb') as cfg:
+        raw_config.write(cfg)
+    os.chmod(config_path, 0o600)
+
+
+def update_and_persist_config(databricks_config):
+    """
+    Takes a DatabricksConfig and adds the in memory contents to the persisted version of the
+    config. This will overwrite any other config that was persisted to the file system under the
+    same profile.
+    :param databricks_config: DatabricksConfig
+    """
+    raw_config = _fetch_from_fs()
+    profile = databricks_config.profile.upper()
+    _create_section_if_absent(raw_config, profile)
+    _set_option(raw_config, profile, HOST, databricks_config.host)
+    _set_option(raw_config, profile, USERNAME, databricks_config.username)
+    _set_option(raw_config, profile, PASSWORD, databricks_config.password)
+    _set_option(raw_config, profile, TOKEN, databricks_config.token)
+    _overwrite_config(raw_config)
+
+
+def get_config_for_profile(profile):
+    """
+    Reads from the filesystem and gets a DatabricksConfig for the specified profile. If it does not
+    exist, then return a DatabricksConfig with fields set.
+    :return: DatabricksConfig
+    """
+    profile = profile.upper()
+    raw_config = _fetch_from_fs()
+    host = _get_option_if_exists(raw_config, profile, HOST)
+    username = _get_option_if_exists(raw_config, profile, USERNAME)
+    password = _get_option_if_exists(raw_config, profile, PASSWORD)
+    token = _get_option_if_exists(raw_config, profile, TOKEN)
+    return DatabricksConfig(profile, host, username, password, token)
+
+
+class DatabricksConfig(object):
+    def __init__(self, profile, host, username, password, token): # noqa
+        self.profile = profile
+        self.host = host
+        self.username = username
+        self.password = password
+        self.token = token
+
+    @classmethod
+    def from_token(cls, profile, host, token):
+        return DatabricksConfig(profile, host, None, None, token)
+
+    @classmethod
+    def from_password(cls, profile, host, username, password):
+        return DatabricksConfig(profile, host, username, password, None)
+
+    @property
+    def is_valid_with_token(self):
+        return self.host is not None and self.token is not None
+
+    @property
+    def is_valid_with_password(self):
+        return self.host is not None and self.username is not None and self.password is not None
+
+    @property
+    def is_valid(self):
+        return self.is_valid_with_token or self.is_valid_with_password

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -66,15 +66,15 @@ def _overwrite_config(raw_config):
     os.chmod(config_path, 0o600)
 
 
-def update_and_persist_config(databricks_config):
+def update_and_persist_config(profile, databricks_config):
     """
     Takes a DatabricksConfig and adds the in memory contents to the persisted version of the
     config. This will overwrite any other config that was persisted to the file system under the
     same profile.
     :param databricks_config: DatabricksConfig
     """
+    profile = profile.upper()
     raw_config = _fetch_from_fs()
-    profile = databricks_config.profile.upper()
     _create_section_if_absent(raw_config, profile)
     _set_option(raw_config, profile, HOST, databricks_config.host)
     _set_option(raw_config, profile, USERNAME, databricks_config.username)
@@ -95,24 +95,23 @@ def get_config_for_profile(profile):
     username = _get_option_if_exists(raw_config, profile, USERNAME)
     password = _get_option_if_exists(raw_config, profile, PASSWORD)
     token = _get_option_if_exists(raw_config, profile, TOKEN)
-    return DatabricksConfig(profile, host, username, password, token)
+    return DatabricksConfig(host, username, password, token)
 
 
 class DatabricksConfig(object):
-    def __init__(self, profile, host, username, password, token): # noqa
-        self.profile = profile
+    def __init__(self, host, username, password, token): # noqa
         self.host = host
         self.username = username
         self.password = password
         self.token = token
 
     @classmethod
-    def from_token(cls, profile, host, token):
-        return DatabricksConfig(profile, host, None, None, token)
+    def from_token(cls, host, token):
+        return DatabricksConfig(host, None, None, token)
 
     @classmethod
-    def from_password(cls, profile, host, username, password):
-        return DatabricksConfig(profile, host, username, password, None)
+    def from_password(cls, host, username, password):
+        return DatabricksConfig(host, username, password, None)
 
     @property
     def is_valid_with_token(self):

--- a/tests/configure/test_cli.py
+++ b/tests/configure/test_cli.py
@@ -1,0 +1,77 @@
+# Databricks CLI
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"), except
+# that the use of services to which certain application programming
+# interfaces (each, an "API") connect requires that the user first obtain
+# a license for the use of the APIs from Databricks, Inc. ("Databricks"),
+# by creating an account at www.databricks.com and agreeing to either (a)
+# the Community Edition Terms of Service, (b) the Databricks Terms of
+# Service, or (c) another written agreement between Licensee and Databricks
+# for the use of the APIs.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint:disable=protected-access
+
+import mock
+from click.testing import CliRunner
+
+from databricks_cli.configure.config import DEFAULT_SECTION, DatabricksConfig
+import databricks_cli.configure.cli as cli
+
+
+TEST_HOST = 'https://test.cloud.databricks.com'
+TEST_USER = 'monkey@databricks.com'
+TEST_PASSWORD = 'banana' # NOQA
+TEST_TOKEN = 'dapiTESTING'
+
+TEST_PROFILE = 'dev'
+TEST_HOST_2 = 'https://test2.cloud.databricks.com'
+
+
+def test_configure_cli(tmpdir):
+    path = tmpdir.strpath
+    with mock.patch.object(DatabricksConfig, 'home', path):
+        runner = CliRunner()
+        runner.invoke(cli.configure_cli,
+                      input=(TEST_HOST + '\n' +
+                             TEST_USER + '\n' +
+                             TEST_PASSWORD + '\n' +
+                             TEST_PASSWORD + '\n'))
+        assert DatabricksConfig.fetch_from_fs().host(DEFAULT_SECTION) == TEST_HOST
+        assert DatabricksConfig.fetch_from_fs().username(DEFAULT_SECTION) == TEST_USER
+        assert DatabricksConfig.fetch_from_fs().password(DEFAULT_SECTION) == TEST_PASSWORD
+
+
+def test_configure_cli_token(tmpdir):
+    path = tmpdir.strpath
+    with mock.patch.object(DatabricksConfig, 'home', path):
+        runner = CliRunner()
+        runner.invoke(cli.configure_cli, ['--token'],
+                      input=(TEST_HOST + '\n' + TEST_TOKEN + '\n'))
+        assert DatabricksConfig.fetch_from_fs().host(DEFAULT_SECTION) == TEST_HOST
+        assert DatabricksConfig.fetch_from_fs().token(DEFAULT_SECTION) == TEST_TOKEN
+
+
+def test_configure_two_sections(tmpdir):
+    path = tmpdir.strpath
+    with mock.patch.object(DatabricksConfig, 'home', path):
+        runner = CliRunner()
+        runner.invoke(cli.configure_cli, ['--token'],
+                      input=(TEST_HOST + '\n' + TEST_TOKEN + '\n'))
+        runner.invoke(cli.configure_cli, ['--token', '--profile', TEST_PROFILE],
+                      input=(TEST_HOST_2 + '\n' + TEST_TOKEN + '\n'))
+        assert DatabricksConfig.fetch_from_fs().host(DEFAULT_SECTION) == TEST_HOST
+        assert DatabricksConfig.fetch_from_fs().token(DEFAULT_SECTION) == TEST_TOKEN
+        assert DatabricksConfig.fetch_from_fs().host(TEST_PROFILE) == TEST_HOST_2
+        assert DatabricksConfig.fetch_from_fs().token(TEST_PROFILE) == TEST_TOKEN

--- a/tests/configure/test_config.py
+++ b/tests/configure/test_config.py
@@ -26,14 +26,14 @@
 import mock
 
 import databricks_cli.configure.config as config
-from databricks_cli.configure.provider import DatabricksConfig, DEFAULT_SECTION
+from databricks_cli.configure.provider import DatabricksConfig
 
 
 def test_require_config_valid():
     with mock.patch('databricks_cli.configure.config.get_config_for_profile') as \
             get_config_for_profile_mock:
         get_config_for_profile_mock.return_value = DatabricksConfig(
-            DEFAULT_SECTION, 'test-host', None, None, 'test-token')
+            'test-host', None, None, 'test-token')
 
         @config.require_config
         def test_function(x):
@@ -46,8 +46,7 @@ def test_require_config_invalid():
     with mock.patch('databricks_cli.configure.config.error_and_quit') as error_and_quit_mock:
         with mock.patch('databricks_cli.configure.config.get_config_for_profile') as \
                 get_config_for_profile_mock:
-            get_config_for_profile_mock.return_value = DatabricksConfig(
-                DEFAULT_SECTION, None, None, None, None)
+            get_config_for_profile_mock.return_value = DatabricksConfig(None, None, None, None)
 
             @config.require_config
             def test_function(x):

--- a/tests/configure/test_config.py
+++ b/tests/configure/test_config.py
@@ -26,12 +26,14 @@
 import mock
 
 import databricks_cli.configure.config as config
+from databricks_cli.configure.provider import DatabricksConfig, DEFAULT_SECTION
 
 
 def test_require_config_valid():
-    with mock.patch('databricks_cli.configure.config.DatabricksConfig') as DatabricksConfigMock:
-        config_mock = DatabricksConfigMock.fetch_from_fs.return_value
-        config_mock.is_valid = True
+    with mock.patch('databricks_cli.configure.config.get_config_for_profile') as \
+            get_config_for_profile_mock:
+        get_config_for_profile_mock.return_value = DatabricksConfig(
+            DEFAULT_SECTION, 'test-host', None, None, 'test-token')
 
         @config.require_config
         def test_function(x):
@@ -41,10 +43,11 @@ def test_require_config_valid():
 
 
 def test_require_config_invalid():
-    with mock.patch('databricks_cli.configure.config.DatabricksConfig') as DatabricksConfigMock:
-        with mock.patch('databricks_cli.configure.config.error_and_quit') as error_and_quit_mock:
-            config_mock = DatabricksConfigMock.fetch_from_fs.return_value
-            config_mock.is_valid = False
+    with mock.patch('databricks_cli.configure.config.error_and_quit') as error_and_quit_mock:
+        with mock.patch('databricks_cli.configure.config.get_config_for_profile') as \
+                get_config_for_profile_mock:
+            get_config_for_profile_mock.return_value = DatabricksConfig(
+                DEFAULT_SECTION, None, None, None, None)
 
             @config.require_config
             def test_function(x):
@@ -54,55 +57,3 @@ def test_require_config_invalid():
 
             assert error_and_quit_mock.call_count == 1
             assert 'You haven\'t configured the CLI' in error_and_quit_mock.call_args[0][0]
-
-
-class TestDatabricksConfig(object):
-    databricks_config_from_password = config.DatabricksConfig()
-    databricks_config_from_password.update_with_password(config.DEFAULT_SECTION, 'test-host',
-                                                         'test-user', 'test-password')
-    databricks_config_from_token = config.DatabricksConfig()
-    databricks_config_from_token.update_with_token(config.DEFAULT_SECTION, 'test-host',
-                                                   'test-token')
-
-    def test_is_valid_true(self):
-        assert self.databricks_config_from_password.is_valid
-        assert self.databricks_config_from_token.is_valid
-
-    def test_is_valid_false(self):
-        databricks_config = config.DatabricksConfig()
-        assert not databricks_config.is_valid(config.DEFAULT_SECTION)
-
-    def test_is_valid_with_password(self):
-        assert self.databricks_config_from_password.is_valid_with_password(config.DEFAULT_SECTION)
-        assert not self.databricks_config_from_token.is_valid_with_password(config.DEFAULT_SECTION)
-
-    def test_is_valid_with_token(self):
-        assert self.databricks_config_from_token.is_valid_with_token(config.DEFAULT_SECTION)
-        assert not self.databricks_config_from_password.is_valid_with_token(config.DEFAULT_SECTION)
-
-    def test_host(self):
-        assert self.databricks_config_from_password.host(config.DEFAULT_SECTION) == 'test-host'
-        assert self.databricks_config_from_token.host(config.DEFAULT_SECTION) == 'test-host'
-
-    def test_username(self):
-        assert self.databricks_config_from_password.username(config.DEFAULT_SECTION) == 'test-user'
-        assert self.databricks_config_from_token.username(config.DEFAULT_SECTION) is None
-
-    def test_password(self):
-        assert self.databricks_config_from_password.password(config.DEFAULT_SECTION) == \
-            'test-password'
-        assert self.databricks_config_from_token.password(config.DEFAULT_SECTION) is None
-
-    def test_token(self):
-        assert self.databricks_config_from_password.token(config.DEFAULT_SECTION) is None
-        assert self.databricks_config_from_token.token(config.DEFAULT_SECTION) == 'test-token'
-
-    def test_fetch_from_fs(self, tmpdir):
-        with mock.patch.object(config.DatabricksConfig, 'get_path') as get_path_mock:
-            test_path = tmpdir.dirpath() + '/.databrickscfg'
-            get_path_mock.return_value = str(test_path)
-
-            self.databricks_config_from_token.overwrite()
-            from_fs = config.DatabricksConfig.fetch_from_fs()
-            assert self.databricks_config_from_token.token(config.DEFAULT_SECTION) == \
-                from_fs.token(config.DEFAULT_SECTION)

--- a/tests/configure/test_config.py
+++ b/tests/configure/test_config.py
@@ -57,10 +57,12 @@ def test_require_config_invalid():
 
 
 class TestDatabricksConfig(object):
-    databricks_config_from_password = config.DatabricksConfig.construct_from_password(
-        'test-host', 'test-user', 'test-password')
-    databricks_config_from_token = config.DatabricksConfig.construct_from_token(
-        'test-host', 'test-token')
+    databricks_config_from_password = config.DatabricksConfig()
+    databricks_config_from_password.update_with_password(config.DEFAULT_SECTION, 'test-host',
+                                                         'test-user', 'test-password')
+    databricks_config_from_token = config.DatabricksConfig()
+    databricks_config_from_token.update_with_token(config.DEFAULT_SECTION, 'test-host',
+                                                   'test-token')
 
     def test_is_valid_true(self):
         assert self.databricks_config_from_password.is_valid
@@ -68,31 +70,32 @@ class TestDatabricksConfig(object):
 
     def test_is_valid_false(self):
         databricks_config = config.DatabricksConfig()
-        assert not databricks_config.is_valid
+        assert not databricks_config.is_valid(config.DEFAULT_SECTION)
 
     def test_is_valid_with_password(self):
-        assert self.databricks_config_from_password.is_valid_with_password
-        assert not self.databricks_config_from_token.is_valid_with_password
+        assert self.databricks_config_from_password.is_valid_with_password(config.DEFAULT_SECTION)
+        assert not self.databricks_config_from_token.is_valid_with_password(config.DEFAULT_SECTION)
 
     def test_is_valid_with_token(self):
-        assert self.databricks_config_from_token.is_valid_with_token
-        assert not self.databricks_config_from_password.is_valid_with_token
+        assert self.databricks_config_from_token.is_valid_with_token(config.DEFAULT_SECTION)
+        assert not self.databricks_config_from_password.is_valid_with_token(config.DEFAULT_SECTION)
 
     def test_host(self):
-        assert self.databricks_config_from_password.host == 'test-host'
-        assert self.databricks_config_from_token.host == 'test-host'
+        assert self.databricks_config_from_password.host(config.DEFAULT_SECTION) == 'test-host'
+        assert self.databricks_config_from_token.host(config.DEFAULT_SECTION) == 'test-host'
 
     def test_username(self):
-        assert self.databricks_config_from_password.username == 'test-user'
-        assert self.databricks_config_from_token.username is None
+        assert self.databricks_config_from_password.username(config.DEFAULT_SECTION) == 'test-user'
+        assert self.databricks_config_from_token.username(config.DEFAULT_SECTION) is None
 
     def test_password(self):
-        assert self.databricks_config_from_password.password == 'test-password'
-        assert self.databricks_config_from_token.password is None
+        assert self.databricks_config_from_password.password(config.DEFAULT_SECTION) == \
+            'test-password'
+        assert self.databricks_config_from_token.password(config.DEFAULT_SECTION) is None
 
     def test_token(self):
-        assert self.databricks_config_from_password.token is None
-        assert self.databricks_config_from_token.token == 'test-token'
+        assert self.databricks_config_from_password.token(config.DEFAULT_SECTION) is None
+        assert self.databricks_config_from_token.token(config.DEFAULT_SECTION) == 'test-token'
 
     def test_fetch_from_fs(self, tmpdir):
         with mock.patch.object(config.DatabricksConfig, 'get_path') as get_path_mock:
@@ -101,4 +104,5 @@ class TestDatabricksConfig(object):
 
             self.databricks_config_from_token.overwrite()
             from_fs = config.DatabricksConfig.fetch_from_fs()
-            assert self.databricks_config_from_token.token == from_fs.token
+            assert self.databricks_config_from_token.token(config.DEFAULT_SECTION) == \
+                from_fs.token(config.DEFAULT_SECTION)

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -31,16 +31,16 @@ TEST_PROFILE = 'testing-profile'
 
 
 def test_update_and_persist_config():
-    config = DatabricksConfig.from_token(DEFAULT_SECTION, TEST_HOST, TEST_TOKEN)
-    update_and_persist_config(config)
+    config = DatabricksConfig.from_token(TEST_HOST, TEST_TOKEN)
+    update_and_persist_config(DEFAULT_SECTION, config)
     config = get_config_for_profile(DEFAULT_SECTION)
     assert config.is_valid_with_token
     assert config.host == TEST_HOST
     assert config.token == TEST_TOKEN
 
     # Overwrite conf for same section.
-    config = DatabricksConfig.from_password(DEFAULT_SECTION, TEST_HOST, TEST_USER, TEST_PASSWORD)
-    update_and_persist_config(config)
+    config = DatabricksConfig.from_password(TEST_HOST, TEST_USER, TEST_PASSWORD)
+    update_and_persist_config(DEFAULT_SECTION, config)
     config = get_config_for_profile(DEFAULT_SECTION)
     assert config.is_valid_with_password
     assert not config.is_valid_with_token
@@ -50,12 +50,12 @@ def test_update_and_persist_config():
 
 
 def test_update_and_persist_config_two_sections():
-    config = DatabricksConfig.from_token(DEFAULT_SECTION, TEST_HOST, TEST_TOKEN)
-    update_and_persist_config(config)
+    config = DatabricksConfig.from_token(TEST_HOST, TEST_TOKEN)
+    update_and_persist_config(DEFAULT_SECTION, config)
 
     # Overwrite conf for same section.
-    config = DatabricksConfig.from_password(TEST_PROFILE, TEST_HOST, TEST_USER, TEST_PASSWORD)
-    update_and_persist_config(config)
+    config = DatabricksConfig.from_password(TEST_HOST, TEST_USER, TEST_PASSWORD)
+    update_and_persist_config(TEST_PROFILE, config)
 
     config = get_config_for_profile(DEFAULT_SECTION)
     assert config.is_valid_with_token
@@ -70,11 +70,10 @@ def test_update_and_persist_config_two_sections():
 
 
 def test_update_and_persist_config_case_insensitive():
-    config = DatabricksConfig.from_token(TEST_PROFILE, TEST_HOST, TEST_TOKEN)
-    update_and_persist_config(config)
-    config = DatabricksConfig.from_password(
-        TEST_PROFILE.upper(), TEST_HOST, TEST_USER, TEST_PASSWORD)
-    update_and_persist_config(config)
+    config = DatabricksConfig.from_token(TEST_HOST, TEST_TOKEN)
+    update_and_persist_config(TEST_PROFILE, config)
+    config = DatabricksConfig.from_password(TEST_HOST, TEST_USER, TEST_PASSWORD)
+    update_and_persist_config(TEST_PROFILE.upper(), config)
 
     config = get_config_for_profile(TEST_PROFILE)
     assert config.is_valid_with_password
@@ -85,7 +84,6 @@ def test_get_config_for_profile_empty():
     config = get_config_for_profile(TEST_PROFILE)
     assert not config.is_valid_with_password
     assert not config.is_valid_with_token
-    assert config.profile == TEST_PROFILE.upper()
     assert config.host is None
     assert config.username is None
     assert config.password is None
@@ -94,32 +92,28 @@ def test_get_config_for_profile_empty():
 
 class TestDatabricksConfig(object):
     def test_from_token(self):
-        config = DatabricksConfig.from_token(TEST_PROFILE, TEST_HOST, TEST_TOKEN)
-        assert config.profile == TEST_PROFILE
+        config = DatabricksConfig.from_token(TEST_HOST, TEST_TOKEN)
         assert config.host == TEST_HOST
         assert config.token == TEST_TOKEN
 
     def test_from_password(self):
-        config = DatabricksConfig.from_password(TEST_PROFILE, TEST_HOST, TEST_USER, TEST_PASSWORD)
-        assert config.profile == TEST_PROFILE
+        config = DatabricksConfig.from_password(TEST_HOST, TEST_USER, TEST_PASSWORD)
         assert config.host == TEST_HOST
         assert config.username == TEST_USER
         assert config.password == TEST_PASSWORD
 
     def test_is_valid_with_token(self):
-        config = DatabricksConfig.from_token(TEST_PROFILE, TEST_HOST, TEST_TOKEN)
+        config = DatabricksConfig.from_token(TEST_HOST, TEST_TOKEN)
         assert not config.is_valid_with_password
-        assert config.profile == TEST_PROFILE
         assert config.is_valid_with_token
 
     def test_is_valid_with_password(self):
-        config = DatabricksConfig.from_password(TEST_PROFILE, TEST_HOST, TEST_USER, TEST_PASSWORD)
+        config = DatabricksConfig.from_password(TEST_HOST, TEST_USER, TEST_PASSWORD)
         assert config.is_valid_with_password
-        assert config.profile == TEST_PROFILE
         assert not config.is_valid_with_token
 
     def test_is_valid(self):
-        config = DatabricksConfig.from_password(TEST_PROFILE, TEST_HOST, TEST_USER, TEST_PASSWORD)
+        config = DatabricksConfig.from_password(TEST_HOST, TEST_USER, TEST_PASSWORD)
         assert config.is_valid
-        config = DatabricksConfig.from_token(TEST_PROFILE, TEST_HOST, TEST_TOKEN)
+        config = DatabricksConfig.from_token(TEST_HOST, TEST_TOKEN)
         assert config.is_valid

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -1,0 +1,125 @@
+# Databricks CLI
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"), except
+# that the use of services to which certain application programming
+# interfaces (each, an "API") connect requires that the user first obtain
+# a license for the use of the APIs from Databricks, Inc. ("Databricks"),
+# by creating an account at www.databricks.com and agreeing to either (a)
+# the Community Edition Terms of Service, (b) the Databricks Terms of
+# Service, or (c) another written agreement between Licensee and Databricks
+# for the use of the APIs.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from databricks_cli.configure.provider import DatabricksConfig, DEFAULT_SECTION, \
+    update_and_persist_config, get_config_for_profile
+
+TEST_HOST = 'https://test.cloud.databricks.com'
+TEST_USER = 'monkey@databricks.com'
+TEST_PASSWORD = 'banana' # NOQA
+TEST_TOKEN = 'dapiTESTING'
+TEST_PROFILE = 'testing-profile'
+
+
+def test_update_and_persist_config():
+    config = DatabricksConfig.from_token(DEFAULT_SECTION, TEST_HOST, TEST_TOKEN)
+    update_and_persist_config(config)
+    config = get_config_for_profile(DEFAULT_SECTION)
+    assert config.is_valid_with_token
+    assert config.host == TEST_HOST
+    assert config.token == TEST_TOKEN
+
+    # Overwrite conf for same section.
+    config = DatabricksConfig.from_password(DEFAULT_SECTION, TEST_HOST, TEST_USER, TEST_PASSWORD)
+    update_and_persist_config(config)
+    config = get_config_for_profile(DEFAULT_SECTION)
+    assert config.is_valid_with_password
+    assert not config.is_valid_with_token
+    assert config.host == TEST_HOST
+    assert config.username == TEST_USER
+    assert config.password == TEST_PASSWORD
+
+
+def test_update_and_persist_config_two_sections():
+    config = DatabricksConfig.from_token(DEFAULT_SECTION, TEST_HOST, TEST_TOKEN)
+    update_and_persist_config(config)
+
+    # Overwrite conf for same section.
+    config = DatabricksConfig.from_password(TEST_PROFILE, TEST_HOST, TEST_USER, TEST_PASSWORD)
+    update_and_persist_config(config)
+
+    config = get_config_for_profile(DEFAULT_SECTION)
+    assert config.is_valid_with_token
+    assert config.host == TEST_HOST
+    assert config.token == TEST_TOKEN
+
+    config = get_config_for_profile(TEST_PROFILE)
+    assert config.is_valid_with_password
+    assert config.host == TEST_HOST
+    assert config.username == TEST_USER
+    assert config.password == TEST_PASSWORD
+
+
+def test_update_and_persist_config_case_insensitive():
+    config = DatabricksConfig.from_token(TEST_PROFILE, TEST_HOST, TEST_TOKEN)
+    update_and_persist_config(config)
+    config = DatabricksConfig.from_password(
+        TEST_PROFILE.upper(), TEST_HOST, TEST_USER, TEST_PASSWORD)
+    update_and_persist_config(config)
+
+    config = get_config_for_profile(TEST_PROFILE)
+    assert config.is_valid_with_password
+    assert not config.is_valid_with_token
+
+
+def test_get_config_for_profile_empty():
+    config = get_config_for_profile(TEST_PROFILE)
+    assert not config.is_valid_with_password
+    assert not config.is_valid_with_token
+    assert config.profile == TEST_PROFILE.upper()
+    assert config.host is None
+    assert config.username is None
+    assert config.password is None
+    assert config.token is None
+
+
+class TestDatabricksConfig(object):
+    def test_from_token(self):
+        config = DatabricksConfig.from_token(TEST_PROFILE, TEST_HOST, TEST_TOKEN)
+        assert config.profile == TEST_PROFILE
+        assert config.host == TEST_HOST
+        assert config.token == TEST_TOKEN
+
+    def test_from_password(self):
+        config = DatabricksConfig.from_password(TEST_PROFILE, TEST_HOST, TEST_USER, TEST_PASSWORD)
+        assert config.profile == TEST_PROFILE
+        assert config.host == TEST_HOST
+        assert config.username == TEST_USER
+        assert config.password == TEST_PASSWORD
+
+    def test_is_valid_with_token(self):
+        config = DatabricksConfig.from_token(TEST_PROFILE, TEST_HOST, TEST_TOKEN)
+        assert not config.is_valid_with_password
+        assert config.profile == TEST_PROFILE
+        assert config.is_valid_with_token
+
+    def test_is_valid_with_password(self):
+        config = DatabricksConfig.from_password(TEST_PROFILE, TEST_HOST, TEST_USER, TEST_PASSWORD)
+        assert config.is_valid_with_password
+        assert config.profile == TEST_PROFILE
+        assert not config.is_valid_with_token
+
+    def test_is_valid(self):
+        config = DatabricksConfig.from_password(TEST_PROFILE, TEST_HOST, TEST_USER, TEST_PASSWORD)
+        assert config.is_valid
+        config = DatabricksConfig.from_token(TEST_PROFILE, TEST_HOST, TEST_TOKEN)
+        assert config.is_valid

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,14 +23,13 @@
 import shutil
 import tempfile
 import pytest
-import mock
 
-from databricks_cli.configure.config import DatabricksConfig
+import databricks_cli.configure.provider as provider
 
 
 @pytest.fixture(autouse=True)
 def mock_conf_dir():
     path = tempfile.mkdtemp()
-    with mock.patch.object(DatabricksConfig, 'home', path):
-        yield
+    provider._home = path
+    yield
     shutil.rmtree(path)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -28,8 +28,8 @@ from databricks_cli.configure.provider import DatabricksConfig, DEFAULT_SECTION,
 
 def provide_conf(test):
     def wrapper(test, *args, **kwargs):
-        config = DatabricksConfig.from_token(DEFAULT_SECTION, 'test-host', 'test-token')
-        update_and_persist_config(config)
+        config = DatabricksConfig.from_token('test-host', 'test-token')
+        update_and_persist_config(DEFAULT_SECTION, config)
         return test(*args, **kwargs)
     return decorator.decorator(wrapper, test)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,12 +22,13 @@
 # limitations under the License.
 import decorator
 
-from databricks_cli.configure.config import DatabricksConfig, DEFAULT_SECTION
+from databricks_cli.configure.provider import DatabricksConfig, DEFAULT_SECTION, \
+    update_and_persist_config
 
 
 def provide_conf(test):
     def wrapper(test, *args, **kwargs):
-        conf = DatabricksConfig().update_with_token(DEFAULT_SECTION, "test-host", "test-token")
-        conf.overwrite()
+        config = DatabricksConfig.from_token(DEFAULT_SECTION, 'test-host', 'test-token')
+        update_and_persist_config(config)
         return test(*args, **kwargs)
     return decorator.decorator(wrapper, test)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,12 +22,12 @@
 # limitations under the License.
 import decorator
 
-from databricks_cli.configure.config import DatabricksConfig
+from databricks_cli.configure.config import DatabricksConfig, DEFAULT_SECTION
 
 
 def provide_conf(test):
     def wrapper(test, *args, **kwargs):
-        conf = DatabricksConfig.construct_from_token("test-host", "test-token")
+        conf = DatabricksConfig().update_with_token(DEFAULT_SECTION, "test-host", "test-token")
         conf.overwrite()
         return test(*args, **kwargs)
     return decorator.decorator(wrapper, test)


### PR DESCRIPTION
This is part one of two for the configuration profile feature.

In this part, we add support for writing configurations with different profiles. In the next PR, we will add support for using this profile to authenticate to a Databricks workspace other than the one specified by the `DEFAULT` profile.