### PR TITLE
Add retry to API call to endpoint "2.0/dbfs/add-block"

### DIFF
--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -35,8 +35,8 @@ from databricks_cli.dbfs.dbfs_path import DbfsPath
 from databricks_cli.dbfs.exceptions import LocalFileExistsException
 
 BUFFER_SIZE_BYTES = 2**20
-DEFAULT_TRIES_INTEGER = 3
-DEFAULT_DELAY_INTEGER = 2
+DEFAULT_TRIES = 3
+DEFAULT_DELAY_SEC = 2
 
 
 class FileInfo(object):
@@ -96,7 +96,7 @@ class DbfsApi(object):
         return FileInfo.from_json(json)
 
     def put_file(self, src_path, dbfs_path,
-                 overwrite, tries=DEFAULT_TRIES_INTEGER, delay=DEFAULT_DELAY_INTEGER):
+                 overwrite, tries=DEFAULT_TRIES, delay=DEFAULT_DELAY_SEC):
         handle = self.client.create(dbfs_path.absolute_path, overwrite)['handle']
         try:
             with open(src_path, 'rb') as local_file:

--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -96,7 +96,7 @@ class DbfsApi(object):
         return FileInfo.from_json(json)
 
     def put_file(self, src_path, dbfs_path,
-                 overwrite, tries = DEFAULT_TRIES, delay = DEFAULT_DELAY):
+                 overwrite, tries=DEFAULT_TRIES, delay=DEFAULT_DELAY):
         handle = self.client.create(dbfs_path.absolute_path, overwrite)['handle']
         try:
             with open(src_path, 'rb') as local_file:

--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -35,8 +35,8 @@ from databricks_cli.dbfs.dbfs_path import DbfsPath
 from databricks_cli.dbfs.exceptions import LocalFileExistsException
 
 BUFFER_SIZE_BYTES = 2**20
-DEFAULT_TRIES = 3
-DEFAULT_DELAY = 2
+DEFAULT_TRIES_INTEGER = 3
+DEFAULT_DELAY_INTEGER = 2
 
 
 class FileInfo(object):
@@ -96,7 +96,7 @@ class DbfsApi(object):
         return FileInfo.from_json(json)
 
     def put_file(self, src_path, dbfs_path,
-                 overwrite, tries=DEFAULT_TRIES, delay=DEFAULT_DELAY):
+                 overwrite, tries=DEFAULT_TRIES_INTEGER, delay=DEFAULT_DELAY_INTEGER):
         handle = self.client.create(dbfs_path.absolute_path, overwrite)['handle']
         try:
             with open(src_path, 'rb') as local_file:

--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -24,8 +24,8 @@
 from base64 import b64encode, b64decode
 
 import os
-import click
 import time
+import click
 
 from requests.exceptions import HTTPError
 
@@ -95,7 +95,8 @@ class DbfsApi(object):
         json = self.client.get_status(dbfs_path.absolute_path)
         return FileInfo.from_json(json)
 
-    def put_file(self, src_path, dbfs_path, overwrite, tries = DEFAULT_TRIES, delay = DEFAULT_DELAY):
+    def put_file(self, src_path, dbfs_path,
+                 overwrite, tries = DEFAULT_TRIES, delay = DEFAULT_DELAY):
         handle = self.client.create(dbfs_path.absolute_path, overwrite)['handle']
         try:
             with open(src_path, 'rb') as local_file:
@@ -104,19 +105,24 @@ class DbfsApi(object):
                     if len(contents) == 0:
                         break
                     # retry on failure
-                    localTries = tries
-                    localDelay = delay
+                    local_tries = tries
+                    local_delay = delay
                     while True:
                         try:
                             # add_block should not take a bytes object.
                             self.client.add_block(handle, b64encode(contents).decode())
                             break
                         except HTTPError as e:
-                            if localTries > 1:
-                                click.echo("%s, Number of tries left: %d, Retrying in %d seconds..." % (e.response.json(), localTries - 1, localDelay))
+                            if local_tries > 1:
+                                click.echo(
+                                    '{}. Number of tries left: {}, Retrying in {} seconds...'
+                                    .format(
+                                        e.response.json(), local_tries - 1, local_delay
+                                    )
+                                )
                                 time.sleep(delay)
-                                localTries -= 1
-                                localDelay *= 2
+                                local_tries -= 1
+                                local_delay *= 2
                             else:
                                 raise e
         finally:

--- a/tests/dbfs/test_api.py
+++ b/tests/dbfs/test_api.py
@@ -128,6 +128,8 @@ class TestDbfsApi(object):
         assert api_mock.add_block.call_count == 1
         assert test_handle == api_mock.add_block.call_args[0][0]
         assert b64encode(b'test').decode() == api_mock.add_block.call_args[0][1]
+        assert api_mock.close.call_count == 1
+        assert test_handle == api_mock.close.call_args[0][0]
 
     def test_put_file_retries_on_failure(self, dbfs_api, tmpdir):
         test_file_path = os.path.join(tmpdir.strpath, 'test')
@@ -148,7 +150,7 @@ class TestDbfsApi(object):
             dbfs_api.put_file(test_file_path, TEST_DBFS_PATH, True, tries, delay)
         assert api_mock.add_block.call_count == tries
         assert api_mock.close.call_count == 1
-
+        assert test_handle == api_mock.close.call_args[0][0]
 
     def test_get_file_check_overwrite(self, dbfs_api, tmpdir):
         test_file_path = os.path.join(tmpdir.strpath, 'test')

--- a/tests/dbfs/test_api.py
+++ b/tests/dbfs/test_api.py
@@ -129,6 +129,28 @@ class TestDbfsApi(object):
         assert test_handle == api_mock.add_block.call_args[0][0]
         assert b64encode(b'test').decode() == api_mock.add_block.call_args[0][1]
 
+    def test_put_file_retries_on_failure(self, dbfs_api, tmpdir):
+        test_file_path = os.path.join(tmpdir.strpath, 'test')
+        with open(test_file_path, 'wt') as f:
+            f.write('test')
+        api_mock = dbfs_api.client
+        test_handle = 0
+        api_mock.create.return_value = {'handle': test_handle}
+
+        add_block_response = requests.Response()
+        add_block_response._content = ('{"error_code": "500"}').encode()
+        exception = requests.exceptions.HTTPError(response=add_block_response)
+        api_mock.add_block = mock.Mock(side_effect=exception)
+
+        tries = 2
+        delay = 0
+
+        with pytest.raises(exception.__class__):
+            dbfs_api.put_file(test_file_path, TEST_DBFS_PATH, True, tries, delay)
+        assert api_mock.add_block.call_count == tries
+        assert api_mock.close.call_count == 1
+
+
     def test_get_file_check_overwrite(self, dbfs_api, tmpdir):
         test_file_path = os.path.join(tmpdir.strpath, 'test')
         with open(test_file_path, 'w') as f:

--- a/tests/dbfs/test_api.py
+++ b/tests/dbfs/test_api.py
@@ -131,6 +131,8 @@ class TestDbfsApi(object):
 
     def test_put_file_retries_on_failure(self, dbfs_api, tmpdir):
         test_file_path = os.path.join(tmpdir.strpath, 'test')
+        tries = 2
+        delay = 0
         with open(test_file_path, 'wt') as f:
             f.write('test')
         api_mock = dbfs_api.client
@@ -141,9 +143,6 @@ class TestDbfsApi(object):
         add_block_response._content = ('{"error_code": "500"}').encode()
         exception = requests.exceptions.HTTPError(response=add_block_response)
         api_mock.add_block = mock.Mock(side_effect=exception)
-
-        tries = 2
-        delay = 0
 
         with pytest.raises(exception.__class__):
             dbfs_api.put_file(test_file_path, TEST_DBFS_PATH, True, tries, delay)


### PR DESCRIPTION
Context:
The API endpoint `2.0/dbfs/add-block` is called repeatedly to upload large files. In the event of a HTTP error, the entire upload would fail.

Instead of failing the entire upload, we will attempt to retry the failed block 3 times before raising an error.