### PR TITLE
Enable Python clients to set an overriding DatabricksConfigProvider

### DIFF
--- a/databricks_cli/click_types.py
+++ b/databricks_cli/click_types.py
@@ -23,8 +23,6 @@
 
 from click import ParamType, Option, MissingParameter, UsageError
 
-from databricks_cli.configure.provider import DEFAULT_SECTION
-
 
 class OutputClickType(ParamType):
     name = 'FORMAT'
@@ -117,6 +115,4 @@ class ContextObject(object):
         self._profile = profile
 
     def get_profile(self):
-        if self._profile is None:
-            return DEFAULT_SECTION
         return self._profile

--- a/databricks_cli/configure/cli.py
+++ b/databricks_cli/configure/cli.py
@@ -26,7 +26,7 @@ import click
 from click import ParamType
 
 from databricks_cli.configure.provider import DatabricksConfig, update_and_persist_config, \
-    get_config_for_profile
+    ProfileConfigProvider
 from databricks_cli.utils import CONTEXT_SETTINGS
 from databricks_cli.configure.config import profile_option, get_profile_from_context, debug_option
 
@@ -37,7 +37,7 @@ PROMPT_TOKEN = 'Token' #  NOQA
 
 
 def _configure_cli_token(profile, insecure):
-    config = get_config_for_profile(profile)
+    config = ProfileConfigProvider(profile).get_config() or DatabricksConfig.empty()
     host = click.prompt(PROMPT_HOST, default=config.host, type=_DbfsHost())
     token = click.prompt(PROMPT_TOKEN, default=config.token)
     new_config = DatabricksConfig.from_token(host, token, insecure)
@@ -45,7 +45,7 @@ def _configure_cli_token(profile, insecure):
 
 
 def _configure_cli_password(profile, insecure):
-    config = get_config_for_profile(profile)
+    config = ProfileConfigProvider(profile).get_config() or DatabricksConfig.empty()
     if config.password:
         default_password = '*' * len(config.password)
     else:

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -249,6 +249,10 @@ class DatabricksConfig(object):
     def from_password(cls, host, username, password, insecure=None):
         return DatabricksConfig(host, username, password, None, insecure)
 
+    @classmethod
+    def empty(cls):
+        return DatabricksConfig(None, None, None, None, None)
+
     @property
     def is_valid_with_token(self):
         return self.host is not None and self.token is not None

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -88,6 +88,7 @@ def update_and_persist_config(profile, databricks_config):
     same profile.
     :param databricks_config: DatabricksConfig
     """
+    profile = profile if profile else DEFAULT_SECTION
     raw_config = _fetch_from_fs()
     _create_section_if_absent(raw_config, profile)
     _set_option(raw_config, profile, HOST, databricks_config.host)
@@ -136,6 +137,7 @@ def get_config_for_profile(profile):
 
     :return: DatabricksConfig
     """
+    profile = profile if profile else DEFAULT_SECTION
     config = EnvironmentVariableConfigProvider().get_config()
     if config and config.is_valid:
         return config
@@ -219,9 +221,6 @@ class ProfileConfigProvider(DatabrickConfigProvider):
         self.profile = profile
 
     def get_config(self):
-        if not os.path.exists(_get_path()):
-            return None
-
         raw_config = _fetch_from_fs()
         host = _get_option_if_exists(raw_config, self.profile, HOST)
         username = _get_option_if_exists(raw_config, self.profile, USERNAME)

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -186,7 +186,6 @@ class DatabrickConfigProvider(object):
 class DefaultConfigProvider(DatabrickConfigProvider):
     """Prefers environment variables, and then the default profile."""
     def __init__(self):
-        super(DatabrickConfigProvider, self).__init__()
         self.env_provider = EnvironmentVariableConfigProvider()
         self.default_profile_provider = ProfileConfigProvider()
 
@@ -217,7 +216,6 @@ class EnvironmentVariableConfigProvider(DatabrickConfigProvider):
 class ProfileConfigProvider(DatabrickConfigProvider):
     """Loads from the databrickscfg file."""
     def __init__(self, profile=DEFAULT_SECTION):
-        super(DatabrickConfigProvider, self).__init__()
         self.profile = profile
 
     def get_config(self):

--- a/databricks_cli/utils.py
+++ b/databricks_cli/utils.py
@@ -29,7 +29,6 @@ import click
 import six
 from requests.exceptions import HTTPError
 
-from databricks_cli.configure.provider import DEFAULT_SECTION
 from databricks_cli.click_types import ContextObject
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
@@ -88,13 +87,14 @@ def truncate_string(s, length=100):
 
 
 class InvalidConfigurationError(RuntimeError):
-    def __init__(self, profile=DEFAULT_SECTION):
-        if profile == DEFAULT_SECTION:
-            message = ('You haven\'t configured the CLI yet! '
-                       'Please configure by entering `{} configure`'.format(sys.argv[0]))
-        else:
-            message = ('You haven\'t configured the CLI yet for the profile {profile}! '
-                       'Please configure by entering '
-                       '`{argv} configure --profile {profile}`').format(
-                profile=profile, argv=sys.argv[0])
-        super(InvalidConfigurationError, self).__init__(message)
+    @staticmethod
+    def for_profile(profile):
+        if profile == None:
+            return InvalidConfigurationError(
+                'You haven\'t configured the CLI yet! '
+                'Please configure by entering `{} configure`'.format(sys.argv[0]))
+        return InvalidConfigurationError(
+            ('You haven\'t configured the CLI yet for the profile {profile}! '
+             'Please configure by entering '
+             '`{argv} configure --profile {profile}`').format(
+                profile=profile, argv=sys.argv[0]))

--- a/databricks_cli/utils.py
+++ b/databricks_cli/utils.py
@@ -89,7 +89,7 @@ def truncate_string(s, length=100):
 class InvalidConfigurationError(RuntimeError):
     @staticmethod
     def for_profile(profile):
-        if profile == None:
+        if profile is None:
             return InvalidConfigurationError(
                 'You haven\'t configured the CLI yet! '
                 'Please configure by entering `{} configure`'.format(sys.argv[0]))

--- a/tests/configure/test_cli.py
+++ b/tests/configure/test_cli.py
@@ -39,11 +39,14 @@ TEST_HOST_2 = 'https://test2.cloud.databricks.com'
 
 def test_configure_cli():
     runner = CliRunner()
-    runner.invoke(cli.configure_cli,
+    result = runner.invoke(cli.configure_cli,
                   input=(TEST_HOST + '\n' +
                          TEST_USER + '\n' +
                          TEST_PASSWORD + '\n' +
                          TEST_PASSWORD + '\n'))
+    print("Exit code = %s" % result.exit_code)
+    print(result.output)
+    print(result.exception)
     assert get_config_for_profile(DEFAULT_SECTION).host == TEST_HOST
     assert get_config_for_profile(DEFAULT_SECTION).username == TEST_USER
     assert get_config_for_profile(DEFAULT_SECTION).password == TEST_PASSWORD

--- a/tests/configure/test_cli.py
+++ b/tests/configure/test_cli.py
@@ -39,11 +39,11 @@ TEST_HOST_2 = 'https://test2.cloud.databricks.com'
 
 def test_configure_cli():
     runner = CliRunner()
-    result = runner.invoke(cli.configure_cli,
-                           input=(TEST_HOST + '\n' +
-                                  TEST_USER + '\n' +
-                                  TEST_PASSWORD + '\n' +
-                                  TEST_PASSWORD + '\n'))
+    runner.invoke(cli.configure_cli,
+                  input=(TEST_HOST + '\n' +
+                         TEST_USER + '\n' +
+                         TEST_PASSWORD + '\n' +
+                         TEST_PASSWORD + '\n'))
     assert get_config().host == TEST_HOST
     assert get_config().username == TEST_USER
     assert get_config().password == TEST_PASSWORD

--- a/tests/configure/test_cli.py
+++ b/tests/configure/test_cli.py
@@ -40,13 +40,10 @@ TEST_HOST_2 = 'https://test2.cloud.databricks.com'
 def test_configure_cli():
     runner = CliRunner()
     result = runner.invoke(cli.configure_cli,
-                  input=(TEST_HOST + '\n' +
-                         TEST_USER + '\n' +
-                         TEST_PASSWORD + '\n' +
-                         TEST_PASSWORD + '\n'))
-    print("Exit code = %s" % result.exit_code)
-    print(result.output)
-    print(result.exception)
+                           input=(TEST_HOST + '\n' +
+                                  TEST_USER + '\n' +
+                                  TEST_PASSWORD + '\n' +
+                                  TEST_PASSWORD + '\n'))
     assert get_config().host == TEST_HOST
     assert get_config().username == TEST_USER
     assert get_config().password == TEST_PASSWORD

--- a/tests/configure/test_cli.py
+++ b/tests/configure/test_cli.py
@@ -26,7 +26,7 @@
 from click.testing import CliRunner
 
 import databricks_cli.configure.cli as cli
-from databricks_cli.configure.provider import get_config_for_profile, DEFAULT_SECTION
+from databricks_cli.configure.provider import get_config, ProfileConfigProvider
 
 TEST_HOST = 'https://test.cloud.databricks.com'
 TEST_USER = 'monkey@databricks.com'
@@ -47,18 +47,18 @@ def test_configure_cli():
     print("Exit code = %s" % result.exit_code)
     print(result.output)
     print(result.exception)
-    assert get_config_for_profile(DEFAULT_SECTION).host == TEST_HOST
-    assert get_config_for_profile(DEFAULT_SECTION).username == TEST_USER
-    assert get_config_for_profile(DEFAULT_SECTION).password == TEST_PASSWORD
+    assert get_config().host == TEST_HOST
+    assert get_config().username == TEST_USER
+    assert get_config().password == TEST_PASSWORD
 
 
 def test_configure_cli_token():
     runner = CliRunner()
     runner.invoke(cli.configure_cli, ['--token'],
                   input=(TEST_HOST + '\n' + TEST_TOKEN + '\n'))
-    assert get_config_for_profile(DEFAULT_SECTION).host == TEST_HOST
-    assert get_config_for_profile(DEFAULT_SECTION).token == TEST_TOKEN
-    assert get_config_for_profile(DEFAULT_SECTION).insecure is None
+    assert get_config().host == TEST_HOST
+    assert get_config().token == TEST_TOKEN
+    assert get_config().insecure is None
 
 
 def test_configure_two_sections():
@@ -67,16 +67,16 @@ def test_configure_two_sections():
                   input=(TEST_HOST + '\n' + TEST_TOKEN + '\n'))
     runner.invoke(cli.configure_cli, ['--token', '--profile', TEST_PROFILE],
                   input=(TEST_HOST_2 + '\n' + TEST_TOKEN + '\n'))
-    assert get_config_for_profile(DEFAULT_SECTION).host == TEST_HOST
-    assert get_config_for_profile(DEFAULT_SECTION).token == TEST_TOKEN
-    assert get_config_for_profile(TEST_PROFILE).host == TEST_HOST_2
-    assert get_config_for_profile(TEST_PROFILE).token == TEST_TOKEN
+    assert get_config().host == TEST_HOST
+    assert get_config().token == TEST_TOKEN
+    assert ProfileConfigProvider(TEST_PROFILE).get_config().host == TEST_HOST_2
+    assert ProfileConfigProvider(TEST_PROFILE).get_config().token == TEST_TOKEN
 
 
 def test_configure_cli_insecure():
     runner = CliRunner()
     runner.invoke(cli.configure_cli, ['--token', '--insecure'],
                   input=(TEST_HOST + '\n' + TEST_TOKEN + '\n'))
-    assert get_config_for_profile(DEFAULT_SECTION).host == TEST_HOST
-    assert get_config_for_profile(DEFAULT_SECTION).token == TEST_TOKEN
-    assert get_config_for_profile(DEFAULT_SECTION).insecure == 'True'
+    assert get_config().host == TEST_HOST
+    assert get_config().token == TEST_TOKEN
+    assert get_config().insecure == 'True'

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -21,9 +21,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import patch
 import os
 import pytest
+
+from mock import patch
 from databricks_cli.configure.provider import DatabricksConfig, DEFAULT_SECTION, \
     update_and_persist_config, get_config_for_profile, get_config, \
     set_config_provider, ProfileConfigProvider, _get_path, DatabrickConfigProvider
@@ -185,4 +186,3 @@ def test_get_config_override_custom():
 def test_get_config_bad_override():
     with pytest.raises(Exception):
         set_config_provider("NotAConfigProvider")
-

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -20,9 +20,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from mock import patch
+import os
+import pytest
 from databricks_cli.configure.provider import DatabricksConfig, DEFAULT_SECTION, \
-    update_and_persist_config, get_config_for_profile
+    update_and_persist_config, get_config_for_profile, get_config, \
+    set_config_provider, ProfileConfigProvider, _get_path, DatabrickConfigProvider
+from databricks_cli.utils import InvalidConfigurationError
 
 
 TEST_HOST = 'https://test.cloud.databricks.com'
@@ -117,30 +122,67 @@ def test_get_config_if_password_environment_set():
         assert config.password == TEST_PASSWORD
 
 
-class TestDatabricksConfig(object):
-    def test_from_token(self):
-        config = DatabricksConfig.from_token(TEST_HOST, TEST_TOKEN)
-        assert config.host == TEST_HOST
-        assert config.token == TEST_TOKEN
+def test_get_config_uses_default_profile():
+    config = DatabricksConfig.from_token("hosty", "hello")
+    update_and_persist_config(DEFAULT_SECTION, config)
+    config = get_config()
+    assert config.is_valid_with_token
+    assert config.host == "hosty"
+    assert config.token == "hello"
 
-    def test_from_password(self):
-        config = DatabricksConfig.from_password(TEST_HOST, TEST_USER, TEST_PASSWORD)
+
+def test_get_config_uses_env_variable():
+    with patch.dict('os.environ', {'DATABRICKS_HOST': TEST_HOST,
+                                   'DATABRICKS_USERNAME': TEST_USER,
+                                   'DATABRICKS_PASSWORD': TEST_PASSWORD}):
+        config = get_config()
         assert config.host == TEST_HOST
         assert config.username == TEST_USER
         assert config.password == TEST_PASSWORD
 
-    def test_is_valid_with_token(self):
-        config = DatabricksConfig.from_token(TEST_HOST, TEST_TOKEN)
-        assert not config.is_valid_with_password
-        assert config.is_valid_with_token
 
-    def test_is_valid_with_password(self):
-        config = DatabricksConfig.from_password(TEST_HOST, TEST_USER, TEST_PASSWORD)
-        assert config.is_valid_with_password
-        assert not config.is_valid_with_token
+def test_get_config_throw_exception_if_profile_invalid():
+    invalid_config = DatabricksConfig.from_token(None, None)
+    update_and_persist_config(DEFAULT_SECTION, invalid_config)
+    with pytest.raises(InvalidConfigurationError):
+        get_config()
 
-    def test_is_valid(self):
-        config = DatabricksConfig.from_password(TEST_HOST, TEST_USER, TEST_PASSWORD)
-        assert config.is_valid
-        config = DatabricksConfig.from_token(TEST_HOST, TEST_TOKEN)
-        assert config.is_valid
+
+def test_get_config_throw_exception_if_profile_absent():
+    assert not os.path.exists(_get_path())
+    with pytest.raises(InvalidConfigurationError):
+        get_config()
+
+
+def test_get_config_override_profile():
+    config = DatabricksConfig.from_token("yo", "lo")
+    update_and_persist_config(TEST_PROFILE, config)
+    try:
+        provider = ProfileConfigProvider(TEST_PROFILE)
+        set_config_provider(provider)
+        config = get_config()
+        assert config.host == "yo"
+        assert config.token == "lo"
+    finally:
+        set_config_provider(None)
+
+
+def test_get_config_override_custom():
+    class TestConfigProvider(DatabrickConfigProvider):
+        def get_config(self):
+            return DatabricksConfig.from_token("Override", "Token!")
+
+    try:
+        provider = TestConfigProvider()
+        set_config_provider(provider)
+        config = get_config()
+        assert config.host == "Override"
+        assert config.token == "Token!"
+    finally:
+        set_config_provider(None)
+
+
+def test_get_config_bad_override():
+    with pytest.raises(Exception):
+        set_config_provider("NotAConfigProvider")
+


### PR DESCRIPTION
This PR cleans up and provides a clearer Python API for how we discover Databricks configuration (API frontend hostname and authentication information). The goal of this kind of refactoring is to enable other Python libraries (e.g., https://github.com/mlflow/mlflow) that want to rely on Databricks authentication to be able to use the Databricks CLI config resolution logic in a relatively futureproof and understandable fashion.

Two major additions:
- Adds a `DatabricksConfigProvider` abstract class, and three implementations (ProfileConfigProvider, EnvironmentConfigProvider, and DefaultConfigProvider) which users can leverage for canonical implementations of identifying Databricks config.
- Adds a `set_config_provider` method which alters the behavior of the global `get_config`.

We also strive to maintain significant backwards-compatibility. MLflow (and potentially other libraries) currently rely on `get_config_for_profile`, so we maintain this API with its exact current behavior, to be deprecated in a later release.

We do change the behavior of `databricks --profile <foo>`. This invocation, where the profile is explicitly provided, will no longer look for environment variables. The invocation where profile is not provided altogether will continue to look for environment variables prior to looking at the DEFAULT profile.

## How is this patch tested?

- [x] Unit tests added
- [x] Manual tested against a Databricks API. Tried using a profile, no profile, in both the existence and non-existence cases.