### PR TITLE
Add / after directory names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 *.swo
 .cache
 .*project
+.idea/*
+*.iml
 env

--- a/databricks_cli/workspace/api.py
+++ b/databricks_cli/workspace/api.py
@@ -45,7 +45,7 @@ class WorkspaceFileInfo(object):
     def to_row(self, is_long_form, is_absolute):
         path = self.path if is_absolute else self.basename
         if self.is_dir:
-            stylized_path = click.style(path, 'cyan')
+            stylized_path = click.style(path, 'cyan') + '/'
         elif self.is_library:
             stylized_path = click.style(path, 'green')
         else:


### PR DESCRIPTION
While "databricks workspace ls -l" will specify a file is a directory, for scripting purposes, it's easier if "databricks workspace ls" includes a / at the end of directory names.

This PR adds a "/" after directory names.  If we are really worried about backward compatibility we could add an option "databricks workspace ls -F" to optionally include the "/" instead, but I'm not sure that's needed.