### PR TITLE
Fix python 3 basic auth.

### DIFF
--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -72,8 +72,9 @@ class ApiClient(object):
 
         self.url = "%s/api/%s" % (host, apiVersion)
         if user is not None and password is not None:
-            userHeaderData = "Basic " + base64.standard_b64encode(user + ":" + password)
-            auth = {'Authorization': userHeaderData, 'Content-Type': 'text/json'}
+            encoded_auth = (user + ":" + password).encode()
+            user_header_data = "Basic " + base64.standard_b64encode(encoded_auth).decode()
+            auth = {'Authorization': user_header_data, 'Content-Type': 'text/json'}
         elif token is not None:
             auth = {'Authorization': 'Bearer {}'.format(token), 'Content-Type': 'text/json'}
         else:

--- a/tests/sdk/test_api_client.py
+++ b/tests/sdk/test_api_client.py
@@ -23,5 +23,9 @@
 
 from databricks_cli.sdk.api_client import ApiClient
 
+
 def test_api_client_constructor():
-    ApiClient(user='apple', password='banana', host='https://databricks.com')
+    """This used to throw when we converted <user>:<password> to base64 encoded string."""
+    client = ApiClient(user='apple', password='banana', host='https://databricks.com')
+    # echo -n "apple:banana" | base64
+    assert client.default_headers['Authorization'] == 'Basic YXBwbGU6YmFuYW5h'

--- a/tests/sdk/test_api_client.py
+++ b/tests/sdk/test_api_client.py
@@ -1,0 +1,27 @@
+# Databricks CLI
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"), except
+# that the use of services to which certain application programming
+# interfaces (each, an "API") connect requires that the user first obtain
+# a license for the use of the APIs from Databricks, Inc. ("Databricks"),
+# by creating an account at www.databricks.com and agreeing to either (a)
+# the Community Edition Terms of Service, (b) the Databricks Terms of
+# Service, or (c) another written agreement between Licensee and Databricks
+# for the use of the APIs.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from databricks_cli.sdk.api_client import ApiClient
+
+def test_api_client_constructor():
+    ApiClient(user='apple', password='banana', host='https://databricks.com')


### PR DESCRIPTION
There was a bug with python 3 basic auth encoding where we put a string into the function `base64.standard_b64encode`.