### PR TITLE
Integration tests for Databricks CLI

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
 ignore:
   - "databricks_cli/sdk"
   - "tests"
+  - "integration"

--- a/integration/__init__.py
+++ b/integration/__init__.py
@@ -1,0 +1,22 @@
+# Databricks CLI
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"), except
+# that the use of services to which certain application programming
+# interfaces (each, an "API") connect requires that the user first obtain
+# a license for the use of the APIs from Databricks, Inc. ("Databricks"),
+# by creating an account at www.databricks.com and agreeing to either (a)
+# the Community Edition Terms of Service, (b) the Databricks Terms of
+# Service, or (c) another written agreement between Licensee and Databricks
+# for the use of the APIs.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -1,0 +1,45 @@
+# Databricks CLI
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"), except
+# that the use of services to which certain application programming
+# interfaces (each, an "API") connect requires that the user first obtain
+# a license for the use of the APIs from Databricks, Inc. ("Databricks"),
+# by creating an account at www.databricks.com and agreeing to either (a)
+# the Community Edition Terms of Service, (b) the Databricks Terms of
+# Service, or (c) another written agreement between Licensee and Databricks
+# for the use of the APIs.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import shutil
+import tempfile
+import pytest
+
+import databricks_cli.configure.provider as provider
+
+
+def pytest_addoption(parser):
+    parser.addoption('--host', required=True)
+    parser.addoption('--token', required=True)
+
+
+@pytest.fixture(autouse=True)
+def mock_conf_dir(request):
+    path = tempfile.mkdtemp()
+    provider._home = path
+    # create config
+    host = request.config.getoption('--host')
+    token = request.config.getoption('--token')
+    config = provider.DatabricksConfig.from_token(host, token)
+    provider.update_and_persist_config(provider.DEFAULT_SECTION, config)
+    yield
+    shutil.rmtree(path)

--- a/integration/dbfs/__init__.py
+++ b/integration/dbfs/__init__.py
@@ -1,0 +1,22 @@
+# Databricks CLI
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"), except
+# that the use of services to which certain application programming
+# interfaces (each, an "API") connect requires that the user first obtain
+# a license for the use of the APIs from Databricks, Inc. ("Databricks"),
+# by creating an account at www.databricks.com and agreeing to either (a)
+# the Community Edition Terms of Service, (b) the Databricks Terms of
+# Service, or (c) another written agreement between Licensee and Databricks
+# for the use of the APIs.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/integration/dbfs/test_integration.py
+++ b/integration/dbfs/test_integration.py
@@ -20,8 +20,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 # pylint:disable=redefined-outer-name
+
 import os
+from random import random
 
 import pytest
 
@@ -29,7 +32,7 @@ from databricks_cli.dbfs import cli
 from databricks_cli.dbfs.dbfs_path import DbfsPath
 from tests.utils import invoke_cli_runner
 
-DBFS_TEST_PATH = 'dbfs:/databricks-cli-test'
+DBFS_TEST_PATH = 'dbfs:/databricks-cli-test-' + str(int(random() * 1000))
 LOCAL_TEMP_FILE = 'temp-file.txt'
 LOCAL_TEMP_DIR = 'temp-dir'
 LOCAL_TEST_FILE = 'test-file.txt'
@@ -52,7 +55,7 @@ def local_dir(tmpdir):
     - tmpdir
       - test-file.txt
       - test-dir
-        - test-file-in-dir.txt
+        - test-file.txt
     """
     path = tmpdir.strpath
     with open(os.path.join(path, LOCAL_TEST_FILE), 'wt') as f:
@@ -63,7 +66,7 @@ def local_dir(tmpdir):
     yield tmpdir
 
 
-def assert_local_file_exists(local_path, expected_contents):
+def assert_local_file_content(local_path, expected_contents):
     assert os.path.exists(local_path)
     with open(local_path, 'rt') as f:
         assert f.read() == expected_contents
@@ -78,10 +81,6 @@ def assert_dbfs_file_exists(dbfs_path):
 
 
 class TestDbfsCli(object):
-    """
-    - tmpdir
-      - test-file.txt
-    """
     @pytest.mark.usefixtures('dbfs_dir')
     def test_mkdirs(self):
         pass
@@ -105,7 +104,7 @@ class TestDbfsCli(object):
         invoke_cli_runner(cli.cp_cli, [os.path.join(DBFS_TEST_PATH, LOCAL_TEST_FILE),
                                        temp_file_path])
 
-        assert_local_file_exists(temp_file_path, TEST_FILE_CONTENTS)
+        assert_local_file_content(temp_file_path, TEST_FILE_CONTENTS)
 
     @pytest.mark.usefixtures('dbfs_dir')
     def test_cp_recursive(self, local_dir):
@@ -119,6 +118,6 @@ class TestDbfsCli(object):
         # Copy the data back to `temp-dir`.
         local_temp_dir = os.path.join(path, LOCAL_TEMP_DIR)
         invoke_cli_runner(cli.cp_cli, ['-r', DBFS_TEST_PATH, local_temp_dir])
-        assert_local_file_exists(os.path.join(local_temp_dir, LOCAL_TEST_FILE), TEST_FILE_CONTENTS)
-        assert_local_file_exists(os.path.join(local_temp_dir, LOCAL_TEST_FILE_IN_DIR),
-                                 TEST_FILE_CONTENTS)
+        assert_local_file_content(os.path.join(local_temp_dir, LOCAL_TEST_FILE), TEST_FILE_CONTENTS)
+        assert_local_file_content(os.path.join(local_temp_dir, LOCAL_TEST_FILE_IN_DIR),
+                                  TEST_FILE_CONTENTS)

--- a/integration/dbfs/test_integration.py
+++ b/integration/dbfs/test_integration.py
@@ -1,0 +1,124 @@
+# Databricks CLI
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"), except
+# that the use of services to which certain application programming
+# interfaces (each, an "API") connect requires that the user first obtain
+# a license for the use of the APIs from Databricks, Inc. ("Databricks"),
+# by creating an account at www.databricks.com and agreeing to either (a)
+# the Community Edition Terms of Service, (b) the Databricks Terms of
+# Service, or (c) another written agreement between Licensee and Databricks
+# for the use of the APIs.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# pylint:disable=redefined-outer-name
+import os
+
+import pytest
+
+from databricks_cli.dbfs import cli
+from databricks_cli.dbfs.dbfs_path import DbfsPath
+from tests.utils import invoke_cli_runner
+
+DBFS_TEST_PATH = 'dbfs:/databricks-cli-test'
+LOCAL_TEMP_FILE = 'temp-file.txt'
+LOCAL_TEMP_DIR = 'temp-dir'
+LOCAL_TEST_FILE = 'test-file.txt'
+LOCAL_TEST_DIR = 'test-dir'
+LOCAL_TEST_FILE_IN_DIR = os.path.join(LOCAL_TEST_DIR, LOCAL_TEST_FILE)
+TEST_FILE_CONTENTS = 'Hi I am a test file.\n'
+
+
+@pytest.fixture()
+def dbfs_dir():
+    invoke_cli_runner(cli.mkdirs_cli, [DBFS_TEST_PATH])
+    yield
+    invoke_cli_runner(cli.rm_cli, ['-r', DBFS_TEST_PATH])
+
+
+@pytest.fixture()
+def local_dir(tmpdir):
+    """
+    Creates a tmpdir with this structure.
+    - tmpdir
+      - test-file.txt
+      - test-dir
+        - test-file-in-dir.txt
+    """
+    path = tmpdir.strpath
+    with open(os.path.join(path, LOCAL_TEST_FILE), 'wt') as f:
+        f.write(TEST_FILE_CONTENTS)
+    os.mkdir(os.path.join(path, LOCAL_TEST_DIR))
+    with open(os.path.join(path, LOCAL_TEST_FILE_IN_DIR), 'wt') as f:
+        f.write(TEST_FILE_CONTENTS)
+    yield tmpdir
+
+
+def assert_local_file_exists(local_path, expected_contents):
+    assert os.path.exists(local_path)
+    with open(local_path, 'rt') as f:
+        assert f.read() == expected_contents
+
+
+def assert_dbfs_file_exists(dbfs_path):
+    basename = dbfs_path.basename
+    dirname = dbfs_path.absolute_path[:-len(basename)]
+    res = invoke_cli_runner(cli.ls_cli, [dirname])
+    files = res.output.split('\n')
+    assert basename in files
+
+
+class TestDbfsCli(object):
+    """
+    - tmpdir
+      - test-file.txt
+    """
+    @pytest.mark.usefixtures('dbfs_dir')
+    def test_mkdirs(self):
+        pass
+
+    @pytest.mark.usefixtures('dbfs_dir')
+    def test_ls(self):
+        assert_dbfs_file_exists(DbfsPath(DBFS_TEST_PATH))
+
+    @pytest.mark.usefixtures('dbfs_dir')
+    def test_cp_from_local(self, local_dir):
+        path = local_dir.strpath
+        invoke_cli_runner(cli.cp_cli, [os.path.join(path, LOCAL_TEST_FILE), DBFS_TEST_PATH])
+        assert_dbfs_file_exists(DbfsPath(DBFS_TEST_PATH).join(LOCAL_TEST_FILE))
+
+    @pytest.mark.usefixtures('dbfs_dir')
+    def test_cp_from_remote(self, local_dir):
+        path = local_dir.strpath
+        invoke_cli_runner(cli.cp_cli, [os.path.join(path, LOCAL_TEST_FILE), DBFS_TEST_PATH])
+
+        temp_file_path = os.path.join(path, LOCAL_TEMP_FILE)
+        invoke_cli_runner(cli.cp_cli, [os.path.join(DBFS_TEST_PATH, LOCAL_TEST_FILE),
+                                       temp_file_path])
+
+        assert_local_file_exists(temp_file_path, TEST_FILE_CONTENTS)
+
+    @pytest.mark.usefixtures('dbfs_dir')
+    def test_cp_recursive(self, local_dir):
+        path = local_dir.strpath
+        os.chdir(path)
+        invoke_cli_runner(cli.cp_cli, ['-r', '.', DBFS_TEST_PATH])
+        assert_dbfs_file_exists(DbfsPath(DBFS_TEST_PATH).join(LOCAL_TEST_FILE))
+        assert_dbfs_file_exists(DbfsPath(DBFS_TEST_PATH).join(LOCAL_TEST_DIR))
+        assert_dbfs_file_exists(DbfsPath(DBFS_TEST_PATH).join(LOCAL_TEST_FILE_IN_DIR))
+
+        # Copy the data back to `temp-dir`.
+        local_temp_dir = os.path.join(path, LOCAL_TEMP_DIR)
+        invoke_cli_runner(cli.cp_cli, ['-r', DBFS_TEST_PATH, local_temp_dir])
+        assert_local_file_exists(os.path.join(local_temp_dir, LOCAL_TEST_FILE), TEST_FILE_CONTENTS)
+        assert_local_file_exists(os.path.join(local_temp_dir, LOCAL_TEST_FILE_IN_DIR),
+                                 TEST_FILE_CONTENTS)

--- a/integration/workspace/test_integration.py
+++ b/integration/workspace/test_integration.py
@@ -20,22 +20,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 # pylint:disable=redefined-outer-name
+
 import os
+from random import random
 
 import pytest
 
 from databricks_cli.workspace import cli
 from tests.utils import invoke_cli_runner
 
-WORKSPACE_TEST_PATH = '/databricks-cli-test'
+WORKSPACE_TEST_PATH = '/databricks-cli-test' + str(int(random() * 1000))
 LOCAL_TEMP_FILE = 'temp-file.txt'
 LOCAL_TEMP_DIR = 'temp-dir'
 
 SCALA_FILE = 'test-a.scala'
 SQL_FILE = 'test-b.sql'
 PYTHON_FILE = 'test-c.py'
-R_FILE = 'test-d.r'
+R_FILE = 'test-d.R'
 
 SCALA_CONTENTS = "println(1+1)"
 SQL_CONTENTS = "select 1+1"
@@ -86,21 +89,16 @@ def assert_local_file_contains(local_path, expected_contents):
 
 
 def assert_workspace_file_exists(workspace_path):
-    remote_dir, basename = os.path.split(workspace_path)
-    res = invoke_cli_runner(cli.ls_cli, [remote_dir])
-    files = res.output.split('\n')
-    assert basename in files
+    dirname, basename = os.path.split(workspace_path)
+    res = invoke_cli_runner(cli.ls_cli, [dirname])
+    assert basename in res.output.split("\n")
 
 
 def strip_suffix(filename):
-    return filename.split('.')[0]
+    return os.path.splitext(filename)[0]
 
 
-class TestDbfsCli(object):
-    """
-    - tmpdir
-      - test-file.txt
-    """
+class TestWorkspaceCli(object):
     @pytest.mark.usefixtures('workspace_dir')
     def test_mkdirs(self):
         pass

--- a/integration/workspace/test_integration.py
+++ b/integration/workspace/test_integration.py
@@ -1,0 +1,142 @@
+# Databricks CLI
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"), except
+# that the use of services to which certain application programming
+# interfaces (each, an "API") connect requires that the user first obtain
+# a license for the use of the APIs from Databricks, Inc. ("Databricks"),
+# by creating an account at www.databricks.com and agreeing to either (a)
+# the Community Edition Terms of Service, (b) the Databricks Terms of
+# Service, or (c) another written agreement between Licensee and Databricks
+# for the use of the APIs.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# pylint:disable=redefined-outer-name
+import os
+
+import pytest
+
+from databricks_cli.workspace import cli
+from tests.utils import invoke_cli_runner
+
+WORKSPACE_TEST_PATH = '/databricks-cli-test'
+LOCAL_TEMP_FILE = 'temp-file.txt'
+LOCAL_TEMP_DIR = 'temp-dir'
+
+SCALA_FILE = 'test-a.scala'
+SQL_FILE = 'test-b.sql'
+PYTHON_FILE = 'test-c.py'
+R_FILE = 'test-d.r'
+
+SCALA_CONTENTS = "println(1+1)"
+SQL_CONTENTS = "select 1+1"
+PYTHON_CONTENTS = "print 1+1"
+R_CONTENTS = "print(1+1)"
+
+LOCAL_TEST_DIR = 'test-dir'
+
+
+@pytest.fixture()
+def workspace_dir():
+    invoke_cli_runner(cli.mkdirs_cli, [WORKSPACE_TEST_PATH])
+    yield
+    invoke_cli_runner(cli.delete_cli, ['-r', WORKSPACE_TEST_PATH])
+
+
+@pytest.fixture()
+def local_dir(tmpdir):
+    """
+    Creates a tmpdir with this structure.
+    - tmpdir
+      - test.scala
+      - test-dir
+        - test.scala
+        - test.sql
+        - test.py
+        - test.R
+    """
+    path = tmpdir.strpath
+    with open(os.path.join(path, SCALA_FILE), 'wt') as f:
+        f.write(SCALA_CONTENTS)
+    os.mkdir(os.path.join(path, LOCAL_TEST_DIR))
+    with open(os.path.join(path, os.path.join(LOCAL_TEST_DIR, SCALA_FILE)), 'wt') as f:
+        f.write(SCALA_CONTENTS)
+    with open(os.path.join(path, os.path.join(LOCAL_TEST_DIR, SQL_FILE)), 'wt') as f:
+        f.write(SQL_CONTENTS)
+    with open(os.path.join(path, os.path.join(LOCAL_TEST_DIR, PYTHON_FILE)), 'wt') as f:
+        f.write(PYTHON_CONTENTS)
+    with open(os.path.join(path, os.path.join(LOCAL_TEST_DIR, R_FILE)), 'wt') as f:
+        f.write(R_CONTENTS)
+    yield tmpdir
+
+
+def assert_local_file_contains(local_path, expected_contents):
+    assert os.path.exists(local_path)
+    with open(local_path, 'rt') as f:
+        assert expected_contents in f.read()
+
+
+def assert_workspace_file_exists(workspace_path):
+    remote_dir, basename = os.path.split(workspace_path)
+    res = invoke_cli_runner(cli.ls_cli, [remote_dir])
+    files = res.output.split('\n')
+    assert basename in files
+
+
+def strip_suffix(filename):
+    return filename.split('.')[0]
+
+
+class TestDbfsCli(object):
+    """
+    - tmpdir
+      - test-file.txt
+    """
+    @pytest.mark.usefixtures('workspace_dir')
+    def test_mkdirs(self):
+        pass
+
+    @pytest.mark.usefixtures('workspace_dir')
+    def test_ls(self):
+        assert_workspace_file_exists(WORKSPACE_TEST_PATH)
+
+    @pytest.mark.usefixtures('workspace_dir')
+    def test_import_export(self, local_dir):
+        path = local_dir.strpath
+        invoke_cli_runner(cli.import_workspace_cli, [os.path.join(path, SCALA_FILE),
+                                                     os.path.join(WORKSPACE_TEST_PATH, SCALA_FILE),
+                                                     "-l", "scala"])
+        assert_workspace_file_exists(os.path.join(WORKSPACE_TEST_PATH, SCALA_FILE))
+        invoke_cli_runner(cli.export_workspace_cli, [os.path.join(WORKSPACE_TEST_PATH, SCALA_FILE),
+                                                     os.path.join(path, LOCAL_TEMP_FILE)])
+        assert_local_file_contains(os.path.join(path, LOCAL_TEMP_FILE), SCALA_CONTENTS)
+
+    @pytest.mark.usefixtures('workspace_dir')
+    def test_import_export_recursive(self, local_dir):
+        path = local_dir.strpath
+        os.chdir(path)
+        invoke_cli_runner(cli.import_dir_cli, ['-o', '.', WORKSPACE_TEST_PATH])
+        assert_workspace_file_exists(os.path.join(WORKSPACE_TEST_PATH, strip_suffix(SCALA_FILE)))
+
+        for f in [SCALA_FILE, SQL_FILE, PYTHON_FILE, R_FILE]:
+            remote_path = os.path.join(WORKSPACE_TEST_PATH, os.path.join(LOCAL_TEST_DIR,
+                                                                         strip_suffix(f)))
+            assert_workspace_file_exists(remote_path)
+
+        # Copy the data back to `temp-dir`.
+        local_temp_dir = os.path.join(path, LOCAL_TEMP_DIR)
+        invoke_cli_runner(cli.export_dir_cli, [WORKSPACE_TEST_PATH, local_temp_dir])
+        assert_local_file_contains(os.path.join(local_temp_dir, SCALA_FILE), SCALA_CONTENTS)
+        for f, content in [(SCALA_FILE, SCALA_CONTENTS), (SQL_FILE, SQL_CONTENTS),
+                           (PYTHON_FILE, PYTHON_CONTENTS), (R_FILE, R_CONTENTS)]:
+            local_path = os.path.join(local_temp_dir, os.path.join(LOCAL_TEST_DIR, f))
+            assert_local_file_contains(local_path, content)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,6 +21,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import decorator
+from click.testing import CliRunner
 
 from databricks_cli.configure.provider import DatabricksConfig, DEFAULT_SECTION, \
     update_and_persist_config
@@ -44,3 +45,9 @@ def assert_cli_output(actual, expected):
     >>> assert_cli_output(res.output, 'EXPECTED-OUTPUT')
     """
     assert actual == expected + '\n'
+
+
+def invoke_cli_runner(*args, **kwargs):
+    res = CliRunner().invoke(*args, **kwargs)
+    assert res.exit_code == 0, 'Exit code was not 0. Output is: {}'.format(res.output)
+    return res

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -48,6 +48,9 @@ def assert_cli_output(actual, expected):
 
 
 def invoke_cli_runner(*args, **kwargs):
+    """
+    Helper method to invoke the CliRunner while asserting that the exit code is actually 0.
+    """
     res = CliRunner().invoke(*args, **kwargs)
     assert res.exit_code == 0, 'Exit code was not 0. Output is: {}'.format(res.output)
     return res

--- a/tests/workspace/test_cli.py
+++ b/tests/workspace/test_cli.py
@@ -20,6 +20,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import os
 import mock
 import pytest


### PR DESCRIPTION
Let's add some integration tests for Databricks CLI. Currently we have only covered APIs from workspace and dbfs command groups.