### PR TITLE
Add global --debug flag

### DIFF
--- a/databricks_cli/cli.py
+++ b/databricks_cli/cli.py
@@ -23,7 +23,7 @@
 
 import click
 
-from databricks_cli.configure.config import profile_option
+from databricks_cli.configure.config import profile_option, debug_option
 from databricks_cli.libraries.cli import libraries_group
 from databricks_cli.version import print_version_callback, version
 from databricks_cli.utils import CONTEXT_SETTINGS
@@ -40,6 +40,7 @@ from databricks_cli.stack.cli import stack_group
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.option('--version', '-v', is_flag=True, callback=print_version_callback,
               expose_value=False, is_eager=True, help=version)
+@debug_option
 @profile_option
 def cli():
     pass

--- a/databricks_cli/click_types.py
+++ b/databricks_cli/click_types.py
@@ -101,12 +101,20 @@ class OneOfOption(Option):
 class ContextObject(object):
     def __init__(self):
         self._profile = None
+        self._debug = False
 
     def set_profile(self, profile):
         if self._profile is not None:
             raise UsageError('--profile can only be provided once. '
                              'The profiles [{}, {}] were provided.'.format(self._profile, profile))
         self._profile = profile
+
+    def set_debug(self, debug=False):
+        self._debug = debug
+
+    @property
+    def debug_mode(self):
+        return self._debug
 
     def get_profile(self):
         if self._profile is None:

--- a/databricks_cli/click_types.py
+++ b/databricks_cli/click_types.py
@@ -103,18 +103,18 @@ class ContextObject(object):
         self._profile = None
         self._debug = False
 
-    def set_profile(self, profile):
-        if self._profile is not None:
-            raise UsageError('--profile can only be provided once. '
-                             'The profiles [{}, {}] were provided.'.format(self._profile, profile))
-        self._profile = profile
-
     def set_debug(self, debug=False):
         self._debug = debug
 
     @property
     def debug_mode(self):
         return self._debug
+
+    def set_profile(self, profile):
+        if self._profile is not None:
+            raise UsageError('--profile can only be provided once. '
+                             'The profiles [{}, {}] were provided.'.format(self._profile, profile))
+        self._profile = profile
 
     def get_profile(self):
         if self._profile is None:

--- a/databricks_cli/configure/config.py
+++ b/databricks_cli/configure/config.py
@@ -58,6 +58,14 @@ def get_profile_from_context():
     return context_object.get_profile()
 
 
+def debug_option(f):
+    def callback(ctx, param, value):
+        context_object = ctx.ensure_object(ContextObject)
+        context_object.set_debug(value)
+    return click.option('--debug', '-d', is_flag=True, callback=callback,
+                        expose_value=False, help="Debug Mode. Shows full stack trace.")(f)
+
+
 def profile_option(f):
     def callback(ctx, param, value): #  NOQA
         if value is not None:

--- a/databricks_cli/configure/config.py
+++ b/databricks_cli/configure/config.py
@@ -62,7 +62,7 @@ def debug_option(f):
     def callback(ctx, param, value): #  NOQA
         context_object = ctx.ensure_object(ContextObject)
         context_object.set_debug(value)
-    return click.option('--debug', '-d', is_flag=True, callback=callback,
+    return click.option('--debug', is_flag=True, callback=callback,
                         expose_value=False, help="Debug Mode. Shows full stack trace on error.")(f)
 
 

--- a/databricks_cli/configure/config.py
+++ b/databricks_cli/configure/config.py
@@ -59,11 +59,11 @@ def get_profile_from_context():
 
 
 def debug_option(f):
-    def callback(ctx, param, value):
+    def callback(ctx, param, value): #  NOQA
         context_object = ctx.ensure_object(ContextObject)
         context_object.set_debug(value)
     return click.option('--debug', '-d', is_flag=True, callback=callback,
-                        expose_value=False, help="Debug Mode. Shows full stack trace.")(f)
+                        expose_value=False, help="Debug Mode. Shows full stack trace on error.")(f)
 
 
 def profile_option(f):

--- a/databricks_cli/utils.py
+++ b/databricks_cli/utils.py
@@ -22,6 +22,7 @@
 # limitations under the License.
 
 import sys
+import traceback
 from json import dumps as json_dumps, loads as json_loads
 
 import click
@@ -29,6 +30,7 @@ import six
 from requests.exceptions import HTTPError
 
 from databricks_cli.configure.provider import DEFAULT_SECTION
+from databricks_cli.click_types import ContextObject
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 DEBUG_MODE = False
@@ -48,11 +50,16 @@ def eat_exceptions(function):
         except Exception as exception: # noqa
             if not DEBUG_MODE:
                 error_and_quit('{}: {}'.format(type(exception).__name__, str(exception)))
+
     decorator.__doc__ = function.__doc__
     return decorator
 
 
 def error_and_quit(message):
+    ctx = click.get_current_context()
+    context_object = ctx.ensure_object(ContextObject)
+    if context_object.debug_mode:
+        traceback.print_exc()
     click.echo('Error: {}'.format(message))
     sys.exit(1)
 

--- a/databricks_cli/utils.py
+++ b/databricks_cli/utils.py
@@ -50,7 +50,6 @@ def eat_exceptions(function):
         except Exception as exception: # noqa
             if not DEBUG_MODE:
                 error_and_quit('{}: {}'.format(type(exception).__name__, str(exception)))
-
     decorator.__doc__ = function.__doc__
     return decorator
 

--- a/tests/configure/test_config.py
+++ b/tests/configure/test_config.py
@@ -28,9 +28,40 @@ import click
 from click.testing import CliRunner
 
 import databricks_cli.configure.config as config
-from databricks_cli.utils import InvalidConfigurationError
+from databricks_cli.utils import InvalidConfigurationError, eat_exceptions
 from databricks_cli.configure.provider import DatabricksConfig
+from databricks_cli.click_types import ContextObject
 from tests.utils import provide_conf
+
+
+@provide_conf
+def test_debug_option():
+    # Test if context object debug_mode property
+    @click.command()
+    @click.option('--debug-fed')
+    @config.debug_option
+    def test_debug(debug_fed): # noqa
+        ctx = click.get_current_context()
+        context_object = ctx.ensure_object(ContextObject)
+        assert context_object.debug_mode is debug_fed
+    result = CliRunner().invoke(test_debug, ['--debug', '--debug-fed', True])
+    assert result.exit_code == 0
+    result = CliRunner().invoke(test_debug, ['--debug-fed', False])
+    assert result.exit_code == 0
+
+    # Test that with eat_exceptions wrapper, 'Traceback' appears or doesn't appear depending on
+    # Whether --debug flag is given.
+    @click.command()
+    @config.debug_option
+    @eat_exceptions
+    def test_debug_traceback():  # noqa
+        assert False
+    result = CliRunner().invoke(test_debug_traceback, ['--debug'])
+    assert result.exit_code == 1
+    assert 'Traceback' in result.output
+    result = CliRunner().invoke(test_debug_traceback)
+    assert result.exit_code == 1
+    assert 'Traceback' not in result.output
 
 
 @provide_conf

--- a/tests/configure/test_config.py
+++ b/tests/configure/test_config.py
@@ -36,7 +36,7 @@ from tests.utils import provide_conf
 
 @provide_conf
 def test_debug_option():
-    # Test if context object debug_mode property
+    # Test that context object debug_mode property changes with --debug flag fed.
     @click.command()
     @click.option('--debug-fed')
     @config.debug_option
@@ -50,7 +50,7 @@ def test_debug_option():
     assert result.exit_code == 0
 
     # Test that with eat_exceptions wrapper, 'Traceback' appears or doesn't appear depending on
-    # Whether --debug flag is given.
+    # whether --debug flag is given.
     @click.command()
     @config.debug_option
     @eat_exceptions


### PR DESCRIPTION
Added `debug_mode` property in `ContextObject` to be accessed by the `error_and_quit` function in `utils.py`

For Issue: https://github.com/databricks/databricks-cli/issues/110 