### PR TITLE
Fix path separator on Windows

### DIFF
--- a/databricks_cli/workspace/cli.py
+++ b/databricks_cli/workspace/cli.py
@@ -191,7 +191,7 @@ def _import_dir_helper(source_path, target_path, overwrite):
     for filename in filenames:
         cur_src = os.path.join(source_path, filename)
         # don't use os.path.join here since it will set \ on Windows
-        cur_dst = target_path + '/' + filename
+        cur_dst = target_path.rstrip('/') + '/' + filename
         if os.path.isdir(cur_src):
             _import_dir_helper(cur_src, cur_dst, overwrite)
         elif os.path.isfile(cur_src):

--- a/databricks_cli/workspace/cli.py
+++ b/databricks_cli/workspace/cli.py
@@ -136,6 +136,8 @@ def delete_cli(workspace_path, recursive):
 
 
 def _export_dir_helper(source_path, target_path, overwrite):
+    # normalize path to local filesystem (e.g. for Windows)
+    target_path = os.path.normpath(target_path)
     if os.path.isfile(target_path):
         click.echo('{} exists as a file. Skipping this subtree {}'
                    .format(target_path, source_path))
@@ -188,7 +190,8 @@ def _import_dir_helper(source_path, target_path, overwrite):
         return
     for filename in filenames:
         cur_src = os.path.join(source_path, filename)
-        cur_dst = os.path.join(target_path, filename)
+        # don't use os.path.join here since it will set \ on Windows
+        cur_dst = target_path + '/' + filename
         if os.path.isdir(cur_src):
             _import_dir_helper(cur_src, cur_dst, overwrite)
         elif os.path.isfile(cur_src):

--- a/databricks_cli/workspace/cli.py
+++ b/databricks_cli/workspace/cli.py
@@ -136,8 +136,6 @@ def delete_cli(workspace_path, recursive):
 
 
 def _export_dir_helper(source_path, target_path, overwrite):
-    # normalize path to local filesystem (e.g. for Windows)
-    target_path = os.path.normpath(target_path)
     if os.path.isfile(target_path):
         click.echo('{} exists as a file. Skipping this subtree {}'
                    .format(target_path, source_path))

--- a/tests/workspace/test_cli.py
+++ b/tests/workspace/test_cli.py
@@ -79,13 +79,13 @@ def test_export_dir_helper(tmpdir):
             # Verify we exported files b, c, d, e with the correct names
             assert export_workspace_mock.call_count == 4
             assert export_workspace_mock.call_args_list[0][0][0] == '/a/b'
-            assert export_workspace_mock.call_args_list[0][0][1] == tmpdir.strpath + '/a/b.scala'
+            assert export_workspace_mock.call_args_list[0][0][1] == os.path.join(tmpdir.strpath, 'a', 'b.scala')
             assert export_workspace_mock.call_args_list[1][0][0] == '/a/c'
-            assert export_workspace_mock.call_args_list[1][0][1] == tmpdir.strpath + '/a/c.py'
+            assert export_workspace_mock.call_args_list[1][0][1] == os.path.join(tmpdir.strpath, 'a', 'c.py')
             assert export_workspace_mock.call_args_list[2][0][0] == '/a/d'
-            assert export_workspace_mock.call_args_list[2][0][1] == tmpdir.strpath + '/a/d.r'
+            assert export_workspace_mock.call_args_list[2][0][1] == os.path.join(tmpdir.strpath, 'a', 'd.r')
             assert export_workspace_mock.call_args_list[3][0][0] == '/a/e'
-            assert export_workspace_mock.call_args_list[3][0][1] == tmpdir.strpath + '/a/e.sql'
+            assert export_workspace_mock.call_args_list[3][0][1] == os.path.join(tmpdir.strpath, 'a', 'e.sql')
             # Verify that we only called list 4 times.
             assert list_objects_mock.call_count == 4
 
@@ -123,13 +123,13 @@ def test_import_dir_helper(tmpdir):
             assert any([ca[0][0] == '/f/g' for ca in mkdirs_mock.call_args_list])
             # Verify that we imported the correct files
             assert import_workspace.call_count == 4
-            assert any([ca[0][0] == tmpdir.strpath + '/a/b.scala' \
+            assert any([ca[0][0] == os.path.join(tmpdir.strpath, 'a', 'b.scala') \
                     for ca in import_workspace.call_args_list])
-            assert any([ca[0][0] == tmpdir.strpath + '/a/c.py' \
+            assert any([ca[0][0] == os.path.join(tmpdir.strpath, 'a', 'c.py') \
                     for ca in import_workspace.call_args_list])
-            assert any([ca[0][0] == tmpdir.strpath + '/a/d.r' \
+            assert any([ca[0][0] == os.path.join(tmpdir.strpath, 'a', 'd.r') \
                     for ca in import_workspace.call_args_list])
-            assert any([ca[0][0] == tmpdir.strpath + '/a/e.sql' \
+            assert any([ca[0][0] == os.path.join(tmpdir.strpath, 'a', 'e.sql') \
                     for ca in import_workspace.call_args_list])
             assert any([ca[0][1] == '/a/b' for ca in import_workspace.call_args_list])
             assert any([ca[0][1] == '/a/c' for ca in import_workspace.call_args_list])
@@ -163,6 +163,6 @@ def test_import_dir_rstrip(tmpdir):
 
             # Verify that we imported the correct files with the right names
             assert import_workspace.call_count == 1
-            assert any([ca[0][0] == tmpdir.strpath + '/a/test-py.py' \
+            assert any([ca[0][0] == os.path.join(tmpdir.strpath, 'a', 'test-py.py') \
                     for ca in import_workspace.call_args_list])
             assert any([ca[0][1] == '/a/test-py' for ca in import_workspace.call_args_list])


### PR DESCRIPTION
Handle Windows paths when exporting and importing with the workspace API, to address #65 