### PR TITLE
Ignore hidden files and fix Windows paths

### DIFF
--- a/databricks_cli/workspace/cli.py
+++ b/databricks_cli/workspace/cli.py
@@ -196,6 +196,7 @@ def _import_dir_helper(source_path, target_path, overwrite):
             ext = WorkspaceLanguage.get_extension(cur_src)
             if ext != '':
                 cur_dst = cur_dst[:-len(ext)]
+                cur_dst = cur_dst.replace(os.path.sep, '/') if (os.path.sep != '/') else cur_dst
                 language = WorkspaceLanguage.to_language(cur_src)
                 import_workspace(cur_src, cur_dst, language, WorkspaceFormat.SOURCE, overwrite)
                 click.echo('{} -> {}'.format(cur_src, cur_dst))

--- a/databricks_cli/workspace/cli.py
+++ b/databricks_cli/workspace/cli.py
@@ -141,7 +141,7 @@ def _export_dir_helper(source_path, target_path, overwrite):
                    .format(target_path, source_path))
         return
     if not os.path.isdir(target_path):
-        os.makedirs(target_path)
+        os.makedirs(os.path.normpath(target_path))
     for obj in list_objects(source_path):
         cur_src = obj.path
         cur_dst = os.path.join(target_path, obj.basename)
@@ -180,8 +180,9 @@ def export_dir_cli(source_path, target_path, overwrite):
 
 def _import_dir_helper(source_path, target_path, overwrite):
     # Try doing the os.listdir before creating the dir in Databricks.
-    filenames = os.listdir(source_path)
+    filenames = [f for f in os.listdir(source_path) if not f.startswith('.')]
     try:
+        target_path = target_path.replace(os.path.sep, '/') if (os.path.sep != '/') else target_path
         mkdirs(target_path)
     except HTTPError as e:
         click.echo(e.response.json())


### PR DESCRIPTION
This PR is to address both #65 and #62

For now I just filter any paths starting with `.` (e.g. `.git`). However, we could also use `glob.glob` instead which automatically ignores hidden files, we could then avoid the recursion as well.