### PR TITLE
Add support for profile option on all commands

### DIFF
--- a/databricks_cli/clusters/api.py
+++ b/databricks_cli/clusters/api.py
@@ -20,41 +20,36 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from databricks_cli.configure.config import get_clusters_client
-
-
-def create_cluster(json):
-    return get_clusters_client().client.perform_query('POST', '/clusters/create', data=json)
+from databricks_cli.sdk import ClusterService
 
 
-def start_cluster(cluster_id):
-    return get_clusters_client().start_cluster(cluster_id)
+class ClusterApi(object):
+    def __init__(self, api_client):
+        self.client = ClusterService(api_client)
 
+    def create_cluster(self, json):
+        return self.client.client.perform_query('POST', '/clusters/create', data=json)
 
-def restart_cluster(cluster_id):
-    return get_clusters_client().restart_cluster(cluster_id)
+    def start_cluster(self, cluster_id):
+        return self.client.start_cluster(cluster_id)
 
+    def restart_cluster(self, cluster_id):
+        return self.client.restart_cluster(cluster_id)
 
-def delete_cluster(cluster_id):
-    return get_clusters_client().delete_cluster(cluster_id)
+    def delete_cluster(self, cluster_id):
+        return self.client.delete_cluster(cluster_id)
 
+    def get_cluster(self, cluster_id):
+        return self.client.get_cluster(cluster_id)
 
-def get_cluster(cluster_id):
-    return get_clusters_client().get_cluster(cluster_id)
+    def list_clusters(self):
+        return self.client.list_clusters()
 
+    def list_zones(self):
+        return self.client.list_available_zones()
 
-def list_clusters():
-    return get_clusters_client().list_clusters()
+    def list_node_types(self):
+        return self.client.list_node_types()
 
-
-def list_zones():
-    return get_clusters_client().list_available_zones()
-
-
-def list_node_types():
-    return get_clusters_client().list_node_types()
-
-
-def spark_versions():
-    return get_clusters_client().list_spark_versions()
+    def spark_versions(self):
+        return self.client.list_spark_versions()

--- a/databricks_cli/clusters/cli.py
+++ b/databricks_cli/clusters/cli.py
@@ -25,11 +25,10 @@ import click
 from tabulate import tabulate
 
 from databricks_cli.click_types import OutputClickType, JsonClickType, ClusterIdClickType
-from databricks_cli.clusters.api import create_cluster, start_cluster, restart_cluster, \
-    delete_cluster, get_cluster, list_clusters, list_zones, list_node_types, spark_versions
+from databricks_cli.clusters.api import ClusterApi
 from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS, pretty_format, json_cli_base, \
     truncate_string
-from databricks_cli.configure.config import require_config
+from databricks_cli.configure.config import require_config, profile_option
 from databricks_cli.version import print_version_callback, version
 
 
@@ -38,54 +37,58 @@ from databricks_cli.version import print_version_callback, version
               help='File containing JSON request to POST to /api/2.0/clusters/create.')
 @click.option('--json', default=None, type=JsonClickType(),
               help=JsonClickType.help('/api/2.0/clusters/create'))
+@profile_option
 @require_config
 @eat_exceptions
-def create_cli(json_file, json):
+def create_cli(api_client, json_file, json):
     """
     Creates a Databricks cluster.
 
     The specification for the request json can be found at
     https://docs.databricks.com/api/latest/clusters.html#create
     """
-    json_cli_base(json_file, json, create_cluster)
+    json_cli_base(json_file, json, lambda json: ClusterApi(api_client).create_cluster(json))
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Starts a terminated Databricks cluster given its ID.')
 @click.option('--cluster-id', required=True, type=ClusterIdClickType(),
               help=ClusterIdClickType.help)
+@profile_option
 @require_config
 @eat_exceptions
-def start_cli(cluster_id):
+def start_cli(api_client, cluster_id):
     """
     Starts a terminated Databricks cluster given its ID.
 
     If the cluster is not currently in a TERMINATED state, nothing will happen.
 
     """
-    start_cluster(cluster_id)
+    ClusterApi(api_client).start_cluster(cluster_id)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--cluster-id', required=True, type=ClusterIdClickType(),
               help=ClusterIdClickType.help)
+@profile_option
 @require_config
 @eat_exceptions
-def restart_cli(cluster_id):
+def restart_cli(api_client, cluster_id):
     """
     Restarts a Databricks cluster given its ID.
 
     If the cluster is not currently in a RUNNING state, nothing will happen
     """
-    restart_cluster(cluster_id)
+    ClusterApi(api_client).restart_cluster(cluster_id)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--cluster-id', required=True, type=ClusterIdClickType(),
               help=ClusterIdClickType.help)
+@profile_option
 @require_config
 @eat_exceptions
-def delete_cli(cluster_id):
+def delete_cli(api_client, cluster_id):
     """
     Removes a Databricks cluster given its ID.
 
@@ -95,19 +98,20 @@ def delete_cli(cluster_id):
 
     Use ``databricks clusters get --cluster-id CLUSTER_ID`` to check termination states.
     """
-    delete_cluster(cluster_id)
+    ClusterApi(api_client).delete_cluster(cluster_id)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--cluster-id', required=True, type=ClusterIdClickType(),
               help=ClusterIdClickType.help)
+@profile_option
 @require_config
 @eat_exceptions
-def get_cli(cluster_id):
+def get_cli(api_client, cluster_id):
     """
     Retrieves metadata about a cluster.
     """
-    click.echo(pretty_format(get_cluster(cluster_id)))
+    click.echo(pretty_format(ClusterApi(api_client).get_cluster(cluster_id)))
 
 
 def _clusters_to_table(clusters_json):
@@ -120,9 +124,10 @@ def _clusters_to_table(clusters_json):
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Lists active and recently terminated clusters.')
 @click.option('--output', default=None, help=OutputClickType.help, type=OutputClickType())
+@profile_option
 @require_config
 @eat_exceptions
-def list_cli(output):
+def list_cli(api_client, output):
     """
     Lists active and recently terminated clusters.
 
@@ -137,7 +142,7 @@ def list_cli(output):
 
       - Cluster state
     """
-    clusters_json = list_clusters()
+    clusters_json = ClusterApi(api_client).list_clusters()
     if OutputClickType.is_json(output):
         click.echo(pretty_format(clusters_json))
     else:
@@ -145,50 +150,52 @@ def list_cli(output):
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
+@profile_option
 @require_config
 @eat_exceptions
-def list_zones_cli():
+def list_zones_cli(api_client):
     """
     Lists zones where clusters can be created.
 
     The output format is specified in
     https://docs.databricks.com/api/latest/clusters.html#list-zones
     """
-    click.echo(pretty_format(list_zones()))
+    click.echo(pretty_format(ClusterApi(api_client).list_zones()))
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Lists possible node types for a cluster.')
+@profile_option
 @require_config
 @eat_exceptions
-def list_node_types_cli():
+def list_node_types_cli(api_client):
     """
     Lists possible node types for a cluster.
 
     The output format is specified in
     https://docs.databricks.com/api/latest/clusters.html#list-node-types
     """
-    click.echo(pretty_format(list_node_types()))
+    click.echo(pretty_format(ClusterApi(api_client).list_node_types()))
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
+@profile_option
 @require_config
 @eat_exceptions
-def spark_versions_cli():
+def spark_versions_cli(api_client):
     """
     Lists possible Databricks Runtime versions for a cluster.
 
     The output format is specified in
     https://docs.databricks.com/api/latest/clusters.html#spark-versions
     """
-    click.echo(pretty_format(spark_versions()))
+    click.echo(pretty_format(ClusterApi(api_client).spark_versions()))
 
 
 @click.group(context_settings=CONTEXT_SETTINGS,
              short_help='Utility to interact with Databricks clusters.')
 @click.option('--version', '-v', is_flag=True, callback=print_version_callback,
               expose_value=False, is_eager=True, help=version)
-@require_config
 @eat_exceptions
 def clusters_group():
     """

--- a/databricks_cli/clusters/cli.py
+++ b/databricks_cli/clusters/cli.py
@@ -28,7 +28,7 @@ from databricks_cli.click_types import OutputClickType, JsonClickType, ClusterId
 from databricks_cli.clusters.api import ClusterApi
 from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS, pretty_format, json_cli_base, \
     truncate_string
-from databricks_cli.configure.config import require_config, profile_option
+from databricks_cli.configure.config import provide_api_client, profile_option
 from databricks_cli.version import print_version_callback, version
 
 
@@ -38,8 +38,8 @@ from databricks_cli.version import print_version_callback, version
 @click.option('--json', default=None, type=JsonClickType(),
               help=JsonClickType.help('/api/2.0/clusters/create'))
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def create_cli(api_client, json_file, json):
     """
     Creates a Databricks cluster.
@@ -55,8 +55,8 @@ def create_cli(api_client, json_file, json):
 @click.option('--cluster-id', required=True, type=ClusterIdClickType(),
               help=ClusterIdClickType.help)
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def start_cli(api_client, cluster_id):
     """
     Starts a terminated Databricks cluster given its ID.
@@ -71,7 +71,7 @@ def start_cli(api_client, cluster_id):
 @click.option('--cluster-id', required=True, type=ClusterIdClickType(),
               help=ClusterIdClickType.help)
 @profile_option
-@require_config
+@provide_api_client
 @eat_exceptions
 def restart_cli(api_client, cluster_id):
     """
@@ -86,8 +86,8 @@ def restart_cli(api_client, cluster_id):
 @click.option('--cluster-id', required=True, type=ClusterIdClickType(),
               help=ClusterIdClickType.help)
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def delete_cli(api_client, cluster_id):
     """
     Removes a Databricks cluster given its ID.
@@ -105,8 +105,8 @@ def delete_cli(api_client, cluster_id):
 @click.option('--cluster-id', required=True, type=ClusterIdClickType(),
               help=ClusterIdClickType.help)
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def get_cli(api_client, cluster_id):
     """
     Retrieves metadata about a cluster.
@@ -125,8 +125,8 @@ def _clusters_to_table(clusters_json):
                short_help='Lists active and recently terminated clusters.')
 @click.option('--output', default=None, help=OutputClickType.help, type=OutputClickType())
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def list_cli(api_client, output):
     """
     Lists active and recently terminated clusters.
@@ -151,8 +151,8 @@ def list_cli(api_client, output):
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def list_zones_cli(api_client):
     """
     Lists zones where clusters can be created.
@@ -166,8 +166,8 @@ def list_zones_cli(api_client):
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Lists possible node types for a cluster.')
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def list_node_types_cli(api_client):
     """
     Lists possible node types for a cluster.
@@ -180,8 +180,8 @@ def list_node_types_cli(api_client):
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def spark_versions_cli(api_client):
     """
     Lists possible Databricks Runtime versions for a cluster.

--- a/databricks_cli/configure/config.py
+++ b/databricks_cli/configure/config.py
@@ -33,7 +33,8 @@ from databricks_cli.sdk import ApiClient
 
 def provide_api_client(function):
     """
-    All callbacks wrapped by require_config expect the argument ``profile`` to be passed in.
+    Injects the api_client keyword argument to the wrapped function.
+    All callbacks wrapped by provide_api_client expect the argument ``profile`` to be passed in.
     """
     @six.wraps(function)
     def decorator(*args, **kwargs):

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -73,7 +73,6 @@ def update_and_persist_config(profile, databricks_config):
     same profile.
     :param databricks_config: DatabricksConfig
     """
-    profile = profile.upper()
     raw_config = _fetch_from_fs()
     _create_section_if_absent(raw_config, profile)
     _set_option(raw_config, profile, HOST, databricks_config.host)
@@ -89,7 +88,6 @@ def get_config_for_profile(profile):
     exist, then return a DatabricksConfig with fields set.
     :return: DatabricksConfig
     """
-    profile = profile.upper()
     raw_config = _fetch_from_fs()
     host = _get_option_if_exists(raw_config, profile, HOST)
     username = _get_option_if_exists(raw_config, profile, USERNAME)

--- a/databricks_cli/dbfs/cli.py
+++ b/databricks_cli/dbfs/cli.py
@@ -29,9 +29,8 @@ from requests.exceptions import HTTPError
 from databricks_cli.utils import eat_exceptions, error_and_quit, CONTEXT_SETTINGS
 from databricks_cli.version import print_version_callback, version
 from databricks_cli.configure.cli import configure_cli
-from databricks_cli.configure.config import require_config
-from databricks_cli.dbfs.api import put_file, get_file, list_files, \
-    delete, mkdirs, get_status, DbfsErrorCodes, move
+from databricks_cli.configure.config import require_config, profile_option
+from databricks_cli.dbfs.api import DbfsErrorCodes, DbfsApi
 from databricks_cli.dbfs.dbfs_path import DbfsPath, DbfsPathClickType
 from databricks_cli.dbfs.exceptions import LocalFileExistsException
 
@@ -42,9 +41,10 @@ from databricks_cli.dbfs.exceptions import LocalFileExistsException
 @click.option('-l', is_flag=True, default=False,
               help='Displays full information including size and file type.')
 @click.argument('dbfs_path', nargs=-1, type=DbfsPathClickType())
+@profile_option
 @require_config
 @eat_exceptions
-def ls_cli(l, absolute, dbfs_path): #  NOQA
+def ls_cli(api_client, l, absolute, dbfs_path): #  NOQA
     """
     List files in DBFS.
     """
@@ -54,7 +54,7 @@ def ls_cli(l, absolute, dbfs_path): #  NOQA
         dbfs_path = dbfs_path[0]
     else:
         error_and_quit('ls can take a maximum of one path.')
-    files = list_files(dbfs_path)
+    files = DbfsApi(api_client).list_files(dbfs_path)
     table = tabulate([f.to_row(is_long_form=l, is_absolute=absolute) for f in files],
                      tablefmt='plain')
     click.echo(table)
@@ -62,54 +62,56 @@ def ls_cli(l, absolute, dbfs_path): #  NOQA
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('dbfs_path', type=DbfsPathClickType())
+@profile_option
 @require_config
 @eat_exceptions
-def mkdirs_cli(dbfs_path):
+def mkdirs_cli(api_client, dbfs_path):
     """
     Make directories in DBFS.
 
     Mkdirs will create directories along the path to the argument directory.
     """
-    mkdirs(dbfs_path)
+    DbfsApi(api_client).mkdirs(dbfs_path)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--recursive', '-r', is_flag=True, default=False)
 @click.argument('dbfs_path', type=DbfsPathClickType())
+@profile_option
 @require_config
 @eat_exceptions
-def rm_cli(recursive, dbfs_path):
+def rm_cli(api_client, recursive, dbfs_path):
     """
     Remove files from dbfs.
 
     To remove a directory you must provide the --recursive flag.
     """
-    delete(dbfs_path, recursive)
+    DbfsApi(api_client).delete(dbfs_path, recursive)
 
 
-def copy_to_dbfs_non_recursive(src, dbfs_path_dst, overwrite):
+def copy_to_dbfs_non_recursive(dbfs_api, src, dbfs_path_dst, overwrite):
     # Munge dst path in case dbfs_path_dst is a dir
     try:
-        if get_status(dbfs_path_dst).is_dir:
+        if dbfs_api.get_status(dbfs_path_dst).is_dir:
             dbfs_path_dst = dbfs_path_dst.join(os.path.basename(src))
     except HTTPError as e:
         if e.response.json()['error_code'] == DbfsErrorCodes.RESOURCE_DOES_NOT_EXIST:
             pass
         else:
             raise e
-    put_file(src, dbfs_path_dst, overwrite)
+    dbfs_api.put_file(src, dbfs_path_dst, overwrite)
 
 
-def copy_from_dbfs_non_recursive(dbfs_path_src, dst, overwrite):
+def copy_from_dbfs_non_recursive(dbfs_api, dbfs_path_src, dst, overwrite):
     # Munge dst path in case dst is a dir
     if os.path.isdir(dst):
         dst = os.path.join(dst, dbfs_path_src.basename)
-    get_file(dbfs_path_src, dst, overwrite)
+    dbfs_api.get_file(dbfs_path_src, dst, overwrite)
 
 
-def copy_to_dbfs_recursive(src, dbfs_path_dst, overwrite):
+def copy_to_dbfs_recursive(dbfs_api, src, dbfs_path_dst, overwrite):
     try:
-        mkdirs(dbfs_path_dst)
+        dbfs_api.mkdirs(dbfs_path_dst)
     except HTTPError as e:
         if e.response.json()['error_code'] == DbfsErrorCodes.RESOURCE_ALREADY_EXISTS:
             click.echo(e.response.json())
@@ -118,10 +120,10 @@ def copy_to_dbfs_recursive(src, dbfs_path_dst, overwrite):
         cur_src = os.path.join(src, filename)
         cur_dbfs_dst = dbfs_path_dst.join(filename)
         if os.path.isdir(cur_src):
-            copy_to_dbfs_recursive(cur_src, cur_dbfs_dst, overwrite)
+            copy_to_dbfs_recursive(dbfs_api, cur_src, cur_dbfs_dst, overwrite)
         elif os.path.isfile(cur_src):
             try:
-                put_file(cur_src, cur_dbfs_dst, overwrite)
+                dbfs_api.put_file(cur_src, cur_dbfs_dst, overwrite)
                 click.echo('{} -> {}'.format(cur_src, cur_dbfs_dst))
             except HTTPError as e:
                 if e.response.json()['error_code'] == DbfsErrorCodes.RESOURCE_ALREADY_EXISTS:
@@ -130,21 +132,21 @@ def copy_to_dbfs_recursive(src, dbfs_path_dst, overwrite):
                     raise e
 
 
-def copy_from_dbfs_recursive(dbfs_path_src, dst, overwrite):
+def copy_from_dbfs_recursive(dbfs_api, dbfs_path_src, dst, overwrite):
     if os.path.isfile(dst):
         click.echo('{} exists as a file. Skipping this subtree {}'.format(dst, repr(dbfs_path_src)))
         return
     elif not os.path.isdir(dst):
         os.makedirs(dst)
 
-    for dbfs_src_file_info in list_files(dbfs_path_src):
+    for dbfs_src_file_info in dbfs_api.list_files(dbfs_path_src):
         cur_dbfs_src = dbfs_src_file_info.dbfs_path
         cur_dst = os.path.join(dst, cur_dbfs_src.basename)
         if dbfs_src_file_info.is_dir:
-            copy_from_dbfs_recursive(cur_dbfs_src, cur_dst, overwrite)
+            copy_from_dbfs_recursive(dbfs_api, cur_dbfs_src, cur_dst, overwrite)
         else:
             try:
-                get_file(cur_dbfs_src, cur_dst, overwrite)
+                dbfs_api.get_file(cur_dbfs_src, cur_dst, overwrite)
                 click.echo('{} -> {}'.format(cur_dbfs_src, cur_dst))
             except LocalFileExistsException:
                 click.echo(('{} already exists locally as {}. Skip. To overwrite, you' +
@@ -156,9 +158,10 @@ def copy_from_dbfs_recursive(dbfs_path_src, dst, overwrite):
 @click.option('--overwrite', is_flag=True, default=False)
 @click.argument('src')
 @click.argument('dst')
+@profile_option
 @require_config
 @eat_exceptions
-def cp_cli(recursive, overwrite, src, dst):
+def cp_cli(api_client, recursive, overwrite, src, dst):
     """
     Copy files to and from DBFS.
 
@@ -175,6 +178,7 @@ def cp_cli(recursive, overwrite, src, dst):
     flag is provided -- however, dbfs cp --recursive will continue to try and copy other files.
     """
     # Copy to DBFS in this case
+    dbfs_api = DbfsApi(api_client)
     if not DbfsPath.is_valid(src) and DbfsPath.is_valid(dst):
         if not os.path.exists(src):
             error_and_quit('The local file {} does not exist.'.format(src))
@@ -182,21 +186,21 @@ def cp_cli(recursive, overwrite, src, dst):
             if os.path.isdir(src):
                 error_and_quit(('The local file {} is a directory. You must provide --recursive')
                                .format(src))
-            copy_to_dbfs_non_recursive(src, DbfsPath(dst), overwrite)
+            copy_to_dbfs_non_recursive(dbfs_api, src, DbfsPath(dst), overwrite)
         else:
             if not os.path.isdir(src):
-                copy_to_dbfs_non_recursive(src, DbfsPath(dst), overwrite)
+                copy_to_dbfs_non_recursive(dbfs_api, src, DbfsPath(dst), overwrite)
                 return
-            copy_to_dbfs_recursive(src, DbfsPath(dst), overwrite)
+            copy_to_dbfs_recursive(dbfs_api, src, DbfsPath(dst), overwrite)
     # Copy from DBFS in this case
     elif DbfsPath.is_valid(src) and not DbfsPath.is_valid(dst):
         if not recursive:
-            copy_from_dbfs_non_recursive(DbfsPath(src), dst, overwrite)
+            copy_from_dbfs_non_recursive(dbfs_api, DbfsPath(src), dst, overwrite)
         else:
             dbfs_path_src = DbfsPath(src)
-            if not get_status(dbfs_path_src).is_dir:
-                copy_from_dbfs_non_recursive(dbfs_path_src, dst, overwrite)
-            copy_from_dbfs_recursive(dbfs_path_src, dst, overwrite)
+            if not dbfs_api.get_status(dbfs_path_src).is_dir:
+                copy_from_dbfs_non_recursive(dbfs_api, dbfs_path_src, dst, overwrite)
+            copy_from_dbfs_recursive(dbfs_api, dbfs_path_src, dst, overwrite)
     elif not DbfsPath.is_valid(src) and not DbfsPath.is_valid(dst):
         error_and_quit('Both paths provided are from your local filesystem. '
                        'To use this utility, one of the src or dst must be prefixed '
@@ -212,13 +216,14 @@ def cp_cli(recursive, overwrite, src, dst):
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('src', type=DbfsPathClickType())
 @click.argument('dst', type=DbfsPathClickType())
+@profile_option
 @require_config
 @eat_exceptions
-def mv_cli(src, dst):
+def mv_cli(api_client, src, dst):
     """
     Moves a file between two DBFS paths.
     """
-    move(src, dst)
+    DbfsApi(api_client).move(src, dst)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Utility to interact with DBFS.')

--- a/databricks_cli/dbfs/cli.py
+++ b/databricks_cli/dbfs/cli.py
@@ -29,7 +29,7 @@ from requests.exceptions import HTTPError
 from databricks_cli.utils import eat_exceptions, error_and_quit, CONTEXT_SETTINGS
 from databricks_cli.version import print_version_callback, version
 from databricks_cli.configure.cli import configure_cli
-from databricks_cli.configure.config import require_config, profile_option
+from databricks_cli.configure.config import provide_api_client, profile_option
 from databricks_cli.dbfs.api import DbfsErrorCodes, DbfsApi
 from databricks_cli.dbfs.dbfs_path import DbfsPath, DbfsPathClickType
 from databricks_cli.dbfs.exceptions import LocalFileExistsException
@@ -42,8 +42,8 @@ from databricks_cli.dbfs.exceptions import LocalFileExistsException
               help='Displays full information including size and file type.')
 @click.argument('dbfs_path', nargs=-1, type=DbfsPathClickType())
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def ls_cli(api_client, l, absolute, dbfs_path): #  NOQA
     """
     List files in DBFS.
@@ -63,8 +63,8 @@ def ls_cli(api_client, l, absolute, dbfs_path): #  NOQA
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('dbfs_path', type=DbfsPathClickType())
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def mkdirs_cli(api_client, dbfs_path):
     """
     Make directories in DBFS.
@@ -78,8 +78,8 @@ def mkdirs_cli(api_client, dbfs_path):
 @click.option('--recursive', '-r', is_flag=True, default=False)
 @click.argument('dbfs_path', type=DbfsPathClickType())
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def rm_cli(api_client, recursive, dbfs_path):
     """
     Remove files from dbfs.
@@ -159,8 +159,8 @@ def copy_from_dbfs_recursive(dbfs_api, dbfs_path_src, dst, overwrite):
 @click.argument('src')
 @click.argument('dst')
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def cp_cli(api_client, recursive, overwrite, src, dst):
     """
     Copy files to and from DBFS.
@@ -217,8 +217,8 @@ def cp_cli(api_client, recursive, overwrite, src, dst):
 @click.argument('src', type=DbfsPathClickType())
 @click.argument('dst', type=DbfsPathClickType())
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def mv_cli(api_client, src, dst):
     """
     Moves a file between two DBFS paths.

--- a/databricks_cli/jobs/api.py
+++ b/databricks_cli/jobs/api.py
@@ -20,30 +20,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from databricks_cli.configure.config import get_jobs_client
-
-
-def create_job(json):
-    return get_jobs_client().client.perform_query('POST', '/jobs/create', data=json)
+from databricks_cli.sdk import JobsService
 
 
-def list_jobs():
-    return get_jobs_client().list_jobs()
+class JobsApi(object):
+    def __init__(self, api_client):
+        self.client = JobsService(api_client)
 
+    def create_job(self, json):
+        return self.client.client.perform_query('POST', '/jobs/create', data=json)
 
-def delete_job(job_id):
-    return get_jobs_client().delete_job(job_id)
+    def list_jobs(self):
+        return self.client.list_jobs()
 
+    def delete_job(self, job_id):
+        return self.client.delete_job(job_id)
 
-def get_job(job_id):
-    return get_jobs_client().get_job(job_id)
+    def get_job(self, job_id):
+        return self.client.get_job(job_id)
 
+    def reset_job(self, json):
+        return self.client.client.perform_query('POST', '/jobs/reset', data=json)
 
-def reset_job(json):
-    return get_jobs_client().client.perform_query('POST', '/jobs/reset', data=json)
-
-
-def run_now(job_id, jar_params, notebook_params, python_params, spark_submit_params):
-    return get_jobs_client().run_now(job_id, jar_params, notebook_params, python_params,
-                                     spark_submit_params)
+    def run_now(self, job_id, jar_params, notebook_params, python_params, spark_submit_params):
+        return self.client.run_now(job_id, jar_params, notebook_params, python_params,
+                                   spark_submit_params)

--- a/databricks_cli/jobs/cli.py
+++ b/databricks_cli/jobs/cli.py
@@ -27,10 +27,10 @@ import click
 from tabulate import tabulate
 
 from databricks_cli.click_types import OutputClickType, JsonClickType, JobIdClickType
-from databricks_cli.jobs.api import create_job, list_jobs, delete_job, get_job, reset_job, run_now
+from databricks_cli.jobs.api import JobsApi
 from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS, pretty_format, json_cli_base, \
     truncate_string
-from databricks_cli.configure.config import require_config
+from databricks_cli.configure.config import require_config, profile_option
 from databricks_cli.version import print_version_callback, version
 
 
@@ -39,16 +39,17 @@ from databricks_cli.version import print_version_callback, version
               help='File containing JSON request to POST to /api/2.0/jobs/create.')
 @click.option('--json', default=None, type=JsonClickType(),
               help=JsonClickType.help('/api/2.0/jobs/create'))
+@profile_option
 @require_config
 @eat_exceptions
-def create_cli(json_file, json):
+def create_cli(api_client, json_file, json):
     """
     Creates a job.
 
     The specification for the json option can be found
     https://docs.databricks.com/api/latest/jobs.html#create
     """
-    json_cli_base(json_file, json, create_job)
+    json_cli_base(json_file, json, lambda json: JobsApi(api_client).create_job(json))
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
@@ -59,9 +60,10 @@ def create_cli(json_file, json):
 @click.option('--json', default=None, type=JsonClickType(),
               help='Partial JSON string to POST to /api/2.0/jobs/reset. '
                    'For more, read full help message.')
+@profile_option
 @require_config
 @eat_exceptions
-def reset_cli(json_file, json, job_id):
+def reset_cli(api_client, json_file, json, job_id):
     """
     Resets (edits) the definition of a job.
 
@@ -83,7 +85,7 @@ def reset_cli(json_file, json, job_id):
         'job_id': job_id,
         'new_settings': deser_json
     }
-    reset_job(request_body)
+    JobsApi(api_client).reset_job(request_body)
 
 
 def _jobs_to_table(jobs_json):
@@ -96,9 +98,10 @@ def _jobs_to_table(jobs_json):
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Lists the jobs in the Databricks Job Service.')
 @click.option('--output', default=None, help=OutputClickType.help, type=OutputClickType())
+@profile_option
 @require_config
 @eat_exceptions
-def list_cli(output):
+def list_cli(api_client, output):
     """
     Lists the jobs in the Databricks Job Service.
 
@@ -112,7 +115,8 @@ def list_cli(output):
 
     In table mode, the jobs are sorted by their name.
     """
-    jobs_json = list_jobs()
+    jobs_api = JobsApi(api_client)
+    jobs_json = jobs_api.list_jobs()
     if OutputClickType.is_json(output):
         click.echo(pretty_format(jobs_json))
     else:
@@ -122,24 +126,26 @@ def list_cli(output):
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Deletes the specified job.')
 @click.option('--job-id', required=True, type=JobIdClickType(), help=JobIdClickType.help)
+@profile_option
 @require_config
 @eat_exceptions
-def delete_cli(job_id):
+def delete_cli(api_client, job_id):
     """
     Deletes the specified job.
     """
-    delete_job(job_id)
+    JobsApi(api_client).delete_job(job_id)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--job-id', required=True, type=JobIdClickType(), help=JobIdClickType.help)
+@profile_option
 @require_config
 @eat_exceptions
-def get_cli(job_id):
+def get_cli(api_client, job_id):
     """
     Describes the metadata for a job.
     """
-    click.echo(pretty_format(get_job(job_id)))
+    click.echo(pretty_format(JobsApi(api_client).get_job(job_id)))
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
@@ -154,9 +160,11 @@ def get_cli(job_id):
 @click.option('--spark-submit-params', default=None, type=JsonClickType(),
               help='JSON string specifying an array of parameters. i.e. '
                    '["--class", "org.apache.spark.examples.SparkPi"]')
+@profile_option
 @require_config
 @eat_exceptions
-def run_now_cli(job_id, jar_params, notebook_params, python_params, spark_submit_params):
+def run_now_cli(api_client, job_id, jar_params, notebook_params, python_params,
+                spark_submit_params):
     """
     Runs a job with optional per-run parameters.
 
@@ -167,7 +175,8 @@ def run_now_cli(job_id, jar_params, notebook_params, python_params, spark_submit
     notebook_params_json = json_loads(notebook_params) if notebook_params else None
     python_params = json_loads(python_params) if python_params else None
     spark_submit_params = json_loads(spark_submit_params) if spark_submit_params else None
-    res = run_now(job_id, jar_params_json, notebook_params_json, python_params, spark_submit_params)
+    res = JobsApi(api_client).run_now(
+        job_id, jar_params_json, notebook_params_json, python_params, spark_submit_params)
     click.echo(pretty_format(res))
 
 
@@ -175,7 +184,6 @@ def run_now_cli(job_id, jar_params, notebook_params, python_params, spark_submit
              short_help='Utility to interact with jobs.')
 @click.option('--version', '-v', is_flag=True, callback=print_version_callback,
               expose_value=False, is_eager=True, help=version)
-@require_config
 @eat_exceptions
 def jobs_group():
     """

--- a/databricks_cli/jobs/cli.py
+++ b/databricks_cli/jobs/cli.py
@@ -30,7 +30,7 @@ from databricks_cli.click_types import OutputClickType, JsonClickType, JobIdClic
 from databricks_cli.jobs.api import JobsApi
 from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS, pretty_format, json_cli_base, \
     truncate_string
-from databricks_cli.configure.config import require_config, profile_option
+from databricks_cli.configure.config import provide_api_client, profile_option
 from databricks_cli.version import print_version_callback, version
 
 
@@ -40,8 +40,8 @@ from databricks_cli.version import print_version_callback, version
 @click.option('--json', default=None, type=JsonClickType(),
               help=JsonClickType.help('/api/2.0/jobs/create'))
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def create_cli(api_client, json_file, json):
     """
     Creates a job.
@@ -61,8 +61,8 @@ def create_cli(api_client, json_file, json):
               help='Partial JSON string to POST to /api/2.0/jobs/reset. '
                    'For more, read full help message.')
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def reset_cli(api_client, json_file, json, job_id):
     """
     Resets (edits) the definition of a job.
@@ -99,8 +99,8 @@ def _jobs_to_table(jobs_json):
                short_help='Lists the jobs in the Databricks Job Service.')
 @click.option('--output', default=None, help=OutputClickType.help, type=OutputClickType())
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def list_cli(api_client, output):
     """
     Lists the jobs in the Databricks Job Service.
@@ -127,8 +127,8 @@ def list_cli(api_client, output):
                short_help='Deletes the specified job.')
 @click.option('--job-id', required=True, type=JobIdClickType(), help=JobIdClickType.help)
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def delete_cli(api_client, job_id):
     """
     Deletes the specified job.
@@ -139,8 +139,8 @@ def delete_cli(api_client, job_id):
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--job-id', required=True, type=JobIdClickType(), help=JobIdClickType.help)
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def get_cli(api_client, job_id):
     """
     Describes the metadata for a job.
@@ -161,8 +161,8 @@ def get_cli(api_client, job_id):
               help='JSON string specifying an array of parameters. i.e. '
                    '["--class", "org.apache.spark.examples.SparkPi"]')
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def run_now_cli(api_client, job_id, jar_params, notebook_params, python_params,
                 spark_submit_params):
     """

--- a/databricks_cli/libraries/api.py
+++ b/databricks_cli/libraries/api.py
@@ -21,20 +21,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from databricks_cli.configure.config import get_libraries_client
+from databricks_cli.sdk import ManagedLibraryService
 
 
-def all_cluster_statuses():
-    return get_libraries_client().all_cluster_statuses()
+class LibrariesApi(object):
+    def __init__(self, api_client):
+        self.client = ManagedLibraryService(api_client)
 
+    def all_cluster_statuses(self):
+        return self.client.all_cluster_statuses()
 
-def cluster_status(cluster_id):
-    return get_libraries_client().cluster_status(cluster_id)
+    def cluster_status(self, cluster_id):
+        return self.client.cluster_status(cluster_id)
 
+    def install_libraries(self, cluster_id, libraries):
+        return self.client.install_libraries(cluster_id, libraries)
 
-def install_libraries(cluster_id, libraries):
-    return get_libraries_client().install_libraries(cluster_id, libraries)
-
-
-def uninstall_libraries(cluster_id, libraries):
-    return get_libraries_client().uninstall_libraries(cluster_id, libraries)
+    def uninstall_libraries(self, cluster_id, libraries):
+        return self.client.uninstall_libraries(cluster_id, libraries)

--- a/databricks_cli/libraries/cli.py
+++ b/databricks_cli/libraries/cli.py
@@ -24,58 +24,60 @@
 import click
 
 from databricks_cli.click_types import ClusterIdClickType, OneOfOption
-from databricks_cli.configure.config import require_config
-from databricks_cli.libraries.api import all_cluster_statuses, cluster_status, install_libraries, \
-    uninstall_libraries
+from databricks_cli.configure.config import require_config, profile_option
+from databricks_cli.libraries.api import LibrariesApi
 from databricks_cli.utils import CONTEXT_SETTINGS, eat_exceptions, pretty_format
 from databricks_cli.version import print_version_callback, version
 
 
-def _all_cluster_statuses():
-    click.echo(pretty_format(all_cluster_statuses()))
+def _all_cluster_statuses(config):
+    click.echo(pretty_format(LibrariesApi(config).all_cluster_statuses()))
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Get the status of all libraries.')
+@profile_option
 @require_config
 @eat_exceptions # noqa
-def all_cluster_statuses_cli():
+def all_cluster_statuses_cli(api_client):
     """
     Get the status of all libraries on all clusters. A status will be available for all libraries
     installed on this cluster via the API or the libraries UI as well as libraries set to be
     installed on all clusters via the libraries UI. If a library has been set to be installed on
     all clusters, is_library_for_all_clusters will be true.
     """
-    _all_cluster_statuses()
+    _all_cluster_statuses(api_client)
 
 
-def _cluster_status(cluster_id):
-    click.echo(pretty_format(cluster_status(cluster_id)))
+def _cluster_status(api_client, cluster_id):
+    click.echo(pretty_format(LibrariesApi(api_client).cluster_status(cluster_id)))
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Get the status of all libraries for a specified cluster.')
 @click.option('--cluster-id', required=True, type=ClusterIdClickType(),
               help=ClusterIdClickType.help)
+@profile_option
 @require_config
 @eat_exceptions # noqa
-def cluster_status_cli(cluster_id):
+def cluster_status_cli(api_client, cluster_id):
     """
     Get the status of all libraries for a specified cluster. A status will be available for all
     libraries installed on this cluster via the API or the libraries UI as well as libraries set to
     be installed on all clusters via the libraries UI. If a library has been set to be installed on
     all clusters, is_library_for_all_clusters will be true.
     """
-    _cluster_status(cluster_id)
+    _cluster_status(api_client, cluster_id)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Shortcut to `all-cluster-statuses` or `cluster-status`.')
 @click.option('--cluster-id', type=ClusterIdClickType(), default=None,
               help=ClusterIdClickType.help)
+@profile_option
 @require_config
 @eat_exceptions # noqa
-def list_cli(cluster_id):
+def list_cli(api_client, cluster_id):
     """
     Get the statsus of all libraries for all clusters or for a specified cluster.
     If the option --cluster-id is provided, then all libraries on that cluster will be listed,
@@ -83,9 +85,9 @@ def list_cli(cluster_id):
     will be listed (all-cluster-statuses).
     """
     if cluster_id is not None:
-        _cluster_status(cluster_id)
+        _cluster_status(api_client, cluster_id)
     else:
-        _all_cluster_statuses()
+        _all_cluster_statuses(api_client)
 
 
 INSTALL_OPTIONS = ['jar', 'egg', 'maven-coordinates', 'pypi-package', 'cran-package']
@@ -158,10 +160,11 @@ def _get_library_from_options(jar, egg, maven_coordinates, maven_repo, maven_exc
 @click.option('--pypi-repo', help=PYPI_REPO_HELP)
 @click.option('--cran-package', cls=OneOfOption, one_of=INSTALL_OPTIONS, help=CRAN_PACKAGE_HELP)
 @click.option('--cran-repo', help=CRAN_REPO_HELP)
+@profile_option
 @require_config
 @eat_exceptions # noqa
-def install_cli(cluster_id, jar, egg, maven_coordinates, maven_repo, maven_exclusion, pypi_package, # noqa
-                pypi_repo, cran_package, cran_repo):
+def install_cli(api_client, cluster_id, jar, egg, maven_coordinates, maven_repo, maven_exclusion, # noqa
+                pypi_package, pypi_repo, cran_package, cran_repo):
     """
     Install a library ona a cluster. Libraries must be first uploaded to dbfs or s3
     (see `dbfs cp -h`). Unlike the API, only one library can be installed for each execution of
@@ -172,7 +175,7 @@ def install_cli(cluster_id, jar, egg, maven_coordinates, maven_repo, maven_exclu
     """
     library = _get_library_from_options(jar, egg, maven_coordinates, maven_repo, maven_exclusion,
                                         pypi_package, pypi_repo, cran_package, cran_repo)
-    install_libraries(cluster_id, [library])
+    LibrariesApi(api_client).install_libraries(cluster_id, [library])
 
 
 def _uninstall_cli_exit_help(cluster_id):
@@ -196,23 +199,24 @@ def _uninstall_cli_exit_help(cluster_id):
 @click.option('--pypi-repo', help=PYPI_REPO_HELP)
 @click.option('--cran-package', cls=OneOfOption, one_of=INSTALL_OPTIONS, help=CRAN_PACKAGE_HELP)
 @click.option('--cran-repo', help=CRAN_REPO_HELP)
+@profile_option
 @require_config
 @eat_exceptions # noqa
-def uninstall_cli(cluster_id, all, jar, egg, maven_coordinates, maven_repo, maven_exclusion, # noqa
-                  pypi_package, pypi_repo, cran_package, cran_repo):
+def uninstall_cli(api_client, cluster_id, all, jar, egg, maven_coordinates, maven_repo, # noqa
+                  maven_exclusion, pypi_package, pypi_repo, cran_package, cran_repo):
     """
     Mark libraries on a cluster to be uninstalled. Libraries which are marked to be uninstalled
     will stay attached until the cluster is restarted. (see `databricks clusters restart -h`).
     """
     if all:
-        library_statuses = _cluster_status(cluster_id).get('library_statuses', [])
+        library_statuses = _cluster_status(api_client, cluster_id).get('library_statuses', [])
         libraries = [l_status['library'] for l_status in library_statuses]
-        uninstall_libraries(cluster_id, libraries)
+        LibrariesApi(api_client).uninstall_libraries(cluster_id, libraries)
         _uninstall_cli_exit_help(cluster_id)
         return
     library = _get_library_from_options(jar, egg, maven_coordinates, maven_repo, maven_exclusion,
                                         pypi_package, pypi_repo, cran_package, cran_repo)
-    uninstall_libraries(cluster_id, [library])
+    LibrariesApi(api_client).uninstall_libraries(cluster_id, [library])
     _uninstall_cli_exit_help(cluster_id)
 
 
@@ -220,7 +224,6 @@ def uninstall_cli(cluster_id, all, jar, egg, maven_coordinates, maven_repo, mave
              short_help='Utility to interact with libraries.')
 @click.option('--version', '-v', is_flag=True, callback=print_version_callback,
               expose_value=False, is_eager=True, help=version)
-@require_config
 @eat_exceptions
 def libraries_group():
     """

--- a/databricks_cli/libraries/cli.py
+++ b/databricks_cli/libraries/cli.py
@@ -24,7 +24,7 @@
 import click
 
 from databricks_cli.click_types import ClusterIdClickType, OneOfOption
-from databricks_cli.configure.config import require_config, profile_option
+from databricks_cli.configure.config import provide_api_client, profile_option
 from databricks_cli.libraries.api import LibrariesApi
 from databricks_cli.utils import CONTEXT_SETTINGS, eat_exceptions, pretty_format
 from databricks_cli.version import print_version_callback, version
@@ -37,8 +37,8 @@ def _all_cluster_statuses(config):
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Get the status of all libraries.')
 @profile_option
-@require_config
 @eat_exceptions # noqa
+@provide_api_client
 def all_cluster_statuses_cli(api_client):
     """
     Get the status of all libraries on all clusters. A status will be available for all libraries
@@ -58,8 +58,8 @@ def _cluster_status(api_client, cluster_id):
 @click.option('--cluster-id', required=True, type=ClusterIdClickType(),
               help=ClusterIdClickType.help)
 @profile_option
-@require_config
 @eat_exceptions # noqa
+@provide_api_client
 def cluster_status_cli(api_client, cluster_id):
     """
     Get the status of all libraries for a specified cluster. A status will be available for all
@@ -75,8 +75,8 @@ def cluster_status_cli(api_client, cluster_id):
 @click.option('--cluster-id', type=ClusterIdClickType(), default=None,
               help=ClusterIdClickType.help)
 @profile_option
-@require_config
 @eat_exceptions # noqa
+@provide_api_client
 def list_cli(api_client, cluster_id):
     """
     Get the statsus of all libraries for all clusters or for a specified cluster.
@@ -161,8 +161,8 @@ def _get_library_from_options(jar, egg, maven_coordinates, maven_repo, maven_exc
 @click.option('--cran-package', cls=OneOfOption, one_of=INSTALL_OPTIONS, help=CRAN_PACKAGE_HELP)
 @click.option('--cran-repo', help=CRAN_REPO_HELP)
 @profile_option
-@require_config
 @eat_exceptions # noqa
+@provide_api_client
 def install_cli(api_client, cluster_id, jar, egg, maven_coordinates, maven_repo, maven_exclusion, # noqa
                 pypi_package, pypi_repo, cran_package, cran_repo):
     """
@@ -200,8 +200,8 @@ def _uninstall_cli_exit_help(cluster_id):
 @click.option('--cran-package', cls=OneOfOption, one_of=INSTALL_OPTIONS, help=CRAN_PACKAGE_HELP)
 @click.option('--cran-repo', help=CRAN_REPO_HELP)
 @profile_option
-@require_config
 @eat_exceptions # noqa
+@provide_api_client
 def uninstall_cli(api_client, cluster_id, all, jar, egg, maven_coordinates, maven_repo, # noqa
                   maven_exclusion, pypi_package, pypi_repo, cran_package, cran_repo):
     """

--- a/databricks_cli/runs/api.py
+++ b/databricks_cli/runs/api.py
@@ -21,20 +21,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from databricks_cli.configure.config import get_jobs_client
+from databricks_cli.sdk import JobsService
 
 
-def submit_run(json):
-    return get_jobs_client().client.perform_query('POST', '/jobs/runs/submit', data=json)
+class RunsApi(object):
+    def __init__(self, api_client):
+        self.client = JobsService(api_client)
 
+    def submit_run(self, json):
+        return self.client.client.perform_query('POST', '/jobs/runs/submit', data=json)
 
-def list_runs(job_id, active_only, completed_only, offset, limit):
-    return get_jobs_client().list_runs(job_id, active_only, completed_only, offset, limit)
+    def list_runs(self, job_id, active_only, completed_only, offset, limit):
+        return self.client.list_runs(job_id, active_only, completed_only, offset, limit)
 
+    def get_run(self, run_id):
+        return self.client.get_run(run_id)
 
-def get_run(run_id):
-    return get_jobs_client().get_run(run_id)
-
-
-def cancel_run(run_id):
-    return get_jobs_client().cancel_run(run_id)
+    def cancel_run(self, run_id):
+        return self.client.cancel_run(run_id)

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -27,7 +27,7 @@ from tabulate import tabulate
 from databricks_cli.click_types import OutputClickType, JsonClickType, RunIdClickType
 from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS, pretty_format, json_cli_base, \
     truncate_string
-from databricks_cli.configure.config import require_config, profile_option
+from databricks_cli.configure.config import provide_api_client, profile_option
 from databricks_cli.runs.api import RunsApi
 from databricks_cli.version import print_version_callback, version
 
@@ -38,8 +38,8 @@ from databricks_cli.version import print_version_callback, version
 @click.option('--json', default=None, type=JsonClickType(),
               help=JsonClickType.help('/api/2.0/jobs/runs/submit'))
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def submit_cli(api_client, json_file, json):
     """
     Submits a one-time run.
@@ -77,8 +77,8 @@ def _runs_to_table(runs_json):
                    'Limit must be between 0 and 1000. Set to 20 runs by default.')
 @click.option('--output', help=OutputClickType.help, type=OutputClickType())
 @profile_option
-@require_config
 @eat_exceptions # noqa
+@provide_api_client
 def list_cli(api_client, job_id, active_only, completed_only, offset, limit, output): # noqa
     """
     Lists job runs.
@@ -106,8 +106,8 @@ def list_cli(api_client, job_id, active_only, completed_only, offset, limit, out
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--run-id', required=True, type=RunIdClickType())
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def get_cli(api_client, run_id):
     """
     Gets the metadata about a run in json form.
@@ -120,8 +120,8 @@ def get_cli(api_client, run_id):
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--run-id', required=True, type=RunIdClickType())
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def cancel_cli(api_client, run_id):
     """
     Cancels the run specified.

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -27,8 +27,8 @@ from tabulate import tabulate
 from databricks_cli.click_types import OutputClickType, JsonClickType, RunIdClickType
 from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS, pretty_format, json_cli_base, \
     truncate_string
-from databricks_cli.configure.config import require_config
-from databricks_cli.runs.api import submit_run, list_runs, get_run, cancel_run
+from databricks_cli.configure.config import require_config, profile_option
+from databricks_cli.runs.api import RunsApi
 from databricks_cli.version import print_version_callback, version
 
 
@@ -37,16 +37,17 @@ from databricks_cli.version import print_version_callback, version
               help='File containing JSON request to POST to /api/2.0/jobs/runs/submit.')
 @click.option('--json', default=None, type=JsonClickType(),
               help=JsonClickType.help('/api/2.0/jobs/runs/submit'))
+@profile_option
 @require_config
 @eat_exceptions
-def submit_cli(json_file, json):
+def submit_cli(api_client, json_file, json):
     """
     Submits a one-time run.
 
     The specification for the request json can be found
     https://docs.databricks.com/api/latest/jobs.html#runs-submit
     """
-    json_cli_base(json_file, json, submit_run)
+    json_cli_base(json_file, json, lambda json: RunsApi(api_client).submit_run(json))
 
 
 def _runs_to_table(runs_json):
@@ -75,9 +76,10 @@ def _runs_to_table(runs_json):
               help='The limit determines the number of runs listed. '
                    'Limit must be between 0 and 1000. Set to 20 runs by default.')
 @click.option('--output', help=OutputClickType.help, type=OutputClickType())
+@profile_option
 @require_config
 @eat_exceptions # noqa
-def list_cli(job_id, active_only, completed_only, offset, limit, output): # noqa
+def list_cli(api_client, job_id, active_only, completed_only, offset, limit, output): # noqa
     """
     Lists job runs.
 
@@ -94,7 +96,7 @@ def list_cli(job_id, active_only, completed_only, offset, limit, output): # noqa
 
       - Result state (can be n/a)
     """
-    runs_json = list_runs(job_id, active_only, completed_only, offset, limit)
+    runs_json = RunsApi(api_client).list_runs(job_id, active_only, completed_only, offset, limit)
     if OutputClickType.is_json(output):
         click.echo(pretty_format(runs_json))
     else:
@@ -103,33 +105,34 @@ def list_cli(job_id, active_only, completed_only, offset, limit, output): # noqa
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--run-id', required=True, type=RunIdClickType())
+@profile_option
 @require_config
 @eat_exceptions
-def get_cli(run_id):
+def get_cli(api_client, run_id):
     """
     Gets the metadata about a run in json form.
 
     The output schema is documented https://docs.databricks.com/api/latest/jobs.html#runs-get.
     """
-    click.echo(pretty_format(get_run(run_id)))
+    click.echo(pretty_format(RunsApi(api_client).get_run(run_id)))
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--run-id', required=True, type=RunIdClickType())
+@profile_option
 @require_config
 @eat_exceptions
-def cancel_cli(run_id):
+def cancel_cli(api_client, run_id):
     """
     Cancels the run specified.
     """
-    click.echo(pretty_format(cancel_run(run_id)))
+    click.echo(pretty_format(RunsApi(api_client).cancel_run(run_id)))
 
 
 @click.group(context_settings=CONTEXT_SETTINGS,
              short_help='Utility to interact with the jobs runs.')
 @click.option('--version', '-v', is_flag=True, callback=print_version_callback,
               expose_value=False, is_eager=True, help=version)
-@require_config
 @eat_exceptions
 def runs_group():
     """

--- a/databricks_cli/utils.py
+++ b/databricks_cli/utils.py
@@ -28,6 +28,7 @@ import click
 import six
 from requests.exceptions import HTTPError
 
+from databricks_cli.configure.provider import DEFAULT_SECTION
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 DEBUG_MODE = False
@@ -78,3 +79,16 @@ def truncate_string(s, length=100):
     if len(s) <= length:
         return s
     return s[:length] + '...'
+
+
+class InvalidConfigurationError(RuntimeError):
+    def __init__(self, profile=DEFAULT_SECTION):
+        if profile == DEFAULT_SECTION:
+            message = ('You haven\'t configured the CLI yet! '
+                       'Please configure by entering `{} configure`'.format(sys.argv[0]))
+        else:
+            message = ('You haven\'t configured the CLI yet for the profile {profile}! '
+                       'Please configure by entering '
+                       '`{argv} configure --profile {profile}`').format(
+                profile=profile, argv=sys.argv[0])
+        super(InvalidConfigurationError, self).__init__(message)

--- a/databricks_cli/workspace/cli.py
+++ b/databricks_cli/workspace/cli.py
@@ -28,10 +28,9 @@ from requests.exceptions import HTTPError
 
 from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS
 from databricks_cli.version import print_version_callback, version
-from databricks_cli.configure.config import require_config
+from databricks_cli.configure.config import require_config, profile_option
 from databricks_cli.dbfs.exceptions import LocalFileExistsException
-from databricks_cli.workspace.api import list_objects, mkdirs, import_workspace, export_workspace, \
-    delete, get_status
+from databricks_cli.workspace.api import WorkspaceApi
 from databricks_cli.workspace.types import LanguageClickType, FormatClickType, WorkspaceFormat, \
     WorkspaceLanguage
 
@@ -43,9 +42,10 @@ from databricks_cli.workspace.types import LanguageClickType, FormatClickType, W
 @click.option('-l', is_flag=True, default=False,
               help='Displays full information including ObjectType, Path, Language')
 @click.argument('workspace_path', type=str, nargs=-1)
+@profile_option
 @require_config
 @eat_exceptions
-def ls_cli(l, absolute, workspace_path):
+def ls_cli(api_client, l, absolute, workspace_path):
     """
     List objects in the Databricks Workspace.
     """
@@ -53,7 +53,7 @@ def ls_cli(l, absolute, workspace_path):
         workspace_path = '/'
     else:
         workspace_path = workspace_path[0]
-    objects = list_objects(workspace_path)
+    objects = WorkspaceApi(api_client).list_objects(workspace_path)
     table = tabulate([obj.to_row(is_long_form=l, is_absolute=absolute) for obj in objects],
                      tablefmt='plain')
     click.echo(table)
@@ -62,15 +62,16 @@ def ls_cli(l, absolute, workspace_path):
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Make directories in the Databricks Workspace.')
 @click.argument('workspace_path')
+@profile_option
 @require_config
 @eat_exceptions
-def mkdirs_cli(workspace_path):
+def mkdirs_cli(api_client, workspace_path):
     """
     Make directories in the Databricks Workspace.
 
     Mkdirs will create directories along the path to the argument directory.
     """
-    mkdirs(workspace_path)
+    WorkspaceApi(api_client).mkdirs(workspace_path)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
@@ -81,9 +82,10 @@ def mkdirs_cli(workspace_path):
               help=', '.join(WorkspaceLanguage.ALL))
 @click.option('--format', '-f', default=WorkspaceFormat.SOURCE, type=FormatClickType())
 @click.option('--overwrite', '-o', is_flag=True, default=False)
+@profile_option
 @require_config
 @eat_exceptions
-def import_workspace_cli(source_path, target_path, language, format, overwrite): # NOQA
+def import_workspace_cli(api_client, source_path, target_path, language, format, overwrite): # NOQA
     """
     Imports a file from local to the Databricks workspace.
 
@@ -91,7 +93,7 @@ def import_workspace_cli(source_path, target_path, language, format, overwrite):
     format is documented at
     https://docs.databricks.com/api/latest/workspace.html#notebookexportformat.
     """
-    import_workspace(source_path, target_path, language, format, overwrite) # NOQA
+    WorkspaceApi(api_client).import_workspace(source_path, target_path, language, format, overwrite) # NOQA
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
@@ -100,9 +102,10 @@ def import_workspace_cli(source_path, target_path, language, format, overwrite):
 @click.argument('target_path')
 @click.option('--format', '-f', default=WorkspaceFormat.SOURCE, type=FormatClickType())
 @click.option('--overwrite', '-o', is_flag=True, default=False)
+@profile_option
 @require_config
 @eat_exceptions
-def export_workspace_cli(source_path, target_path, format, overwrite): # NOQA
+def export_workspace_cli(api_client, source_path, target_path, format, overwrite): # NOQA
     """
     Exports a notebook from the Databricks workspace.
 
@@ -111,12 +114,12 @@ def export_workspace_cli(source_path, target_path, format, overwrite): # NOQA
     https://docs.databricks.com/api/latest/workspace.html#notebookexportformat.
     """
     if os.path.isdir(target_path):
-        file_info = get_status(source_path)
+        file_info = WorkspaceApi(api_client).get_status(source_path)
         if not file_info.is_notebook:
             raise RuntimeError('Export can only be called on a notebook.')
         extension = WorkspaceLanguage.to_extension(file_info.language)
         target_path = os.path.join(target_path, file_info.basename + extension)
-    export_workspace(source_path, target_path, format, overwrite) # NOQA
+    WorkspaceApi(api_client).export_workspace(source_path, target_path, format, overwrite) # NOQA
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
@@ -124,33 +127,34 @@ def export_workspace_cli(source_path, target_path, format, overwrite): # NOQA
                           'rm and delete are synonyms.')
 @click.argument('workspace_path')
 @click.option('--recursive', '-r', is_flag=True, default=False)
+@profile_option
 @require_config
 @eat_exceptions
-def delete_cli(workspace_path, recursive):
+def delete_cli(api_client, workspace_path, recursive):
     """
     Deletes objects from the Databricks workspace.
 
     To delete a folder add the recursive flag.
     """
-    delete(workspace_path, recursive)
+    WorkspaceApi(api_client).delete(workspace_path, recursive)
 
 
-def _export_dir_helper(source_path, target_path, overwrite):
+def _export_dir_helper(workspace_api, source_path, target_path, overwrite):
     if os.path.isfile(target_path):
         click.echo('{} exists as a file. Skipping this subtree {}'
                    .format(target_path, source_path))
         return
     if not os.path.isdir(target_path):
         os.makedirs(target_path)
-    for obj in list_objects(source_path):
+    for obj in workspace_api.list_objects(source_path):
         cur_src = obj.path
         cur_dst = os.path.join(target_path, obj.basename)
         if obj.is_dir:
-            _export_dir_helper(cur_src, cur_dst, overwrite)
+            _export_dir_helper(workspace_api, cur_src, cur_dst, overwrite)
         elif obj.is_notebook:
             cur_dst = cur_dst + WorkspaceLanguage.to_extension(obj.language)
             try:
-                export_workspace(cur_src, cur_dst, WorkspaceFormat.SOURCE, overwrite)
+                workspace_api.export_workspace(cur_src, cur_dst, WorkspaceFormat.SOURCE, overwrite)
                 click.echo('{} -> {}'.format(cur_src, cur_dst))
             except LocalFileExistsException:
                 click.echo('{} already exists locally as {}. Skip.'.format(cur_src, cur_dst))
@@ -163,9 +167,10 @@ def _export_dir_helper(source_path, target_path, overwrite):
 @click.argument('source_path')
 @click.argument('target_path')
 @click.option('--overwrite', '-o', is_flag=True, default=False)
+@profile_option
 @require_config
 @eat_exceptions
-def export_dir_cli(source_path, target_path, overwrite):
+def export_dir_cli(api_client, source_path, target_path, overwrite):
     """
     Recursively exports a directory from the Databricks workspace.
 
@@ -173,19 +178,20 @@ def export_dir_cli(source_path, target_path, overwrite):
     format. Notebooks will also have the extension of .scala, .py, .sql, or .r appended
     depending on the language type.
     """
-    assert get_status(source_path).is_dir, 'The source path must be a directory. {}' \
+    workspace_api = WorkspaceApi(api_client)
+    assert workspace_api.get_status(source_path).is_dir, 'The source path must be a directory. {}' \
         .format(source_path)
-    _export_dir_helper(source_path, target_path, overwrite)
+    _export_dir_helper(workspace_api, source_path, target_path, overwrite)
 
 
-def _import_dir_helper(source_path, target_path, overwrite, exclude_hidden_files):
+def _import_dir_helper(workspace_api, source_path, target_path, overwrite, exclude_hidden_files):
     # Try doing the os.listdir before creating the dir in Databricks.
     filenames = os.listdir(source_path)
     if exclude_hidden_files:
         # for now, just exclude hidden files or directories based on starting '.'
         filenames = [f for f in filenames if not f.startswith('.')]
     try:
-        mkdirs(target_path)
+        workspace_api.mkdirs(target_path)
     except HTTPError as e:
         click.echo(e.response.json())
         return
@@ -194,13 +200,13 @@ def _import_dir_helper(source_path, target_path, overwrite, exclude_hidden_files
         # don't use os.path.join here since it will set \ on Windows
         cur_dst = target_path.rstrip('/') + '/' + filename
         if os.path.isdir(cur_src):
-            _import_dir_helper(cur_src, cur_dst, overwrite, exclude_hidden_files)
+            _import_dir_helper(workspace_api, cur_src, cur_dst, overwrite, exclude_hidden_files)
         elif os.path.isfile(cur_src):
             ext = WorkspaceLanguage.get_extension(cur_src)
             if ext != '':
                 cur_dst = cur_dst[:-len(ext)]
                 (language, file_format) = WorkspaceLanguage.to_language_and_format(cur_src)
-                import_workspace(cur_src, cur_dst, language, file_format, overwrite)
+                workspace_api.import_workspace(cur_src, cur_dst, language, file_format, overwrite)
                 click.echo('{} -> {}'.format(cur_src, cur_dst))
             else:
                 extensions = ', '.join(WorkspaceLanguage.EXTENSIONS)
@@ -214,16 +220,18 @@ def _import_dir_helper(source_path, target_path, overwrite, exclude_hidden_files
 @click.argument('target_path')
 @click.option('--overwrite', '-o', is_flag=True, default=False)
 @click.option('--exclude-hidden-files', '-e', is_flag=True, default=False)
+@profile_option
 @require_config
 @eat_exceptions
-def import_dir_cli(source_path, target_path, overwrite, exclude_hidden_files):
+def import_dir_cli(api_client, source_path, target_path, overwrite, exclude_hidden_files):
     """
     Recursively imports a directory from local to the Databricks workspace.
 
     Only directories and files with the extensions .scala, .py, .sql, .r, .R, .ipynb are imported.
     When imported, these extensions will be stripped off the name of the notebook.
     """
-    _import_dir_helper(source_path, target_path, overwrite, exclude_hidden_files)
+    _import_dir_helper(WorkspaceApi(api_client), source_path, target_path, overwrite,
+                       exclude_hidden_files)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS,

--- a/databricks_cli/workspace/cli.py
+++ b/databricks_cli/workspace/cli.py
@@ -28,7 +28,7 @@ from requests.exceptions import HTTPError
 
 from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS
 from databricks_cli.version import print_version_callback, version
-from databricks_cli.configure.config import require_config, profile_option
+from databricks_cli.configure.config import provide_api_client, profile_option
 from databricks_cli.dbfs.exceptions import LocalFileExistsException
 from databricks_cli.workspace.api import WorkspaceApi
 from databricks_cli.workspace.types import LanguageClickType, FormatClickType, WorkspaceFormat, \
@@ -43,8 +43,8 @@ from databricks_cli.workspace.types import LanguageClickType, FormatClickType, W
               help='Displays full information including ObjectType, Path, Language')
 @click.argument('workspace_path', type=str, nargs=-1)
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def ls_cli(api_client, l, absolute, workspace_path):
     """
     List objects in the Databricks Workspace.
@@ -63,8 +63,8 @@ def ls_cli(api_client, l, absolute, workspace_path):
                short_help='Make directories in the Databricks Workspace.')
 @click.argument('workspace_path')
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def mkdirs_cli(api_client, workspace_path):
     """
     Make directories in the Databricks Workspace.
@@ -83,8 +83,8 @@ def mkdirs_cli(api_client, workspace_path):
 @click.option('--format', '-f', default=WorkspaceFormat.SOURCE, type=FormatClickType())
 @click.option('--overwrite', '-o', is_flag=True, default=False)
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def import_workspace_cli(api_client, source_path, target_path, language, format, overwrite): # NOQA
     """
     Imports a file from local to the Databricks workspace.
@@ -103,8 +103,8 @@ def import_workspace_cli(api_client, source_path, target_path, language, format,
 @click.option('--format', '-f', default=WorkspaceFormat.SOURCE, type=FormatClickType())
 @click.option('--overwrite', '-o', is_flag=True, default=False)
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def export_workspace_cli(api_client, source_path, target_path, format, overwrite): # NOQA
     """
     Exports a notebook from the Databricks workspace.
@@ -128,8 +128,8 @@ def export_workspace_cli(api_client, source_path, target_path, format, overwrite
 @click.argument('workspace_path')
 @click.option('--recursive', '-r', is_flag=True, default=False)
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def delete_cli(api_client, workspace_path, recursive):
     """
     Deletes objects from the Databricks workspace.
@@ -168,8 +168,8 @@ def _export_dir_helper(workspace_api, source_path, target_path, overwrite):
 @click.argument('target_path')
 @click.option('--overwrite', '-o', is_flag=True, default=False)
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def export_dir_cli(api_client, source_path, target_path, overwrite):
     """
     Recursively exports a directory from the Databricks workspace.
@@ -221,8 +221,8 @@ def _import_dir_helper(workspace_api, source_path, target_path, overwrite, exclu
 @click.option('--overwrite', '-o', is_flag=True, default=False)
 @click.option('--exclude-hidden-files', '-e', is_flag=True, default=False)
 @profile_option
-@require_config
 @eat_exceptions
+@provide_api_client
 def import_dir_cli(api_client, source_path, target_path, overwrite, exclude_hidden_files):
     """
     Recursively imports a directory from local to the Databricks workspace.

--- a/prospector.yaml
+++ b/prospector.yaml
@@ -17,6 +17,7 @@ pylint:
     - no-else-return
     - no-self-use
     - protected-access
+    - too-many-arguments
 
 mccabe:
   disable:

--- a/tests/configure/test_config.py
+++ b/tests/configure/test_config.py
@@ -24,9 +24,11 @@
 # pylint:disable=protected-access
 
 import mock
+import pytest
 
 import databricks_cli.configure.config as config
 from databricks_cli.configure.provider import DatabricksConfig, DEFAULT_SECTION
+from databricks_cli.utils import InvalidConfigurationError
 
 
 def test_require_config_valid():
@@ -35,7 +37,7 @@ def test_require_config_valid():
         get_config_for_profile_mock.return_value = DatabricksConfig(
             'test-host', None, None, 'test-token')
 
-        @config.require_config
+        @config.provide_api_client
         def test_function(api_client, x): # noqa
             return x
 
@@ -50,11 +52,9 @@ def test_require_config_invalid():
                     get_api_client_mock: # noqa
                 get_config_for_profile_mock.return_value = DatabricksConfig(None, None, None, None)
 
-                @config.require_config
+                @config.provide_api_client
                 def test_function(api_client, x): # noqa
                     return x
 
-                test_function(x=1, profile=DEFAULT_SECTION) # noqa
-
-                assert error_and_quit_mock.call_count == 1
-                assert 'You haven\'t configured the CLI' in error_and_quit_mock.call_args[0][0]
+                with pytest.raises(InvalidConfigurationError):
+                    test_function(x=1, profile=DEFAULT_SECTION) # noqa

--- a/tests/configure/test_config.py
+++ b/tests/configure/test_config.py
@@ -26,7 +26,7 @@
 import mock
 
 import databricks_cli.configure.config as config
-from databricks_cli.configure.provider import DatabricksConfig
+from databricks_cli.configure.provider import DatabricksConfig, DEFAULT_SECTION
 
 
 def test_require_config_valid():
@@ -36,23 +36,25 @@ def test_require_config_valid():
             'test-host', None, None, 'test-token')
 
         @config.require_config
-        def test_function(x):
+        def test_function(api_client, x): # noqa
             return x
 
-        assert test_function(1) == 1
+        assert test_function(x=1, profile=DEFAULT_SECTION) == 1 # noqa
 
 
 def test_require_config_invalid():
     with mock.patch('databricks_cli.configure.config.error_and_quit') as error_and_quit_mock:
         with mock.patch('databricks_cli.configure.config.get_config_for_profile') as \
                 get_config_for_profile_mock:
-            get_config_for_profile_mock.return_value = DatabricksConfig(None, None, None, None)
+            with mock.patch('databricks_cli.configure.config._get_api_client') as \
+                    get_api_client_mock: # noqa
+                get_config_for_profile_mock.return_value = DatabricksConfig(None, None, None, None)
 
-            @config.require_config
-            def test_function(x):
-                return x
+                @config.require_config
+                def test_function(api_client, x): # noqa
+                    return x
 
-            test_function(1)
+                test_function(x=1, profile=DEFAULT_SECTION) # noqa
 
-            assert error_and_quit_mock.call_count == 1
-            assert 'You haven\'t configured the CLI' in error_and_quit_mock.call_args[0][0]
+                assert error_and_quit_mock.call_count == 1
+                assert 'You haven\'t configured the CLI' in error_and_quit_mock.call_args[0][0]

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -69,15 +69,20 @@ def test_update_and_persist_config_two_sections():
     assert config.password == TEST_PASSWORD
 
 
-def test_update_and_persist_config_case_insensitive():
+def test_update_and_persist_config_case_sensitive():
     config = DatabricksConfig.from_token(TEST_HOST, TEST_TOKEN)
     update_and_persist_config(TEST_PROFILE, config)
-    config = DatabricksConfig.from_password(TEST_HOST, TEST_USER, TEST_PASSWORD)
-    update_and_persist_config(TEST_PROFILE.upper(), config)
+
+    config_2 = DatabricksConfig.from_password(TEST_HOST, TEST_USER, TEST_PASSWORD)
+    update_and_persist_config(TEST_PROFILE.upper(), config_2)
 
     config = get_config_for_profile(TEST_PROFILE)
-    assert config.is_valid_with_password
-    assert not config.is_valid_with_token
+    assert config.is_valid_with_token
+    assert not config.is_valid_with_password
+
+    config_2 = get_config_for_profile(TEST_PROFILE.upper())
+    assert config_2.is_valid_with_password
+    assert not config_2.is_valid_with_token
 
 
 def test_get_config_for_profile_empty():

--- a/tests/jobs/test_cli.py
+++ b/tests/jobs/test_cli.py
@@ -21,8 +21,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint:disable=redefined-outer-name
+
 import json
 import mock
+import pytest
 from tabulate import tabulate
 from click.testing import CliRunner
 
@@ -34,43 +37,48 @@ CREATE_RETURN = {'job_id': 5}
 CREATE_JSON = '{"name": "test_job"}'
 
 
-@provide_conf
-def test_create_cli_json():
-    with mock.patch('databricks_cli.jobs.cli.create_job') as create_job_mock:
-        with mock.patch('databricks_cli.jobs.cli.click.echo') as echo_mock:
-            create_job_mock.return_value = CREATE_RETURN
-            runner = CliRunner()
-            runner.invoke(cli.create_cli, ['--json', CREATE_JSON])
-            assert create_job_mock.call_args[0][0] == json.loads(CREATE_JSON)
-            assert echo_mock.call_args[0][0] == pretty_format(CREATE_RETURN)
+@pytest.fixture()
+def jobs_api_mock():
+    with mock.patch('databricks_cli.jobs.cli.JobsApi') as JobsApiMock:
+        _jobs_api_mock = mock.MagicMock()
+        JobsApiMock.return_value = _jobs_api_mock
+        yield _jobs_api_mock
 
 
 @provide_conf
-def test_create_cli_json_file(tmpdir):
+def test_create_cli_json(jobs_api_mock):
+    with mock.patch('databricks_cli.jobs.cli.click.echo') as echo_mock:
+        jobs_api_mock.create_job.return_value = CREATE_RETURN
+        runner = CliRunner()
+        runner.invoke(cli.create_cli, ['--json', CREATE_JSON])
+        assert jobs_api_mock.create_job.call_args[0][0] == json.loads(CREATE_JSON)
+        assert echo_mock.call_args[0][0] == pretty_format(CREATE_RETURN)
+
+
+@provide_conf
+def test_create_cli_json_file(jobs_api_mock, tmpdir):
     path = tmpdir.join('job.json').strpath
     with open(path, 'w') as f:
         f.write(CREATE_JSON)
-    with mock.patch('databricks_cli.jobs.cli.create_job') as create_job_mock:
-        with mock.patch('databricks_cli.jobs.cli.click.echo') as echo_mock:
-            create_job_mock.return_value = CREATE_RETURN
-            runner = CliRunner()
-            runner.invoke(cli.create_cli, ['--json-file', path])
-            assert create_job_mock.call_args[0][0] == json.loads(CREATE_JSON)
-            assert echo_mock.call_args[0][0] == pretty_format(CREATE_RETURN)
+    with mock.patch('databricks_cli.jobs.cli.click.echo') as echo_mock:
+        jobs_api_mock.create_job.return_value = CREATE_RETURN
+        runner = CliRunner()
+        runner.invoke(cli.create_cli, ['--json-file', path])
+        assert jobs_api_mock.create_job.call_args[0][0] == json.loads(CREATE_JSON)
+        assert echo_mock.call_args[0][0] == pretty_format(CREATE_RETURN)
 
 
 RESET_JSON = '{"job_name": "test_job"}'
 
 
 @provide_conf
-def test_reset_cli_json():
-    with mock.patch('databricks_cli.jobs.cli.reset_job') as reset_job_mock:
-        runner = CliRunner()
-        runner.invoke(cli.reset_cli, ['--json', RESET_JSON, '--job-id', 1])
-        assert reset_job_mock.call_args[0][0] == {
-            'job_id': 1,
-            'new_settings': json.loads(RESET_JSON)
-        }
+def test_reset_cli_json(jobs_api_mock):
+    runner = CliRunner()
+    runner.invoke(cli.reset_cli, ['--json', RESET_JSON, '--job-id', 1])
+    assert jobs_api_mock.reset_job.call_args[0][0] == {
+        'job_id': 1,
+        'new_settings': json.loads(RESET_JSON)
+    }
 
 
 LIST_RETURN = {
@@ -95,26 +103,24 @@ LIST_RETURN = {
 
 
 @provide_conf
-def test_list_jobs():
-    with mock.patch('databricks_cli.jobs.cli.list_jobs') as list_jobs_mock:
-        with mock.patch('databricks_cli.jobs.cli.click.echo') as echo_mock:
-            list_jobs_mock.return_value = LIST_RETURN
-            runner = CliRunner()
-            runner.invoke(cli.list_cli)
-            # Output should be sorted here.
-            rows = [(2, 'a'), (1, 'b'), (30, 'C')]
-            assert echo_mock.call_args[0][0] == \
-                tabulate(rows, tablefmt='plain', disable_numparse=True)
+def test_list_jobs(jobs_api_mock):
+    with mock.patch('databricks_cli.jobs.cli.click.echo') as echo_mock:
+        jobs_api_mock.list_jobs.return_value = LIST_RETURN
+        runner = CliRunner()
+        runner.invoke(cli.list_cli)
+        # Output should be sorted here.
+        rows = [(2, 'a'), (1, 'b'), (30, 'C')]
+        assert echo_mock.call_args[0][0] == \
+            tabulate(rows, tablefmt='plain', disable_numparse=True)
 
 
 @provide_conf
-def test_list_jobs_output_json():
-    with mock.patch('databricks_cli.jobs.cli.list_jobs') as list_jobs_mock:
-        with mock.patch('databricks_cli.jobs.cli.click.echo') as echo_mock:
-            list_jobs_mock.return_value = LIST_RETURN
-            runner = CliRunner()
-            runner.invoke(cli.list_cli, ['--output', 'json'])
-            assert echo_mock.call_args[0][0] == pretty_format(LIST_RETURN)
+def test_list_jobs_output_json(jobs_api_mock):
+    with mock.patch('databricks_cli.jobs.cli.click.echo') as echo_mock:
+        jobs_api_mock.list_jobs.return_value = LIST_RETURN
+        runner = CliRunner()
+        runner.invoke(cli.list_cli, ['--output', 'json'])
+        assert echo_mock.call_args[0][0] == pretty_format(LIST_RETURN)
 
 
 RUN_NOW_RETURN = {
@@ -128,34 +134,32 @@ SPARK_SUBMIT_PARAMS = '["--class", "org.apache.spark.examples.SparkPi"]'
 
 
 @provide_conf
-def test_run_now_no_params():
-    with mock.patch('databricks_cli.jobs.cli.run_now') as run_now_mock:
-        with mock.patch('databricks_cli.jobs.cli.click.echo') as echo_mock:
-            run_now_mock.return_value = RUN_NOW_RETURN
-            runner = CliRunner()
-            runner.invoke(cli.run_now_cli, ['--job-id', 1])
-            assert run_now_mock.call_args[0][0] == 1
-            assert run_now_mock.call_args[0][1] is None
-            assert run_now_mock.call_args[0][2] is None
-            assert run_now_mock.call_args[0][3] is None
-            assert run_now_mock.call_args[0][4] is None
-            assert echo_mock.call_args[0][0] == pretty_format(RUN_NOW_RETURN)
+def test_run_now_no_params(jobs_api_mock):
+    with mock.patch('databricks_cli.jobs.cli.click.echo') as echo_mock:
+        jobs_api_mock.run_now.return_value = RUN_NOW_RETURN
+        runner = CliRunner()
+        runner.invoke(cli.run_now_cli, ['--job-id', 1])
+        assert jobs_api_mock.run_now.call_args[0][0] == 1
+        assert jobs_api_mock.run_now.call_args[0][1] is None
+        assert jobs_api_mock.run_now.call_args[0][2] is None
+        assert jobs_api_mock.run_now.call_args[0][3] is None
+        assert jobs_api_mock.run_now.call_args[0][4] is None
+        assert echo_mock.call_args[0][0] == pretty_format(RUN_NOW_RETURN)
 
 
 @provide_conf
-def test_run_now_with_params():
-    with mock.patch('databricks_cli.jobs.cli.run_now') as run_now_mock:
-        with mock.patch('databricks_cli.jobs.cli.click.echo') as echo_mock:
-            run_now_mock.return_value = RUN_NOW_RETURN
-            runner = CliRunner()
-            runner.invoke(cli.run_now_cli, ['--job-id', 1,
-                                            '--jar-params', JAR_PARAMS,
-                                            '--notebook-params', NOTEBOOK_PARAMS,
-                                            '--python-params', PYTHON_PARAMS,
-                                            '--spark-submit-params', SPARK_SUBMIT_PARAMS])
-            assert run_now_mock.call_args[0][0] == 1
-            assert run_now_mock.call_args[0][1] == json.loads(JAR_PARAMS)
-            assert run_now_mock.call_args[0][2] == json.loads(NOTEBOOK_PARAMS)
-            assert run_now_mock.call_args[0][3] == json.loads(PYTHON_PARAMS)
-            assert run_now_mock.call_args[0][4] == json.loads(SPARK_SUBMIT_PARAMS)
-            assert echo_mock.call_args[0][0] == pretty_format(RUN_NOW_RETURN)
+def test_run_now_with_params(jobs_api_mock):
+    with mock.patch('databricks_cli.jobs.cli.click.echo') as echo_mock:
+        jobs_api_mock.run_now.return_value = RUN_NOW_RETURN
+        runner = CliRunner()
+        runner.invoke(cli.run_now_cli, ['--job-id', 1,
+                                        '--jar-params', JAR_PARAMS,
+                                        '--notebook-params', NOTEBOOK_PARAMS,
+                                        '--python-params', PYTHON_PARAMS,
+                                        '--spark-submit-params', SPARK_SUBMIT_PARAMS])
+        assert jobs_api_mock.run_now.call_args[0][0] == 1
+        assert jobs_api_mock.run_now.call_args[0][1] == json.loads(JAR_PARAMS)
+        assert jobs_api_mock.run_now.call_args[0][2] == json.loads(NOTEBOOK_PARAMS)
+        assert jobs_api_mock.run_now.call_args[0][3] == json.loads(PYTHON_PARAMS)
+        assert jobs_api_mock.run_now.call_args[0][4] == json.loads(SPARK_SUBMIT_PARAMS)
+        assert echo_mock.call_args[0][0] == pretty_format(RUN_NOW_RETURN)

--- a/tests/libraries/test_cli.py
+++ b/tests/libraries/test_cli.py
@@ -20,8 +20,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# pylint:disable=redefined-outer-name
+
 import itertools
 import mock
+import pytest
 from click.testing import CliRunner
 
 import databricks_cli.libraries.cli as cli
@@ -43,26 +47,30 @@ ALL_CLUSTER_STATUSES_RETURN = {
 }
 
 
-@provide_conf
-def test_all_cluster_statuses_cli():
-    with mock.patch('databricks_cli.libraries.cli.all_cluster_statuses') as \
-            all_cluster_statuses_mock:
-        all_cluster_statuses_mock.return_value = ALL_CLUSTER_STATUSES_RETURN
-        runner = CliRunner()
-        res = runner.invoke(cli.all_cluster_statuses_cli)
-        all_cluster_statuses_mock.assert_called_once()
-        assert_cli_output(res.output, pretty_format(ALL_CLUSTER_STATUSES_RETURN))
+@pytest.fixture()
+def libraries_api_mock():
+    with mock.patch('databricks_cli.libraries.cli.LibrariesApi') as LibrariesApi:
+        _libraries_api_mock = mock.MagicMock()
+        LibrariesApi.return_value = _libraries_api_mock
+        yield _libraries_api_mock
 
 
 @provide_conf
-def test_list_cli_without_cluster_id():
-    with mock.patch('databricks_cli.libraries.cli.all_cluster_statuses') as \
-            all_cluster_statuses_mock:
-        all_cluster_statuses_mock.return_value = ALL_CLUSTER_STATUSES_RETURN
-        runner = CliRunner()
-        res = runner.invoke(cli.list_cli)
-        all_cluster_statuses_mock.assert_called_once()
-        assert_cli_output(res.output, pretty_format(ALL_CLUSTER_STATUSES_RETURN))
+def test_all_cluster_statuses_cli(libraries_api_mock):
+    libraries_api_mock.all_cluster_statuses.return_value = ALL_CLUSTER_STATUSES_RETURN
+    runner = CliRunner()
+    res = runner.invoke(cli.all_cluster_statuses_cli)
+    libraries_api_mock.all_cluster_statuses.assert_called_once()
+    assert_cli_output(res.output, pretty_format(ALL_CLUSTER_STATUSES_RETURN))
+
+
+@provide_conf
+def test_list_cli_without_cluster_id(libraries_api_mock):
+    libraries_api_mock.all_cluster_statuses.return_value = ALL_CLUSTER_STATUSES_RETURN
+    runner = CliRunner()
+    res = runner.invoke(cli.list_cli)
+    libraries_api_mock.all_cluster_statuses.assert_called_once()
+    assert_cli_output(res.output, pretty_format(ALL_CLUSTER_STATUSES_RETURN))
 
 
 CLUSTER_STATUS_RETURN = {
@@ -78,263 +86,244 @@ CLUSTER_STATUS_RETURN = {
 
 
 @provide_conf
-def test_cluster_status_cli():
-    with mock.patch('databricks_cli.libraries.cli.cluster_status') as cluster_status_mock:
-        cluster_status_mock.return_value = CLUSTER_STATUS_RETURN
-        runner = CliRunner()
-        res = runner.invoke(cli.cluster_status_cli, ['--cluster-id', TEST_CLUSTER_ID])
-        cluster_status_mock.assert_called_with(TEST_CLUSTER_ID)
-        assert_cli_output(res.output, pretty_format(CLUSTER_STATUS_RETURN))
+def test_cluster_status_cli(libraries_api_mock):
+    libraries_api_mock.cluster_status.return_value = CLUSTER_STATUS_RETURN
+    runner = CliRunner()
+    res = runner.invoke(cli.cluster_status_cli, ['--cluster-id', TEST_CLUSTER_ID])
+    libraries_api_mock.cluster_status.assert_called_with(TEST_CLUSTER_ID)
+    assert_cli_output(res.output, pretty_format(CLUSTER_STATUS_RETURN))
 
 
 @provide_conf
-def test_list_cli_with_cluster_id():
-    with mock.patch('databricks_cli.libraries.cli.cluster_status') as cluster_status_mock:
-        cluster_status_mock.return_value = CLUSTER_STATUS_RETURN
-        runner = CliRunner()
-        res = runner.invoke(cli.list_cli, ['--cluster-id', TEST_CLUSTER_ID])
-        cluster_status_mock.assert_called_with(TEST_CLUSTER_ID)
-        assert_cli_output(res.output, pretty_format(CLUSTER_STATUS_RETURN))
+def test_list_cli_with_cluster_id(libraries_api_mock):
+    libraries_api_mock.cluster_status.return_value = CLUSTER_STATUS_RETURN
+    runner = CliRunner()
+    res = runner.invoke(cli.list_cli, ['--cluster-id', TEST_CLUSTER_ID])
+    libraries_api_mock.cluster_status.assert_called_with(TEST_CLUSTER_ID)
+    assert_cli_output(res.output, pretty_format(CLUSTER_STATUS_RETURN))
 
 
 @provide_conf
-def test_install_cli_with_multiple_oneof():
+def test_install_cli_with_multiple_oneof(libraries_api_mock):
     for lib_a, lib_b in itertools.combinations(cli.INSTALL_OPTIONS, 2):
-        with mock.patch('databricks_cli.libraries.cli.install_libraries') as install_libraries_mock:
-            runner = CliRunner()
-            res = runner.invoke(cli.install_cli, [
-                '--cluster-id', TEST_CLUSTER_ID,
-                '--{}'.format(lib_a), 'test_a',
-                '--{}'.format(lib_b), 'test_b'])
-            install_libraries_mock.assert_not_called()
+        runner = CliRunner()
+        res = runner.invoke(cli.install_cli, [
+            '--cluster-id', TEST_CLUSTER_ID,
+            '--{}'.format(lib_a), 'test_a',
+            '--{}'.format(lib_b), 'test_b'])
+        libraries_api_mock.install_libraries.assert_not_called()
 
-            assert 'Only one of {} should be provided'.format(cli.INSTALL_OPTIONS) in res.output
+        assert 'Only one of {} should be provided'.format(cli.INSTALL_OPTIONS) in res.output
 
 
 @provide_conf
-def test_install_cli_jar():
+def test_install_cli_jar(libraries_api_mock):
     test_jar = 'dbfs:/test.jar'
-    with mock.patch('databricks_cli.libraries.cli.install_libraries') as install_libraries_mock:
-        runner = CliRunner()
-        runner.invoke(cli.install_cli, [
-            '--cluster-id', TEST_CLUSTER_ID,
-            '--jar', test_jar])
-        install_libraries_mock.assert_called_with(TEST_CLUSTER_ID, [{'jar': test_jar}])
+    runner = CliRunner()
+    runner.invoke(cli.install_cli, [
+        '--cluster-id', TEST_CLUSTER_ID,
+        '--jar', test_jar])
+    libraries_api_mock.install_libraries.assert_called_with(TEST_CLUSTER_ID, [{'jar': test_jar}])
 
 
 @provide_conf
-def test_install_cli_egg():
+def test_install_cli_egg(libraries_api_mock):
     test_egg = 'dbfs:/test.egg'
-    with mock.patch('databricks_cli.libraries.cli.install_libraries') as install_libraries_mock:
-        runner = CliRunner()
-        runner.invoke(cli.install_cli, [
-            '--cluster-id', TEST_CLUSTER_ID,
-            '--egg', test_egg])
-        install_libraries_mock.assert_called_with(TEST_CLUSTER_ID, [{'egg': test_egg}])
+    runner = CliRunner()
+    runner.invoke(cli.install_cli, [
+        '--cluster-id', TEST_CLUSTER_ID,
+        '--egg', test_egg])
+    libraries_api_mock.install_libraries.assert_called_with(TEST_CLUSTER_ID, [{'egg': test_egg}])
 
 
 @provide_conf
-def test_install_cli_maven():
+def test_install_cli_maven(libraries_api_mock):
     test_maven_coordinates = 'org.jsoup:jsoup:1.7.2'
     test_maven_repo = 'https://maven.databricks.com'
     test_maven_exclusions = ['a', 'b']
     # Coordinates
-    with mock.patch('databricks_cli.libraries.cli.install_libraries') as install_libraries_mock:
-        runner = CliRunner()
-        runner.invoke(cli.install_cli, [
-            '--cluster-id', TEST_CLUSTER_ID,
-            '--maven-coordinates', test_maven_coordinates])
-        install_libraries_mock.assert_called_with(TEST_CLUSTER_ID, [{
-            'maven': {
-                'coordinates': test_maven_coordinates
-            }
-        }])
+    runner = CliRunner()
+    runner.invoke(cli.install_cli, [
+        '--cluster-id', TEST_CLUSTER_ID,
+        '--maven-coordinates', test_maven_coordinates])
+    libraries_api_mock.install_libraries.assert_called_with(TEST_CLUSTER_ID, [{
+        'maven': {
+            'coordinates': test_maven_coordinates
+        }
+    }])
     # Coordinates, Repo
-    with mock.patch('databricks_cli.libraries.cli.install_libraries') as install_libraries_mock:
-        runner = CliRunner()
-        runner.invoke(cli.install_cli, [
-            '--cluster-id', TEST_CLUSTER_ID,
-            '--maven-coordinates', test_maven_coordinates,
-            '--maven-repo', test_maven_repo])
-        install_libraries_mock.assert_called_with(TEST_CLUSTER_ID, [{
-            'maven': {
-                'coordinates': test_maven_coordinates,
-                'repo': test_maven_repo
-            }
-        }])
+    runner = CliRunner()
+    runner.invoke(cli.install_cli, [
+        '--cluster-id', TEST_CLUSTER_ID,
+        '--maven-coordinates', test_maven_coordinates,
+        '--maven-repo', test_maven_repo])
+    libraries_api_mock.install_libraries.assert_called_with(TEST_CLUSTER_ID, [{
+        'maven': {
+            'coordinates': test_maven_coordinates,
+            'repo': test_maven_repo
+        }
+    }])
     # Coordinates, Repo, Exclusions
-    with mock.patch('databricks_cli.libraries.cli.install_libraries') as install_libraries_mock:
-        runner = CliRunner()
-        runner.invoke(cli.install_cli, [
-            '--cluster-id', TEST_CLUSTER_ID,
-            '--maven-coordinates', test_maven_coordinates,
-            '--maven-repo', test_maven_repo,
-            '--maven-exclusion', test_maven_exclusions[0],
-            '--maven-exclusion', test_maven_exclusions[1]])
-        install_libraries_mock.assert_called_with(TEST_CLUSTER_ID, [{
-            'maven': {
-                'coordinates': test_maven_coordinates,
-                'repo': test_maven_repo,
-                'exclusions': test_maven_exclusions
-            }
-        }])
+    runner = CliRunner()
+    runner.invoke(cli.install_cli, [
+        '--cluster-id', TEST_CLUSTER_ID,
+        '--maven-coordinates', test_maven_coordinates,
+        '--maven-repo', test_maven_repo,
+        '--maven-exclusion', test_maven_exclusions[0],
+        '--maven-exclusion', test_maven_exclusions[1]])
+    libraries_api_mock.install_libraries.assert_called_with(TEST_CLUSTER_ID, [{
+        'maven': {
+            'coordinates': test_maven_coordinates,
+            'repo': test_maven_repo,
+            'exclusions': test_maven_exclusions
+        }
+    }])
 
 
 @provide_conf
-def test_install_cli_pypi():
+def test_install_cli_pypi(libraries_api_mock):
     test_pypi_package = 'databricks-cli'
     test_pypi_repo = 'https://pypi.databricks.com'
     # Coordinates
-    with mock.patch('databricks_cli.libraries.cli.install_libraries') as install_libraries_mock:
-        runner = CliRunner()
-        runner.invoke(cli.install_cli, [
-            '--cluster-id', TEST_CLUSTER_ID,
-            '--pypi-package', test_pypi_package,
-            '--pypi-repo', test_pypi_repo])
-        install_libraries_mock.assert_called_with(TEST_CLUSTER_ID, [{
-            'pypi': {
-                'package': test_pypi_package,
-                'repo': test_pypi_repo
-            }
-        }])
+    runner = CliRunner()
+    runner.invoke(cli.install_cli, [
+        '--cluster-id', TEST_CLUSTER_ID,
+        '--pypi-package', test_pypi_package,
+        '--pypi-repo', test_pypi_repo])
+    libraries_api_mock.install_libraries.assert_called_with(TEST_CLUSTER_ID, [{
+        'pypi': {
+            'package': test_pypi_package,
+            'repo': test_pypi_repo
+        }
+    }])
 
 
 @provide_conf
-def test_install_cli_cran():
+def test_install_cli_cran(libraries_api_mock):
     test_cran_package = 'cran-package'
     test_cran_repo = 'https://cran.databricks.com'
     # Coordinates
-    with mock.patch('databricks_cli.libraries.cli.install_libraries') as install_libraries_mock:
-        runner = CliRunner()
-        runner.invoke(cli.install_cli, [
-            '--cluster-id', TEST_CLUSTER_ID,
-            '--cran-package', test_cran_package,
-            '--cran-repo', test_cran_repo])
-        install_libraries_mock.assert_called_with(TEST_CLUSTER_ID, [{
-            'cran': {
-                'package': test_cran_package,
-                'repo': test_cran_repo
-            }
-        }])
+    runner = CliRunner()
+    runner.invoke(cli.install_cli, [
+        '--cluster-id', TEST_CLUSTER_ID,
+        '--cran-package', test_cran_package,
+        '--cran-repo', test_cran_repo])
+    libraries_api_mock.install_libraries.assert_called_with(TEST_CLUSTER_ID, [{
+        'cran': {
+            'package': test_cran_package,
+            'repo': test_cran_repo
+        }
+    }])
 
 
 @provide_conf
-def test_uninstall_cli_with_multiple_oneof():
+def test_uninstall_cli_with_multiple_oneof(libraries_api_mock):
     for lib_a, lib_b in itertools.combinations(cli.INSTALL_OPTIONS, 2):
-        with mock.patch('databricks_cli.libraries.cli.uninstall_libraries') as \
-                uninstall_libraries_mock:
-            runner = CliRunner()
-            res = runner.invoke(cli.uninstall_cli, [
-                '--cluster-id', TEST_CLUSTER_ID,
-                '--{}'.format(lib_a), 'test_a',
-                '--{}'.format(lib_b), 'test_b'])
-            uninstall_libraries_mock.assert_not_called()
+        runner = CliRunner()
+        res = runner.invoke(cli.uninstall_cli, [
+            '--cluster-id', TEST_CLUSTER_ID,
+            '--{}'.format(lib_a), 'test_a',
+            '--{}'.format(lib_b), 'test_b'])
+        libraries_api_mock.uninstall_libraries.assert_not_called()
 
-            assert 'Only one of {} should be provided'.format(cli.INSTALL_OPTIONS) in res.output
+        assert 'Only one of {} should be provided'.format(cli.INSTALL_OPTIONS) in res.output
 
 
 @provide_conf
-def test_uninstall_cli_jar():
+def test_uninstall_cli_jar(libraries_api_mock):
     test_jar = 'dbfs:/test.jar'
-    with mock.patch('databricks_cli.libraries.cli.uninstall_libraries') as uninstall_libraries_mock:
-        runner = CliRunner()
-        runner.invoke(cli.uninstall_cli, [
-            '--cluster-id', TEST_CLUSTER_ID,
-            '--jar', test_jar])
-        uninstall_libraries_mock.assert_called_with(TEST_CLUSTER_ID, [{'jar': test_jar}])
+    runner = CliRunner()
+    runner.invoke(cli.uninstall_cli, [
+        '--cluster-id', TEST_CLUSTER_ID,
+        '--jar', test_jar])
+    libraries_api_mock.uninstall_libraries.assert_called_with(TEST_CLUSTER_ID, [{'jar': test_jar}])
 
 
 @provide_conf
-def test_uninstall_cli_egg():
+def test_uninstall_cli_egg(libraries_api_mock):
     test_egg = 'dbfs:/test.egg'
-    with mock.patch('databricks_cli.libraries.cli.uninstall_libraries') as uninstall_libraries_mock:
-        runner = CliRunner()
-        runner.invoke(cli.uninstall_cli, [
-            '--cluster-id', TEST_CLUSTER_ID,
-            '--egg', test_egg])
-        uninstall_libraries_mock.assert_called_with(TEST_CLUSTER_ID, [{'egg': test_egg}])
+    runner = CliRunner()
+    runner.invoke(cli.uninstall_cli, [
+        '--cluster-id', TEST_CLUSTER_ID,
+        '--egg', test_egg])
+    libraries_api_mock.uninstall_libraries.assert_called_with(TEST_CLUSTER_ID, [{'egg': test_egg}])
 
 
 @provide_conf
-def test_uninstall_cli_maven():
+def test_uninstall_cli_maven(libraries_api_mock):
     test_maven_coordinates = 'org.jsoup:jsoup:1.7.2'
     test_maven_repo = 'https://maven.databricks.com'
     test_maven_exclusions = ['a', 'b']
     # Coordinates
-    with mock.patch('databricks_cli.libraries.cli.uninstall_libraries') as uninstall_libraries_mock:
-        runner = CliRunner()
-        runner.invoke(cli.uninstall_cli, [
-            '--cluster-id', TEST_CLUSTER_ID,
-            '--maven-coordinates', test_maven_coordinates])
-        uninstall_libraries_mock.assert_called_with(TEST_CLUSTER_ID, [{
-            'maven': {
-                'coordinates': test_maven_coordinates
-            }
-        }])
+    runner = CliRunner()
+    runner.invoke(cli.uninstall_cli, [
+        '--cluster-id', TEST_CLUSTER_ID,
+        '--maven-coordinates', test_maven_coordinates])
+    libraries_api_mock.uninstall_libraries.assert_called_with(TEST_CLUSTER_ID, [{
+        'maven': {
+            'coordinates': test_maven_coordinates
+        }
+    }])
     # Coordinates, Repo
-    with mock.patch('databricks_cli.libraries.cli.uninstall_libraries') as uninstall_libraries_mock:
-        runner = CliRunner()
-        runner.invoke(cli.uninstall_cli, [
-            '--cluster-id', TEST_CLUSTER_ID,
-            '--maven-coordinates', test_maven_coordinates,
-            '--maven-repo', test_maven_repo])
-        uninstall_libraries_mock.assert_called_with(TEST_CLUSTER_ID, [{
-            'maven': {
-                'coordinates': test_maven_coordinates,
-                'repo': test_maven_repo
-            }
-        }])
+    runner = CliRunner()
+    runner.invoke(cli.uninstall_cli, [
+        '--cluster-id', TEST_CLUSTER_ID,
+        '--maven-coordinates', test_maven_coordinates,
+        '--maven-repo', test_maven_repo])
+    libraries_api_mock.uninstall_libraries.assert_called_with(TEST_CLUSTER_ID, [{
+        'maven': {
+            'coordinates': test_maven_coordinates,
+            'repo': test_maven_repo
+        }
+    }])
     # Coordinates, Repo, Exclusions
-    with mock.patch('databricks_cli.libraries.cli.uninstall_libraries') as uninstall_libraries_mock:
-        runner = CliRunner()
-        runner.invoke(cli.uninstall_cli, [
-            '--cluster-id', TEST_CLUSTER_ID,
-            '--maven-coordinates', test_maven_coordinates,
-            '--maven-repo', test_maven_repo,
-            '--maven-exclusion', test_maven_exclusions[0],
-            '--maven-exclusion', test_maven_exclusions[1]])
-        uninstall_libraries_mock.assert_called_with(TEST_CLUSTER_ID, [{
-            'maven': {
-                'coordinates': test_maven_coordinates,
-                'repo': test_maven_repo,
-                'exclusions': test_maven_exclusions
-            }
-        }])
+    runner = CliRunner()
+    runner.invoke(cli.uninstall_cli, [
+        '--cluster-id', TEST_CLUSTER_ID,
+        '--maven-coordinates', test_maven_coordinates,
+        '--maven-repo', test_maven_repo,
+        '--maven-exclusion', test_maven_exclusions[0],
+        '--maven-exclusion', test_maven_exclusions[1]])
+    libraries_api_mock.uninstall_libraries.assert_called_with(TEST_CLUSTER_ID, [{
+        'maven': {
+            'coordinates': test_maven_coordinates,
+            'repo': test_maven_repo,
+            'exclusions': test_maven_exclusions
+        }
+    }])
 
 
 @provide_conf
-def test_uninstall_cli_pypi():
+def test_uninstall_cli_pypi(libraries_api_mock):
     test_pypi_package = 'databricks-cli'
     test_pypi_repo = 'https://pypi.databricks.com'
     # Coordinates
-    with mock.patch('databricks_cli.libraries.cli.uninstall_libraries') as uninstall_libraries_mock:
-        runner = CliRunner()
-        runner.invoke(cli.uninstall_cli, [
-            '--cluster-id', TEST_CLUSTER_ID,
-            '--pypi-package', test_pypi_package,
-            '--pypi-repo', test_pypi_repo])
-        uninstall_libraries_mock.assert_called_with(TEST_CLUSTER_ID, [{
-            'pypi': {
-                'package': test_pypi_package,
-                'repo': test_pypi_repo
-            }
-        }])
+    runner = CliRunner()
+    runner.invoke(cli.uninstall_cli, [
+        '--cluster-id', TEST_CLUSTER_ID,
+        '--pypi-package', test_pypi_package,
+        '--pypi-repo', test_pypi_repo])
+    libraries_api_mock.uninstall_libraries.assert_called_with(TEST_CLUSTER_ID, [{
+        'pypi': {
+            'package': test_pypi_package,
+            'repo': test_pypi_repo
+        }
+    }])
 
 
 @provide_conf
-def test_uninstall_cli_cran():
+def test_uninstall_cli_cran(libraries_api_mock):
     test_cran_package = 'cran-package'
     test_cran_repo = 'https://cran.databricks.com'
     # Coordinates
-    with mock.patch('databricks_cli.libraries.cli.uninstall_libraries') as uninstall_libraries_mock:
-        runner = CliRunner()
-        runner.invoke(cli.uninstall_cli, [
-            '--cluster-id', TEST_CLUSTER_ID,
-            '--cran-package', test_cran_package,
-            '--cran-repo', test_cran_repo])
-        uninstall_libraries_mock.assert_called_with(TEST_CLUSTER_ID, [{
-            'cran': {
-                'package': test_cran_package,
-                'repo': test_cran_repo
-            }
-        }])
+    runner = CliRunner()
+    runner.invoke(cli.uninstall_cli, [
+        '--cluster-id', TEST_CLUSTER_ID,
+        '--cran-package', test_cran_package,
+        '--cran-repo', test_cran_repo])
+    libraries_api_mock.uninstall_libraries.assert_called_with(TEST_CLUSTER_ID, [{
+        'cran': {
+            'package': test_cran_package,
+            'repo': test_cran_repo
+        }
+    }])


### PR DESCRIPTION
This is part two of two for the configuration profile feature.

In this part, we actually read out the different confs given by the different profiles and use them in our API calls.