### PR TITLE
Fix installation from setup.py for Python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'requests>=2.17.3',
         'tabulate>=0.7.7',
         'six>=1.10.0',
+        'configparser >= 0.3.5'
     ],
     entry_points='''
         [console_scripts]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
-envlist = py27, py36
-[testenv]
+envlist = py27, py36, {py27,py36}-clean
+
+[testenv:{py27, py36}]
 # https://github.com/codecov/codecov-python/blob/5b9d539a6a09bc84501b381b563956295478651a/README.md#using-tox
 passenv = TOXENV CI TRAVIS TRAVIS_*
 deps = -rtox-requirements.txt


### PR DESCRIPTION
Without this fix, in a fresh installation of `databricks-cli` you'd get this error in python 2.7.

```
Traceback (most recent call last):
  File "/Users/andrew/databricks-cli/.tox/py27clean/bin/databricks", line 7, in <module>
    from databricks_cli.cli import cli
  File "/Users/andrew/databricks-cli/.tox/py27clean/lib/python2.7/site-packages/databricks_cli/cli.py", line 26, in <module>
    from databricks_cli.libraries.cli import libraries_group
  File "/Users/andrew/databricks-cli/.tox/py27clean/lib/python2.7/site-packages/databricks_cli/libraries/cli.py", line 27, in <module>
    from databricks_cli.configure.config import provide_api_client, profile_option
  File "/Users/andrew/databricks-cli/.tox/py27clean/lib/python2.7/site-packages/databricks_cli/configure/config.py", line 27, in <module>
    from databricks_cli.configure.provider import DEFAULT_SECTION, get_config_for_profile
  File "/Users/andrew/databricks-cli/.tox/py27clean/lib/python2.7/site-packages/databricks_cli/configure/provider.py", line 23, in <module>
    from configparser import ConfigParser
ImportError: No module named configparser```