### PR TITLE
Enable configuring path to auth file via an environment variable

### DIFF
--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -30,13 +30,13 @@ from databricks_cli.utils import InvalidConfigurationError
 
 
 _home = expanduser('~')
+CONFIG_FILE_ENV_VAR = "DATABRICKS_CONFIG_FILE"
 HOST = 'host'
 USERNAME = 'username'
 PASSWORD = 'password' # NOQA
 TOKEN = 'token'
 INSECURE = 'insecure'
 DEFAULT_SECTION = 'DEFAULT'
-CONFIG_FILE_ENV_VAR = "DATABRICKS_CONFIG_FILE"
 
 # User-provided override for the DatabricksConfigProvider
 _config_provider = None

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -36,14 +36,14 @@ PASSWORD = 'password' # NOQA
 TOKEN = 'token'
 INSECURE = 'insecure'
 DEFAULT_SECTION = 'DEFAULT'
-CONFIG_PATH_ENV_VAR = "DATABRICKS_CFG_PATH"
+CONFIG_FILE_ENV_VAR = "DATABRICKS_CONFIG_FILE"
 
 # User-provided override for the DatabricksConfigProvider
 _config_provider = None
 
 
 def _get_path():
-    return os.environ.get(CONFIG_PATH_ENV_VAR, join(_home, '.databrickscfg'))
+    return os.environ.get(CONFIG_FILE_ENV_VAR, join(_home, '.databrickscfg'))
 
 
 def _fetch_from_fs():

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -36,13 +36,14 @@ PASSWORD = 'password' # NOQA
 TOKEN = 'token'
 INSECURE = 'insecure'
 DEFAULT_SECTION = 'DEFAULT'
+CONFIG_PATH_ENV_VAR = "DATABRICKS_CFG_PATH"
 
 # User-provided override for the DatabricksConfigProvider
 _config_provider = None
 
 
 def _get_path():
-    return join(_home, '.databrickscfg')
+    return os.environ.get(CONFIG_PATH_ENV_VAR, join(_home, '.databrickscfg'))
 
 
 def _fetch_from_fs():

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -152,7 +152,7 @@ def test_get_config_uses_path_env_variable(tmpdir):
         host = {host}
         token = {token}
         """.format(host="hosty", token="hello")))
-    with patch.dict('os.environ', {'DATABRICKS_CFG_PATH': cfg_file}):
+    with patch.dict('os.environ', {'DATABRICKS_CONFIG_FILE': cfg_file}):
         config = get_config()
     assert config.is_valid_with_token
     assert config.host == "hosty"

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -146,14 +146,12 @@ def test_get_config_uses_env_variable():
 
 def test_get_config_uses_path_env_variable(tmpdir):
     cfg_file = tmpdir.join("some-cfg-path").strpath
-    with open(cfg_file, "w") as handle:
-        handle.write(textwrap.dedent("""
-        [DEFAULT]
-        host = {host}
-        token = {token}
-        """.format(host="hosty", token="hello")))
     with patch.dict('os.environ', {'DATABRICKS_CONFIG_FILE': cfg_file}):
+        config = DatabricksConfig.from_token("hosty", "hello")
+        update_and_persist_config(DEFAULT_SECTION, config)
         config = get_config()
+    assert os.path.exists(cfg_file)
+    assert not os.path.exists(_get_path())
     assert config.is_valid_with_token
     assert config.host == "hosty"
     assert config.token == "hello"

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -22,7 +22,6 @@
 # limitations under the License.
 
 import os
-import textwrap
 
 from mock import patch
 import pytest


### PR DESCRIPTION
Enable configuring the path to a Databricks-cli profile file via a `DATABRICKS_CONFIG_FILE` environment variable. Adds a unit test verifying the new behavior