### PR TITLE
Add get_jobs_by_name function in Jobs API

### DIFF
--- a/databricks_cli/jobs/api.py
+++ b/databricks_cli/jobs/api.py
@@ -40,7 +40,7 @@ class JobsApi(object):
         return self.client.get_job(job_id)
 
     def get_jobs_by_name(self, full_job_name):
-        jobs = self.client.list_jobs()['jobs']
+        jobs = self.list_jobs()['jobs']
         result = list(filter(lambda job: job['settings']['name'] == full_job_name, jobs))
         return result
 

--- a/databricks_cli/jobs/api.py
+++ b/databricks_cli/jobs/api.py
@@ -39,6 +39,11 @@ class JobsApi(object):
     def get_job(self, job_id):
         return self.client.get_job(job_id)
 
+    def get_jobs_by_name(self, full_job_name):
+        jobs = self.client.list_jobs()['jobs']
+        result = list(filter(lambda job: job['settings']['name'] == full_job_name, jobs))
+        return result
+
     def reset_job(self, json):
         return self.client.client.perform_query('POST', '/jobs/reset', data=json)
 

--- a/databricks_cli/jobs/api.py
+++ b/databricks_cli/jobs/api.py
@@ -39,14 +39,14 @@ class JobsApi(object):
     def get_job(self, job_id):
         return self.client.get_job(job_id)
 
-    def get_jobs_by_name(self, name):
-        jobs = self.list_jobs()['jobs']
-        result = list(filter(lambda job: job['settings']['name'] == name, jobs))
-        return result
-
     def reset_job(self, json):
         return self.client.client.perform_query('POST', '/jobs/reset', data=json)
 
     def run_now(self, job_id, jar_params, notebook_params, python_params, spark_submit_params):
         return self.client.run_now(job_id, jar_params, notebook_params, python_params,
                                    spark_submit_params)
+
+    def _list_jobs_by_name(self, name):
+        jobs = self.list_jobs()['jobs']
+        result = list(filter(lambda job: job['settings']['name'] == name, jobs))
+        return result

--- a/databricks_cli/jobs/api.py
+++ b/databricks_cli/jobs/api.py
@@ -39,9 +39,9 @@ class JobsApi(object):
     def get_job(self, job_id):
         return self.client.get_job(job_id)
 
-    def get_jobs_by_name(self, full_job_name):
+    def get_jobs_by_name(self, name):
         jobs = self.list_jobs()['jobs']
-        result = list(filter(lambda job: job['settings']['name'] == full_job_name, jobs))
+        result = list(filter(lambda job: job['settings']['name'] == name, jobs))
         return result
 
     def reset_job(self, json):

--- a/tests/jobs/test_api.py
+++ b/tests/jobs/test_api.py
@@ -43,24 +43,24 @@ def jobs_api():
 
 @provide_conf
 def test_get_jobs_by_name(jobs_api):
-    job_name = 'test job'
-    job_other_name = 'test job alt'
-    test_job = {'settings': {'name': job_name}}
-    test_job_alt = {'settings': {'name': job_other_name}}
+    test_job_name = 'test job'
+    test_job_alt_name = 'test job alt'
+    test_job = {'settings': {'name': test_job_name}}
+    test_job_alt = {'settings': {'name': test_job_alt_name}}
     jobs_api.list_jobs = mock.MagicMock()
 
     jobs_api.list_jobs.return_value = {'jobs': []}
-    res = jobs_api.get_jobs_by_name(job_name)
+    res = jobs_api.get_jobs_by_name(test_job_name)
     assert len(res) == 0
 
     jobs_api.list_jobs.return_value = {'jobs': [test_job_alt]}
-    res = jobs_api.get_jobs_by_name(job_name)
+    res = jobs_api.get_jobs_by_name(test_job_name)
     assert len(res) == 0
 
     jobs_api.list_jobs.return_value = {'jobs': [test_job, test_job_alt]}
-    res = jobs_api.get_jobs_by_name(job_name)
+    res = jobs_api.get_jobs_by_name(test_job_name)
     assert len(res) == 1
 
     jobs_api.list_jobs.return_value = {'jobs': [test_job, test_job_alt, test_job]}
-    res = jobs_api.get_jobs_by_name(job_name)
+    res = jobs_api.get_jobs_by_name(test_job_name)
     assert len(res) == 2

--- a/tests/jobs/test_api.py
+++ b/tests/jobs/test_api.py
@@ -1,0 +1,66 @@
+# Databricks CLI
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"), except
+# that the use of services to which certain application programming
+# interfaces (each, an "API") connect requires that the user first obtain
+# a license for the use of the APIs from Databricks, Inc. ("Databricks"),
+# by creating an account at www.databricks.com and agreeing to either (a)
+# the Community Edition Terms of Service, (b) the Databricks Terms of
+# Service, or (c) another written agreement between Licensee and Databricks
+# for the use of the APIs.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint:disable=redefined-outer-name
+
+import mock
+import pytest
+
+from databricks_cli.jobs.api import JobsApi
+from tests.utils import provide_conf
+
+CREATE_RETURN = {'job_id': 5}
+CREATE_JSON = '{"name": "test_job"}'
+
+
+@pytest.fixture()
+def jobs_api():
+    with mock.patch('databricks_cli.sdk.JobsService') as jobs_service_mock:
+        jobs_service_mock.return_value = mock.MagicMock()
+        jobs_api_mock = JobsApi(None)
+        yield jobs_api_mock
+
+
+@provide_conf
+def test_get_jobs_by_name(jobs_api):
+    job_name = 'test job'
+    job_other_name = 'test job alt'
+    test_job = {'settings': {'name': job_name}}
+    test_job_alt = {'settings': {'name': job_other_name}}
+    jobs_api.list_jobs = mock.MagicMock()
+
+    jobs_api.list_jobs.return_value = {'jobs': []}
+    res = jobs_api.get_jobs_by_name(job_name)
+    assert len(res) == 0
+
+    jobs_api.list_jobs.return_value = {'jobs': [test_job_alt]}
+    res = jobs_api.get_jobs_by_name(job_name)
+    assert len(res) == 0
+
+    jobs_api.list_jobs.return_value = {'jobs': [test_job, test_job_alt]}
+    res = jobs_api.get_jobs_by_name(job_name)
+    assert len(res) == 1
+
+    jobs_api.list_jobs.return_value = {'jobs': [test_job, test_job_alt, test_job]}
+    res = jobs_api.get_jobs_by_name(job_name)
+    assert len(res) == 2

--- a/tests/jobs/test_api.py
+++ b/tests/jobs/test_api.py
@@ -29,9 +29,6 @@ import pytest
 from databricks_cli.jobs.api import JobsApi
 from tests.utils import provide_conf
 
-CREATE_RETURN = {'job_id': 5}
-CREATE_JSON = '{"name": "test_job"}'
-
 
 @pytest.fixture()
 def jobs_api():
@@ -42,7 +39,7 @@ def jobs_api():
 
 
 @provide_conf
-def test_get_jobs_by_name(jobs_api):
+def test_list_jobs_by_name(jobs_api):
     test_job_name = 'test job'
     test_job_alt_name = 'test job alt'
     test_job = {'settings': {'name': test_job_name}}
@@ -50,17 +47,20 @@ def test_get_jobs_by_name(jobs_api):
     jobs_api.list_jobs = mock.MagicMock()
 
     jobs_api.list_jobs.return_value = {'jobs': []}
-    res = jobs_api.get_jobs_by_name(test_job_name)
+    res = jobs_api._list_jobs_by_name(test_job_name)
     assert len(res) == 0
 
     jobs_api.list_jobs.return_value = {'jobs': [test_job_alt]}
-    res = jobs_api.get_jobs_by_name(test_job_name)
+    res = jobs_api._list_jobs_by_name(test_job_name)
     assert len(res) == 0
 
     jobs_api.list_jobs.return_value = {'jobs': [test_job, test_job_alt]}
-    res = jobs_api.get_jobs_by_name(test_job_name)
+    res = jobs_api._list_jobs_by_name(test_job_name)
     assert len(res) == 1
+    assert res[0]['settings']['name'] == test_job_name
 
     jobs_api.list_jobs.return_value = {'jobs': [test_job, test_job_alt, test_job]}
-    res = jobs_api.get_jobs_by_name(test_job_name)
+    res = jobs_api._list_jobs_by_name(test_job_name)
     assert len(res) == 2
+    assert res[0]['settings']['name'] == test_job_name
+    assert res[1]['settings']['name'] == test_job_name


### PR DESCRIPTION
The get_jobs_by_name function takes in a job name and returns a list of the jobs that have the same name. If no jobs have the same name as the inputted job, an empty list will be returned. 