### PR TITLE
Revert retry logic on call to 2.0/dbfs/add-block

### DIFF
--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -24,7 +24,6 @@
 from base64 import b64encode, b64decode
 
 import os
-import time
 import click
 
 from requests.exceptions import HTTPError
@@ -35,9 +34,6 @@ from databricks_cli.dbfs.dbfs_path import DbfsPath
 from databricks_cli.dbfs.exceptions import LocalFileExistsException
 
 BUFFER_SIZE_BYTES = 2**20
-DEFAULT_TRIES = 3
-DEFAULT_DELAY_SEC = 2
-
 
 class FileInfo(object):
     def __init__(self, dbfs_path, is_dir, file_size):
@@ -95,37 +91,15 @@ class DbfsApi(object):
         json = self.client.get_status(dbfs_path.absolute_path)
         return FileInfo.from_json(json)
 
-    def put_file(self, src_path, dbfs_path,
-                 overwrite, tries=DEFAULT_TRIES, delay=DEFAULT_DELAY_SEC):
+    def put_file(self, src_path, dbfs_path, overwrite):
         handle = self.client.create(dbfs_path.absolute_path, overwrite)['handle']
-        try:
-            with open(src_path, 'rb') as local_file:
-                while True:
-                    contents = local_file.read(BUFFER_SIZE_BYTES)
-                    if len(contents) == 0:
-                        break
-                    # retry on failure
-                    local_tries = tries
-                    local_delay = delay
-                    while True:
-                        try:
-                            # add_block should not take a bytes object.
-                            self.client.add_block(handle, b64encode(contents).decode())
-                            break
-                        except HTTPError as e:
-                            if local_tries > 1:
-                                click.echo(
-                                    '{}. Number of tries left: {}, Retrying in {} seconds...'
-                                    .format(
-                                        e.response.json(), local_tries - 1, local_delay
-                                    )
-                                )
-                                time.sleep(delay)
-                                local_tries -= 1
-                                local_delay *= 2
-                            else:
-                                raise e
-        finally:
+        with open(src_path, 'rb') as local_file:
+            while True:
+                contents = local_file.read(BUFFER_SIZE_BYTES)
+                if len(contents) == 0:
+                    break
+                # add_block should not take a bytes object.
+                self.client.add_block(handle, b64encode(contents).decode())
             self.client.close(handle)
 
     def get_file(self, dbfs_path, dst_path, overwrite):

--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -35,6 +35,7 @@ from databricks_cli.dbfs.exceptions import LocalFileExistsException
 
 BUFFER_SIZE_BYTES = 2**20
 
+
 class FileInfo(object):
     def __init__(self, dbfs_path, is_dir, file_size):
         self.dbfs_path = dbfs_path

--- a/tests/dbfs/test_api.py
+++ b/tests/dbfs/test_api.py
@@ -131,27 +131,6 @@ class TestDbfsApi(object):
         assert api_mock.close.call_count == 1
         assert test_handle == api_mock.close.call_args[0][0]
 
-    def test_put_file_retries_on_failure(self, dbfs_api, tmpdir):
-        test_file_path = os.path.join(tmpdir.strpath, 'test')
-        tries = 2
-        delay = 0
-        with open(test_file_path, 'wt') as f:
-            f.write('test')
-        api_mock = dbfs_api.client
-        test_handle = 0
-        api_mock.create.return_value = {'handle': test_handle}
-
-        add_block_response = requests.Response()
-        add_block_response._content = ('{"error_code": "500"}').encode()
-        exception = requests.exceptions.HTTPError(response=add_block_response)
-        api_mock.add_block = mock.Mock(side_effect=exception)
-
-        with pytest.raises(exception.__class__):
-            dbfs_api.put_file(test_file_path, TEST_DBFS_PATH, True, tries, delay)
-        assert api_mock.add_block.call_count == tries
-        assert api_mock.close.call_count == 1
-        assert test_handle == api_mock.close.call_args[0][0]
-
     def test_get_file_check_overwrite(self, dbfs_api, tmpdir):
         test_file_path = os.path.join(tmpdir.strpath, 'test')
         with open(test_file_path, 'w') as f:


### PR DESCRIPTION
Revert changes from:
https://github.com/databricks/databricks-cli/pull/170

Calls to 2.0/dbfs/add-block are not idempotent. Hence, a retry may corrupt the file. Revert back to previous behavior in favor of more appropriate solution in future PR.