### PR TITLE
Minimal set of changes to get python 3 working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27
+    - python: 3.6
+      env: TOXENV=py36
 install:
   - pip install --upgrade pip
   - pip install .

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -20,7 +20,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import ConfigParser
+from configparser import ConfigParser
 from os.path import expanduser, join
 
 import os
@@ -38,7 +38,7 @@ def _get_path():
 
 
 def _fetch_from_fs():
-    raw_config = ConfigParser.RawConfigParser()
+    raw_config = ConfigParser()
     raw_config.read(_get_path())
     return raw_config
 
@@ -61,7 +61,7 @@ def _set_option(raw_config, profile, option, value):
 
 def _overwrite_config(raw_config):
     config_path = _get_path()
-    with open(config_path, 'wb') as cfg:
+    with open(config_path, 'w') as cfg:
         raw_config.write(cfg)
     os.chmod(config_path, 0o600)
 

--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -99,7 +99,8 @@ class DbfsApi(object):
                 contents = local_file.read(BUFFER_SIZE_BYTES)
                 if len(contents) == 0:
                     break
-                self.client.add_block(handle, b64encode(contents))
+                # add_block should not take a bytes object.
+                self.client.add_block(handle, b64encode(contents).decode())
             self.client.close(handle)
 
     def get_file(self, dbfs_path, dst_path, overwrite):

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -34,7 +34,7 @@ import warnings
 import requests
 import ssl
 
-import version
+from . import version
 
 from requests.adapters import HTTPAdapter
 
@@ -62,16 +62,8 @@ class ApiClient(object):
     A partial Python implementation of dbc rest api
     to be used by different versions of the client.
     """
-    def __init__(self, user = None, password = None, host = None, token = None, configUrl = None,
-            apiVersion = version.API_VERSION, default_headers = {}, verify = True):
-        if configUrl:
-            self.url = configUrl
-            params = self.performQuery("/", headers = {})[1]
-            params = credential.json
-            user = str(params["user"])
-            password = str(params["password"])
-            host = str(params["apiUrl"].split("/api")[0])
-
+    def __init__(self, user = None, password = None, host = None, token = None,
+                 apiVersion = version.API_VERSION, default_headers = {}, verify = True):
         if host[-1] == "/":
             host = host[:-1]
 
@@ -87,7 +79,10 @@ class ApiClient(object):
         else:
             auth = {}
         user_agent = {'user-agent': 'databricks-cli-{v}'.format(v=databricks_cli_version)}
-        self.default_headers = dict(auth.items() + default_headers.items() + user_agent.items())
+        self.default_headers = {}
+        self.default_headers.update(auth)
+        self.default_headers.update(default_headers)
+        self.default_headers.update(user_agent)
         self.verify = verify
 
     def close(self):
@@ -108,6 +103,6 @@ class ApiClient(object):
 
         try:
             resp.raise_for_status()
-        except requests.exceptions.HTTPError, e:
+        except requests.exceptions.HTTPError as e:
             raise e
         return resp.json()

--- a/databricks_cli/workspace/api.py
+++ b/databricks_cli/workspace/api.py
@@ -95,8 +95,9 @@ class WorkspaceApi(object):
         self.client.mkdirs(workspace_path)
 
     def import_workspace(self, source_path, target_path, language, fmt, is_overwrite):
-        with open(source_path, 'r') as f:
-            content = b64encode(f.read())
+        with open(source_path, 'rb') as f:
+            # import_workspace must take content that is typed str.
+            content = b64encode(f.read()).decode()
             self.client.import_workspace(
                 target_path,
                 fmt,

--- a/prospector.yaml
+++ b/prospector.yaml
@@ -18,6 +18,7 @@ pylint:
     - no-self-use
     - protected-access
     - too-many-arguments
+    - inconsistent-return-statements
 
 mccabe:
   disable:

--- a/tests/dbfs/test_api.py
+++ b/tests/dbfs/test_api.py
@@ -22,7 +22,6 @@
 # limitations under the License.
 
 # pylint:disable=redefined-outer-name
-
 from base64 import b64encode
 
 import os
@@ -45,7 +44,7 @@ TEST_FILE_INFO = api.FileInfo(TEST_DBFS_PATH, False, 1)
 
 def get_resource_does_not_exist_exception():
     response = requests.Response()
-    response._content = '{"error_code": "' + api.DbfsErrorCodes.RESOURCE_DOES_NOT_EXIST + '"}' #  NOQA
+    response._content = ('{"error_code": "' + api.DbfsErrorCodes.RESOURCE_DOES_NOT_EXIST + '"}').encode() #  NOQA
     return requests.exceptions.HTTPError(response=response)
 
 
@@ -118,7 +117,7 @@ class TestDbfsApi(object):
 
     def test_put_file(self, dbfs_api, tmpdir):
         test_file_path = os.path.join(tmpdir.strpath, 'test')
-        with open(test_file_path, 'w') as f:
+        with open(test_file_path, 'wt') as f:
             f.write('test')
 
         api_mock = dbfs_api.client
@@ -128,7 +127,7 @@ class TestDbfsApi(object):
 
         assert api_mock.add_block.call_count == 1
         assert test_handle == api_mock.add_block.call_args[0][0]
-        assert b64encode('test') == api_mock.add_block.call_args[0][1]
+        assert b64encode(b'test').decode() == api_mock.add_block.call_args[0][1]
 
     def test_get_file_check_overwrite(self, dbfs_api, tmpdir):
         test_file_path = os.path.join(tmpdir.strpath, 'test')
@@ -142,7 +141,7 @@ class TestDbfsApi(object):
         api_mock.get_status.return_value = TEST_FILE_JSON
         api_mock.read.return_value = {
             'bytes_read': 1,
-            'data': b64encode('x'),
+            'data': b64encode(b'x'),
         }
 
         test_file_path = os.path.join(tmpdir.strpath, 'test')

--- a/tests/workspace/test_api.py
+++ b/tests/workspace/test_api.py
@@ -20,7 +20,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import os
 import mock
 from base64 import b64encode
@@ -108,12 +107,12 @@ class TestWorkspaceApi(object):
         assert import_workspace_mock.call_args[0][0] == TEST_WORKSPACE_PATH
         assert import_workspace_mock.call_args[0][1] == TEST_FMT
         assert import_workspace_mock.call_args[0][2] == TEST_LANGUAGE
-        assert import_workspace_mock.call_args[0][3] == b64encode('test')
+        assert import_workspace_mock.call_args[0][3] == b64encode(b'test').decode()
         assert import_workspace_mock.call_args[0][4] == False
 
     def test_export_workspace(self, workspace_api, tmpdir):
         test_file_path = os.path.join(tmpdir.strpath, 'test')
-        workspace_api.client.export_workspace.return_value = {'content': b64encode('test')}
+        workspace_api.client.export_workspace.return_value = {'content': b64encode(b'test')}
         workspace_api.export_workspace(TEST_WORKSPACE_PATH, test_file_path, TEST_FMT, is_overwrite=False)
         with open(test_file_path, 'r') as f:
             contents = f.read()

--- a/tests/workspace/test_cli.py
+++ b/tests/workspace/test_cli.py
@@ -20,7 +20,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import os
 import mock
 import pytest
@@ -47,7 +46,7 @@ def test_export_workspace_cli(workspace_api_mock, tmpdir):
     workspace_api_mock.get_status.return_value = \
         WorkspaceFileInfo('/notebook-name', NOTEBOOK, WorkspaceLanguage.SCALA)
     runner = CliRunner()
-    runner.invoke(cli.export_workspace_cli, ['--format', 'SOURCE', '/notebook-name', path])
+    print(runner.invoke(cli.export_workspace_cli, ['--format', 'SOURCE', '/notebook-name', path]).output)
     assert workspace_api_mock.export_workspace.call_args[0][1] == \
            os.path.join(path, 'notebook-name.scala')
 
@@ -116,13 +115,13 @@ def test_import_dir_helper(workspace_api_mock, tmpdir):
     os.makedirs(os.path.join(tmpdir.strpath, 'a'))
     os.makedirs(os.path.join(tmpdir.strpath, 'f'))
     os.makedirs(os.path.join(tmpdir.strpath, 'f', 'g'))
-    with open(os.path.join(tmpdir.strpath, 'a', 'b.scala'), 'wb') as f:
+    with open(os.path.join(tmpdir.strpath, 'a', 'b.scala'), 'wt') as f:
         f.write('println(1 + 1)')
-    with open(os.path.join(tmpdir.strpath, 'a', 'c.py'), 'wb') as f:
+    with open(os.path.join(tmpdir.strpath, 'a', 'c.py'), 'wt') as f:
         f.write('print 1 + 1')
-    with open(os.path.join(tmpdir.strpath, 'a', 'd.r'), 'wb') as f:
+    with open(os.path.join(tmpdir.strpath, 'a', 'd.r'), 'wt') as f:
         f.write('I don\'t know how to write r')
-    with open(os.path.join(tmpdir.strpath, 'a', 'e.sql'), 'wb') as f:
+    with open(os.path.join(tmpdir.strpath, 'a', 'e.sql'), 'wt') as f:
         f.write('select 1+1 from table;')
     cli._import_dir_helper(workspace_api_mock, tmpdir.strpath, '/', False, False)
     # Verify that the directories a, f, g exist.
@@ -163,7 +162,7 @@ def test_import_dir_rstrip(workspace_api_mock, tmpdir):
       - test-py.py (python)
     """
     os.makedirs(os.path.join(tmpdir.strpath, 'a'))
-    with open(os.path.join(tmpdir.strpath, 'a', 'test-py.py'), 'wb'):
+    with open(os.path.join(tmpdir.strpath, 'a', 'test-py.py'), 'wt'):
         pass
     cli._import_dir_helper(workspace_api_mock, tmpdir.strpath, '/', False, False)
     assert workspace_api_mock.mkdirs.call_count == 2

--- a/tests/workspace/test_cli.py
+++ b/tests/workspace/test_cli.py
@@ -46,7 +46,7 @@ def test_export_workspace_cli(workspace_api_mock, tmpdir):
     workspace_api_mock.get_status.return_value = \
         WorkspaceFileInfo('/notebook-name', NOTEBOOK, WorkspaceLanguage.SCALA)
     runner = CliRunner()
-    print(runner.invoke(cli.export_workspace_cli, ['--format', 'SOURCE', '/notebook-name', path]).output)
+    runner.invoke(cli.export_workspace_cli, ['--format', 'SOURCE', '/notebook-name', path])
     assert workspace_api_mock.export_workspace.call_args[0][1] == \
            os.path.join(path, 'notebook-name.scala')
 

--- a/tox-requirements.txt
+++ b/tox-requirements.txt
@@ -1,6 +1,6 @@
 # Test reqs
 prospector[with_pyroma]==0.12.7
-pylint==1.7.4
+pylint==1.8.2
 pytest==3.2.1
 mock==2.0.0
 decorator==4.2.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-# Add py36 to tox later
-# envlist = py27, py36
-envlist = py27
+envlist = py27, py36
 [testenv]
 # https://github.com/codecov/codecov-python/blob/5b9d539a6a09bc84501b381b563956295478651a/README.md#using-tox
 passenv = TOXENV CI TRAVIS TRAVIS_*
 deps = -rtox-requirements.txt
-commands = ./lint.sh
+commands =
 	pytest tests --cov=./
+	./lint.sh
 	codecov -e TOXENV


### PR DESCRIPTION
Made some tweaks to the code to get Databricks CLI working on Python 3. Tests passed but two commands still failed because of insufficient test coverage.
  - `databricks workspace import_dir`
  - `databricks fs cp local remote`
I applied fixes for both of these in this PR. I didn't add regression tests for these two cases yet because the error is in the SDK layer which we currently mock out of all unit tests...

Lots of ideas stolen from https://github.com/databricks/databricks-cli/pull/58/files. Thanks @andreabedini!