### PR TITLE
Use --profile option anywhere.

### DIFF
--- a/databricks_cli/cli.py
+++ b/databricks_cli/cli.py
@@ -23,6 +23,7 @@
 
 import click
 
+from databricks_cli.configure.config import profile_option
 from databricks_cli.libraries.cli import libraries_group
 from databricks_cli.version import print_version_callback, version
 from databricks_cli.utils import CONTEXT_SETTINGS
@@ -37,6 +38,7 @@ from databricks_cli.runs.cli import runs_group
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.option('--version', '-v', is_flag=True, callback=print_version_callback,
               expose_value=False, is_eager=True, help=version)
+@profile_option
 def cli():
     pass
 

--- a/databricks_cli/click_types.py
+++ b/databricks_cli/click_types.py
@@ -23,6 +23,8 @@
 
 from click import ParamType, Option, MissingParameter, UsageError
 
+from databricks_cli.configure.provider import DEFAULT_SECTION
+
 
 class OutputClickType(ParamType):
     name = 'FORMAT'
@@ -79,3 +81,12 @@ class OneOfOption(Option):
         if len(cleaned_opts.intersection(set(self.one_of))) > 1:
             raise UsageError('Only one of {} should be provided.'.format(self.one_of))
         return super(OneOfOption, self).handle_parse_result(ctx, opts, args)
+
+
+class ContextObject(object):
+    def __init__(self):
+        self.profile = DEFAULT_SECTION
+
+    def set_profile(self, profile):
+        if self.profile == DEFAULT_SECTION:
+            self.profile = profile

--- a/databricks_cli/click_types.py
+++ b/databricks_cli/click_types.py
@@ -85,8 +85,14 @@ class OneOfOption(Option):
 
 class ContextObject(object):
     def __init__(self):
-        self.profile = DEFAULT_SECTION
+        self._profile = None
 
     def set_profile(self, profile):
-        if self.profile == DEFAULT_SECTION:
-            self.profile = profile
+        if self._profile is not None:
+            raise UsageError('--profile can only be provided once.')
+        self._profile = profile
+
+    def get_profile(self):
+        if self._profile is None:
+            return DEFAULT_SECTION
+        return self._profile

--- a/databricks_cli/click_types.py
+++ b/databricks_cli/click_types.py
@@ -89,7 +89,8 @@ class ContextObject(object):
 
     def set_profile(self, profile):
         if self._profile is not None:
-            raise UsageError('--profile can only be provided once.')
+            raise UsageError('--profile can only be provided once. '
+                             'The profiles [{}, {}] were provided.'.format(self._profile, profile))
         self._profile = profile
 
     def get_profile(self):

--- a/databricks_cli/clusters/cli.py
+++ b/databricks_cli/clusters/cli.py
@@ -196,6 +196,7 @@ def spark_versions_cli(api_client):
              short_help='Utility to interact with Databricks clusters.')
 @click.option('--version', '-v', is_flag=True, callback=print_version_callback,
               expose_value=False, is_eager=True, help=version)
+@profile_option
 @eat_exceptions
 def clusters_group():
     """

--- a/databricks_cli/configure/cli.py
+++ b/databricks_cli/configure/cli.py
@@ -28,7 +28,7 @@ from click import ParamType
 from databricks_cli.configure.provider import DatabricksConfig, update_and_persist_config, \
     get_config_for_profile
 from databricks_cli.utils import CONTEXT_SETTINGS
-from databricks_cli.configure.config import profile_option_injected
+from databricks_cli.configure.config import profile_option, get_profile_from_context
 
 PROMPT_HOST = 'Databricks Host (should begin with https://)'
 PROMPT_USERNAME = 'Username'
@@ -63,11 +63,12 @@ def _configure_cli_password(profile):
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Configures host and authentication info for the CLI.')
 @click.option('--token', show_default=True, is_flag=True, default=False)
-@profile_option_injected
-def configure_cli(profile, token):
+@profile_option
+def configure_cli(token):
     """
     Configures host and authentication info for the CLI.
     """
+    profile = get_profile_from_context()
     if token:
         _configure_cli_token(profile)
     else:

--- a/databricks_cli/configure/cli.py
+++ b/databricks_cli/configure/cli.py
@@ -28,8 +28,7 @@ from click import ParamType
 from databricks_cli.configure.provider import DatabricksConfig, update_and_persist_config, \
     get_config_for_profile
 from databricks_cli.utils import CONTEXT_SETTINGS
-from databricks_cli.configure.config import profile_option
-
+from databricks_cli.configure.config import profile_option_injected
 
 PROMPT_HOST = 'Databricks Host (should begin with https://)'
 PROMPT_USERNAME = 'Username'
@@ -64,7 +63,7 @@ def _configure_cli_password(profile):
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Configures host and authentication info for the CLI.')
 @click.option('--token', show_default=True, is_flag=True, default=False)
-@profile_option
+@profile_option_injected
 def configure_cli(profile, token):
     """
     Configures host and authentication info for the CLI.

--- a/databricks_cli/configure/config.py
+++ b/databricks_cli/configure/config.py
@@ -60,7 +60,8 @@ def profile_option(f):
             context_object = ctx.ensure_object(ContextObject)
             context_object.set_profile(value)
     return click.option('--profile', required=False, default=None, callback=callback,
-                        expose_value=False, help='CLI connection profile to use.')(f)
+                        expose_value=False,
+                        help='CLI connection profile to use. The default profile is "DEFAULT".')(f)
 
 
 def _get_api_client(config):

--- a/databricks_cli/dbfs/cli.py
+++ b/databricks_cli/dbfs/cli.py
@@ -229,6 +229,7 @@ def mv_cli(api_client, src, dst):
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Utility to interact with DBFS.')
 @click.option('--version', '-v', is_flag=True, callback=print_version_callback,
               expose_value=False, is_eager=True, help=version)
+@profile_option
 def dbfs_group():
     """
     Utility to interact with DBFS.

--- a/databricks_cli/jobs/cli.py
+++ b/databricks_cli/jobs/cli.py
@@ -184,6 +184,7 @@ def run_now_cli(api_client, job_id, jar_params, notebook_params, python_params,
              short_help='Utility to interact with jobs.')
 @click.option('--version', '-v', is_flag=True, callback=print_version_callback,
               expose_value=False, is_eager=True, help=version)
+@profile_option
 @eat_exceptions
 def jobs_group():
     """

--- a/databricks_cli/libraries/cli.py
+++ b/databricks_cli/libraries/cli.py
@@ -227,6 +227,7 @@ def uninstall_cli(api_client, cluster_id, all, jar, egg, maven_coordinates, mave
              short_help='Utility to interact with libraries.')
 @click.option('--version', '-v', is_flag=True, callback=print_version_callback,
               expose_value=False, is_eager=True, help=version)
+@profile_option
 @eat_exceptions
 def libraries_group():
     """

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -133,6 +133,7 @@ def cancel_cli(api_client, run_id):
              short_help='Utility to interact with the jobs runs.')
 @click.option('--version', '-v', is_flag=True, callback=print_version_callback,
               expose_value=False, is_eager=True, help=version)
+@profile_option
 @eat_exceptions
 def runs_group():
     """

--- a/databricks_cli/workspace/cli.py
+++ b/databricks_cli/workspace/cli.py
@@ -238,6 +238,7 @@ def import_dir_cli(api_client, source_path, target_path, overwrite, exclude_hidd
              short_help='Utility to interact with the Databricks workspace.')
 @click.option('--version', '-v', is_flag=True, callback=print_version_callback,
               expose_value=False, is_eager=True, help=version)
+@profile_option
 def workspace_group():
     """
     Utility to interact with the Databricks workspace.

--- a/tests/configure/test_config.py
+++ b/tests/configure/test_config.py
@@ -55,3 +55,21 @@ def test_provide_api_client_invalid():
     result = CliRunner().invoke(test_command, ['--x', '1'])
     assert result.exit_code == -1
     assert isinstance(result.exception, InvalidConfigurationError)
+
+
+def test_provide_profile_twice():
+    @click.group()
+    @config.profile_option
+    def test_group():
+        pass
+
+    @click.command()
+    @config.profile_option
+    def test_command(): # noqa
+        pass
+
+    test_group.add_command(test_command, 'test')
+
+    result = CliRunner().invoke(test_group, ['--profile', 'test-profile-1', 'test', '--profile',
+                                             'test-profile-2'])
+    assert '--profile can only be provided once.' in result.output

--- a/tests/configure/test_config.py
+++ b/tests/configure/test_config.py
@@ -57,6 +57,10 @@ def test_provide_api_client_invalid():
     assert isinstance(result.exception, InvalidConfigurationError)
 
 
+TEST_PROFILE_1 = 'test-profile-1'
+TEST_PROFILE_2 = 'test-profile-2'
+
+
 def test_provide_profile_twice():
     @click.group()
     @config.profile_option
@@ -70,6 +74,7 @@ def test_provide_profile_twice():
 
     test_group.add_command(test_command, 'test')
 
-    result = CliRunner().invoke(test_group, ['--profile', 'test-profile-1', 'test', '--profile',
-                                             'test-profile-2'])
-    assert '--profile can only be provided once.' in result.output
+    result = CliRunner().invoke(test_group, ['--profile', TEST_PROFILE_1, 'test', '--profile',
+                                             TEST_PROFILE_2])
+    assert '--profile can only be provided once. The profiles [{}, {}] were provided.'.format(
+        TEST_PROFILE_1, TEST_PROFILE_2) in result.output

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,11 +26,15 @@ from click.testing import CliRunner
 from databricks_cli.configure.provider import DatabricksConfig, DEFAULT_SECTION, \
     update_and_persist_config
 
+TEST_PROFILE = 'test-profile'
+
 
 def provide_conf(test):
     def wrapper(test, *args, **kwargs):
         config = DatabricksConfig.from_token('test-host', 'test-token')
         update_and_persist_config(DEFAULT_SECTION, config)
+        config = DatabricksConfig.from_token('test-host-2', 'test-token-2')
+        update_and_persist_config(TEST_PROFILE, config)
         return test(*args, **kwargs)
     return decorator.decorator(wrapper, test)
 


### PR DESCRIPTION
Previously only commands like `databricks jobs list --profile <profile>` would work. Let's enable people to use the `profile` option in more places i.e.

- `databricks --profile <profile> jobs list`
- `databricks jobs --profile <profile> list`

This closes https://github.com/databricks/databricks-cli/issues/84

