### PR TITLE
Add insecure option to configure

### DIFF
--- a/databricks_cli/configure/cli.py
+++ b/databricks_cli/configure/cli.py
@@ -36,15 +36,15 @@ PROMPT_PASSWORD = 'Password' #  NOQA
 PROMPT_TOKEN = 'Token' #  NOQA
 
 
-def _configure_cli_token(profile):
+def _configure_cli_token(profile, insecure):
     config = get_config_for_profile(profile)
     host = click.prompt(PROMPT_HOST, default=config.host, type=_DbfsHost())
     token = click.prompt(PROMPT_TOKEN, default=config.token)
-    new_config = DatabricksConfig.from_token(host, token)
+    new_config = DatabricksConfig.from_token(host, token, insecure)
     update_and_persist_config(profile, new_config)
 
 
-def _configure_cli_password(profile):
+def _configure_cli_password(profile, insecure):
     config = get_config_for_profile(profile)
     if config.password:
         default_password = '*' * len(config.password)
@@ -56,23 +56,24 @@ def _configure_cli_password(profile):
                             confirmation_prompt=True)
     if password == default_password:
         password = config.password
-    new_config = DatabricksConfig.from_password(host, username, password)
+    new_config = DatabricksConfig.from_password(host, username, password, insecure)
     update_and_persist_config(profile, new_config)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Configures host and authentication info for the CLI.')
 @click.option('--token', show_default=True, is_flag=True, default=False)
+@click.option('--insecure', show_default=True, is_flag=True, default=None)
 @profile_option
-def configure_cli(token):
+def configure_cli(token, insecure):
     """
     Configures host and authentication info for the CLI.
     """
     profile = get_profile_from_context()
     if token:
-        _configure_cli_token(profile)
+        _configure_cli_token(profile, str(insecure))
     else:
-        _configure_cli_password(profile)
+        _configure_cli_password(profile, str(insecure))
 
 
 class _DbfsHost(ParamType):

--- a/databricks_cli/configure/cli.py
+++ b/databricks_cli/configure/cli.py
@@ -70,10 +70,11 @@ def configure_cli(token, insecure):
     Configures host and authentication info for the CLI.
     """
     profile = get_profile_from_context()
+    insecure_str = str(insecure) if insecure is not None else None
     if token:
-        _configure_cli_token(profile, str(insecure))
+        _configure_cli_token(profile, insecure_str)
     else:
-        _configure_cli_password(profile, str(insecure))
+        _configure_cli_password(profile, insecure_str)
 
 
 class _DbfsHost(ParamType):

--- a/databricks_cli/configure/config.py
+++ b/databricks_cli/configure/config.py
@@ -65,7 +65,8 @@ def profile_option(f):
 
 
 def _get_api_client(config):
+    verify = config.insecure is None
     if config.is_valid_with_token:
-        return ApiClient(host=config.host, token=config.token)
+        return ApiClient(host=config.host, token=config.token, verify=verify)
     return ApiClient(user=config.username, password=config.password,
-                     host=config.host)
+                     host=config.host, verify=verify)

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -30,6 +30,7 @@ HOST = 'host'
 USERNAME = 'username'
 PASSWORD = 'password' # NOQA
 TOKEN = 'token'
+INSECURE = 'insecure'
 DEFAULT_SECTION = 'DEFAULT'
 
 
@@ -86,6 +87,7 @@ def update_and_persist_config(profile, databricks_config):
     _set_option(raw_config, profile, USERNAME, databricks_config.username)
     _set_option(raw_config, profile, PASSWORD, databricks_config.password)
     _set_option(raw_config, profile, TOKEN, databricks_config.token)
+    _set_option(raw_config, profile, INSECURE, databricks_config.insecure)
     _overwrite_config(raw_config)
 
 
@@ -100,23 +102,25 @@ def get_config_for_profile(profile):
     username = _get_option_if_exists(raw_config, profile, USERNAME)
     password = _get_option_if_exists(raw_config, profile, PASSWORD)
     token = _get_option_if_exists(raw_config, profile, TOKEN)
-    return DatabricksConfig(host, username, password, token)
+    insecure = _get_option_if_exists(raw_config, profile, INSECURE)
+    return DatabricksConfig(host, username, password, token, insecure)
 
 
 class DatabricksConfig(object):
-    def __init__(self, host, username, password, token): # noqa
+    def __init__(self, host, username, password, token, insecure): # noqa
         self.host = host
         self.username = username
         self.password = password
         self.token = token
+        self.insecure = insecure
 
     @classmethod
-    def from_token(cls, host, token):
-        return DatabricksConfig(host, None, None, token)
+    def from_token(cls, host, token, insecure=None):
+        return DatabricksConfig(host, None, None, token, insecure)
 
     @classmethod
-    def from_password(cls, host, username, password):
-        return DatabricksConfig(host, username, password, None)
+    def from_password(cls, host, username, password, insecure=None):
+        return DatabricksConfig(host, username, password, None, insecure)
 
     @property
     def is_valid_with_token(self):

--- a/tests/configure/test_cli.py
+++ b/tests/configure/test_cli.py
@@ -55,6 +55,7 @@ def test_configure_cli_token():
                   input=(TEST_HOST + '\n' + TEST_TOKEN + '\n'))
     assert get_config_for_profile(DEFAULT_SECTION).host == TEST_HOST
     assert get_config_for_profile(DEFAULT_SECTION).token == TEST_TOKEN
+    assert get_config_for_profile(DEFAULT_SECTION).insecure is None
 
 
 def test_configure_two_sections():
@@ -67,3 +68,12 @@ def test_configure_two_sections():
     assert get_config_for_profile(DEFAULT_SECTION).token == TEST_TOKEN
     assert get_config_for_profile(TEST_PROFILE).host == TEST_HOST_2
     assert get_config_for_profile(TEST_PROFILE).token == TEST_TOKEN
+
+
+def test_configure_cli_insecure():
+    runner = CliRunner()
+    runner.invoke(cli.configure_cli, ['--token', '--insecure'],
+                  input=(TEST_HOST + '\n' + TEST_TOKEN + '\n'))
+    assert get_config_for_profile(DEFAULT_SECTION).host == TEST_HOST
+    assert get_config_for_profile(DEFAULT_SECTION).token == TEST_TOKEN
+    assert get_config_for_profile(DEFAULT_SECTION).insecure == 'True'

--- a/tox-requirements.txt
+++ b/tox-requirements.txt
@@ -1,6 +1,7 @@
 # Test reqs
 prospector[with_pyroma]==0.12.7
 pylint==1.8.2
+pep8-naming==0.5.0
 pytest==3.2.1
 mock==2.0.0
 decorator==4.2.1


### PR DESCRIPTION
We would like to use the CLI against shards without proper SSL certificates. (For development purposes.)