### PR TITLE
Fix get_option_if_exists pulling values from DEFAULT.

### DIFF
--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -49,7 +49,14 @@ def _create_section_if_absent(raw_config, profile):
 
 
 def _get_option_if_exists(raw_config, profile, option):
-    return raw_config.get(profile, option) if raw_config.has_option(profile, option) else None
+    if profile == DEFAULT_SECTION:
+        # We must handle the DEFAULT_SECTION differently since it is not in the _sections property
+        # of raw config.
+        return raw_config.get(profile, option) if raw_config.has_option(profile, option) else None
+    # Check if option is defined in the profile.
+    elif not option in raw_config._sections.get(profile, {}).keys():
+        return None
+    return raw_config.get(profile, option)
 
 
 def _set_option(raw_config, profile, option, value):

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -67,6 +67,7 @@ def test_update_and_persist_config_two_sections():
     assert config.host == TEST_HOST
     assert config.username == TEST_USER
     assert config.password == TEST_PASSWORD
+    assert config.token is None
 
 
 def test_update_and_persist_config_case_sensitive():


### PR DESCRIPTION
For the following conf
```
[DEFAULT]
host = https://logfood.cloud.databricks.com
token = dapiREDACTED

[apple]
host = https://logfood.cloud.databricks.com
username = user
password = password
```,
the token field of profile `apple` is not None but instead `dapiREDACTED`. This is very confusing.