### PR TITLE
Enable codecov for Databricks CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,6 @@ install:
 script:
   - pip list
   - ./lint.sh
-  - pytest tests
+  - pytest tests --cov=./
+after_success:
+  - codecov

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "databricks_cli/sdk"
+  - "tests"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,3 +5,5 @@ pytest==3.2.1
 mock==2.0.0
 decorator==4.2.1
 rstcheck==3.2
+pytest-cov
+codecov


### PR DESCRIPTION
Let's add codecov to Databricks CLI because it's fun and free.