### PR TITLE
Adding json_file option to allow notebook_params to be in JSON file

### DIFF
--- a/databricks_cli/jobs/cli.py
+++ b/databricks_cli/jobs/cli.py
@@ -156,7 +156,7 @@ def get_cli(job_id):
                    '["--class", "org.apache.spark.examples.SparkPi"]')
 @require_config
 @eat_exceptions
-def run_now_cli(job_id, jar_params, notebook_params, python_params, spark_submit_params):
+def run_now_cli(job_id, jar_params, notebook_params, python_params, spark_submit_params, json_file):
     """
     Runs a job with optional per-run parameters.
 
@@ -167,6 +167,7 @@ def run_now_cli(job_id, jar_params, notebook_params, python_params, spark_submit
     notebook_params_json = json_loads(notebook_params) if notebook_params else None
     python_params = json_loads(python_params) if python_params else None
     spark_submit_params = json_loads(spark_submit_params) if spark_submit_params else None
+    json_file_params = (json_file, json) if jar_params else None
     res = run_now(job_id, jar_params_json, notebook_params_json, python_params, spark_submit_params)
     click.echo(pretty_format(res))
 


### PR DESCRIPTION
I've probably botched this code, but I'm trying to adding an option to allow notebook parameters to be stored in external JSON file and be called via run-now. I'd expect this to be similar to cluster definition JSON file except notebook parameters JSON file would need notebook_params as a top level key.  Something like this:
{
  "notebook_params" : {
    "parameter1": 0,
    "parameter2": 1
  },
}