### PR TITLE
Make `host` a class attribute of databricks.api_client.ApiClient

### DIFF
--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -64,13 +64,14 @@ class ApiClient(object):
     """
     def __init__(self, user = None, password = None, host = None, token = None,
                  apiVersion = version.API_VERSION, default_headers = {}, verify = True):
-        if host[-1] == "/":
-            host = host[:-1]
+        self.host = host
+        if self.host[-1] == "/":
+            self.host = self.host[:-1]
 
         self.session = requests.Session()
         self.session.mount('https://', TlsV1HttpAdapter())
 
-        self.url = "%s/api/%s" % (host, apiVersion)
+        self.url = "%s/api/%s" % (self.host, apiVersion)
         if user is not None and password is not None:
             encoded_auth = (user + ":" + password).encode()
             user_header_data = "Basic " + base64.standard_b64encode(encoded_auth).decode()


### PR DESCRIPTION
Small change to make host a class attribute of the ApiClient. This can be useful for implementing the display of links to jobs or notebooks on Databricks in the CLI output.