### PR TITLE
Command Information in user-agent header API requests

### DIFF
--- a/databricks_cli/configure/config.py
+++ b/databricks_cli/configure/config.py
@@ -41,7 +41,7 @@ def provide_api_client(function):
         ctx = click.get_current_context()
         command_name = "-".join(ctx.command_path.split(" ")[1:])
         command_uuid = str(uuid.uuid1())
-        default_headers = {"cli-command-name": command_name, "cli-command-uuid": command_uuid}
+        default_headers = {'cli-command-name': command_name, 'cli-command-uuid': command_uuid}
         profile = get_profile_from_context()
         config = get_config_for_profile(profile)
         if not config.is_valid:

--- a/databricks_cli/configure/config.py
+++ b/databricks_cli/configure/config.py
@@ -36,7 +36,6 @@ def provide_api_client(function):
     Injects the api_client keyword argument to the wrapped function.
     All callbacks wrapped by provide_api_client expect the argument ``profile`` to be passed in.
     """
-    # @click.pass_context
     @six.wraps(function)
     def decorator(*args, **kwargs):
         ctx = click.get_current_context()

--- a/databricks_cli/configure/config.py
+++ b/databricks_cli/configure/config.py
@@ -35,6 +35,7 @@ def provide_api_client(function):
     Injects the api_client keyword argument to the wrapped function.
     All callbacks wrapped by provide_api_client expect the argument ``profile`` to be passed in.
     """
+    click.echo(function.__name__)
     @six.wraps(function)
     def decorator(*args, **kwargs):
         profile = get_profile_from_context()
@@ -64,7 +65,7 @@ def profile_option(f):
                         help='CLI connection profile to use. The default profile is "DEFAULT".')(f)
 
 
-def _get_api_client(config):
+def _get_api_client(config, command_name=None):
     verify = config.insecure is None
     if config.is_valid_with_token:
         return ApiClient(host=config.host, token=config.token, verify=verify)

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -62,8 +62,8 @@ class ApiClient(object):
     A partial Python implementation of dbc rest api
     to be used by different versions of the client.
     """
-    def __init__(self, user = None, password = None, host = None, token = None,
-                 apiVersion = version.API_VERSION, default_headers = {}, verify = True):
+    def __init__(self, user=None, password=None, host=None, token=None,
+                 apiVersion=version.API_VERSION, default_headers={}, verify=True, command_name=""):
         if host[-1] == "/":
             host = host[:-1]
 
@@ -79,7 +79,8 @@ class ApiClient(object):
             auth = {'Authorization': 'Bearer {}'.format(token), 'Content-Type': 'text/json'}
         else:
             auth = {}
-        user_agent = {'user-agent': 'databricks-cli-{v}'.format(v=databricks_cli_version)}
+        user_agent = {'user-agent': 'databricks-cli-{v}-{c}'.format(v=databricks_cli_version,
+                                                                    c=command_name)}
         self.default_headers = {}
         self.default_headers.update(auth)
         self.default_headers.update(default_headers)

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -64,14 +64,14 @@ class ApiClient(object):
     """
     def __init__(self, user = None, password = None, host = None, token = None,
                  apiVersion = version.API_VERSION, default_headers = {}, verify = True):
-        self.host = host
-        if self.host[-1] == "/":
-            self.host = self.host[:-1]
+        host = host
+        if host[-1] == "/":
+            host = host[:-1]
 
         self.session = requests.Session()
         self.session.mount('https://', TlsV1HttpAdapter())
 
-        self.url = "%s/api/%s" % (self.host, apiVersion)
+        self.url = "%s/api/%s" % (host, apiVersion)
         if user is not None and password is not None:
             encoded_auth = (user + ":" + password).encode()
             user_header_data = "Basic " + base64.standard_b64encode(encoded_auth).decode()

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -64,7 +64,6 @@ class ApiClient(object):
     """
     def __init__(self, user = None, password = None, host = None, token = None,
                  apiVersion = version.API_VERSION, default_headers = {}, verify = True):
-        host = host
         if host[-1] == "/":
             host = host[:-1]
 

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -64,13 +64,14 @@ class ApiClient(object):
     """
     def __init__(self, user = None, password = None, host = None, token = None,
                  apiVersion = version.API_VERSION, default_headers = {}, verify = True):
-        if host[-1] == "/":
-            host = host[:-1]
+        self.host = host
+        if self.host[-1] == "/":
+            self.host = self.host[:-1]
 
         self.session = requests.Session()
         self.session.mount('https://', TlsV1HttpAdapter())
 
-        self.url = "%s/api/%s" % (host, apiVersion)
+        self.url = "%s/api/%s" % (self.host, apiVersion)
         if user is not None and password is not None:
             encoded_auth = (user + ":" + password).encode()
             user_header_data = "Basic " + base64.standard_b64encode(encoded_auth).decode()

--- a/tests/configure/test_config.py
+++ b/tests/configure/test_config.py
@@ -105,11 +105,14 @@ def test_command_headers():
         click.echo(json.dumps(api_client.default_headers))
 
     with mock.patch("databricks_cli.configure.provider.DatabricksConfig") as ConfigMock:
-        ConfigMock.return_value = DatabricksConfig.from_token(TEST_HOST, TEST_TOKEN)
-        test_group_2.add_command(test_command, 'test')
-        test_group.add_command(test_group_2, 'my')
-        result = CliRunner().invoke(test_group, ['my', 'test', '--x', '1'])
-        default_headers = json.loads(result.output)
-        assert 'cli-command-name' in default_headers
-        assert 'cli-command-uuid' in default_headers
-        assert default_headers['cli-command-name'] == "my-test"
+        with mock.patch("uuid.uuid1") as uuid_mock:
+            ConfigMock.return_value = DatabricksConfig.from_token(TEST_HOST, TEST_TOKEN)
+            uuid_mock.return_value = '1234'
+            test_group_2.add_command(test_command, 'test')
+            test_group.add_command(test_group_2, 'my')
+            result = CliRunner().invoke(test_group, ['my', 'test', '--x', '1'])
+            default_headers = json.loads(result.output)
+            assert 'cli-command-name' in default_headers
+            assert 'cli-command-uuid' in default_headers
+            assert default_headers['cli-command-name'] == "my-test"
+            assert default_headers['cli-command-uuid'] == '1234'

--- a/tests/configure/test_config.py
+++ b/tests/configure/test_config.py
@@ -101,7 +101,7 @@ def test_command_headers():
     @click.command()
     @config.profile_option
     @config.provide_api_client
-    def test_command(api_client, x): # noqa
+    def test_command(api_client): # noqa
         click.echo(json.dumps(api_client.default_headers))
 
     with mock.patch("databricks_cli.configure.provider.DatabricksConfig") as ConfigMock:
@@ -110,7 +110,7 @@ def test_command_headers():
             uuid_mock.return_value = '1234'
             test_group_2.add_command(test_command, 'test')
             test_group.add_command(test_group_2, 'my')
-            result = CliRunner().invoke(test_group, ['my', 'test', '--x', '1'])
+            result = CliRunner().invoke(test_group, ['my', 'test'])
             default_headers = json.loads(result.output)
             assert 'cli-command-name' in default_headers
             assert 'cli-command-uuid' in default_headers

--- a/tests/configure/test_config.py
+++ b/tests/configure/test_config.py
@@ -109,10 +109,10 @@ def test_command_headers():
         with mock.patch("uuid.uuid1") as uuid_mock:
             config_mock.return_value = DatabricksConfig.from_token(TEST_HOST, TEST_TOKEN)
             uuid_mock.return_value = '1234'
-            inner_test_group.add_command(test_command, 'test-command')
-            outer_test_group.add_command(inner_test_group, 'my')
-            result = CliRunner().invoke(outer_test_group, ['my', 'test-command', '--x', '12'])
+            inner_test_group.add_command(test_command, 'subcommand')
+            outer_test_group.add_command(inner_test_group, 'command')
+            result = CliRunner().invoke(outer_test_group, ['command', 'subcommand', '--x', '12'])
             assert result.exception is None
             default_headers = json.loads(result.output)
             assert 'user-agent' in default_headers
-            assert "my-test-command-1234" in default_headers['user-agent']
+            assert "command-subcommand-1234" in default_headers['user-agent']


### PR DESCRIPTION
Appended the command and subcommand along with a randomly generated UUID into the user-agent header. The command and subcommand are extracted from the click context command path while the uuid is generated from uuid.uuid1, which ensures uniqueness between users and commands through temporal and machine-specific features.

Ex. For a the command `databricks jobs get`:
Headers: `{"user-agent": "databricks-cli-v0.xx-jobs-get-1234-5678"...}`