### PR TITLE
add beta version tag to stack CLI

### DIFF
--- a/databricks_cli/stack/cli.py
+++ b/databricks_cli/stack/cli.py
@@ -142,14 +142,14 @@ def download(api_client, config_path, **kwargs):
 
 
 @click.group(context_settings=CONTEXT_SETTINGS,
-             short_help='Utility to deploy and download Databricks resource stacks.')
+             short_help='Utility to deploy and download Databricks resource stacks, currently in beta version.')
 @click.option('--version', '-v', is_flag=True, callback=print_version_callback,
               expose_value=False, is_eager=True, help=version)
 @debug_option
 @profile_option
 def stack_group():
     """
-    Utility to deploy and download Databricks resource stacks.
+    Utility to deploy and download Databricks resource stacks, currently in beta version.
     """
     pass
 

--- a/databricks_cli/stack/cli.py
+++ b/databricks_cli/stack/cli.py
@@ -142,14 +142,16 @@ def download(api_client, config_path, **kwargs):
 
 
 @click.group(context_settings=CONTEXT_SETTINGS,
-             short_help='Utility to deploy and download Databricks resource stacks, currently in beta version.')
+             short_help='Utility to deploy and download Databricks resource stacks, '
+                        'currently in beta version.')
 @click.option('--version', '-v', is_flag=True, callback=print_version_callback,
               expose_value=False, is_eager=True, help=version)
 @debug_option
 @profile_option
 def stack_group():
     """
-    (Experimental) Utility to deploy and download Databricks resource stacks, currently in beta version.
+    (Experimental) Utility to deploy and download Databricks resource stacks, 
+    currently in beta version.
     """
     pass
 

--- a/databricks_cli/stack/cli.py
+++ b/databricks_cli/stack/cli.py
@@ -149,7 +149,7 @@ def download(api_client, config_path, **kwargs):
 @profile_option
 def stack_group():
     """
-    Utility to deploy and download Databricks resource stacks, currently in beta version.
+    (Experimental) Utility to deploy and download Databricks resource stacks, currently in beta version.
     """
     pass
 

--- a/databricks_cli/stack/cli.py
+++ b/databricks_cli/stack/cli.py
@@ -142,16 +142,14 @@ def download(api_client, config_path, **kwargs):
 
 
 @click.group(context_settings=CONTEXT_SETTINGS,
-             short_help='Utility to deploy and download Databricks resource stacks, '
-                        'currently in beta version.')
+             short_help='[Experimental] Utility to deploy and download Databricks resource stacks.')
 @click.option('--version', '-v', is_flag=True, callback=print_version_callback,
               expose_value=False, is_eager=True, help=version)
 @debug_option
 @profile_option
 def stack_group():
     """
-    (Experimental) Utility to deploy and download Databricks resource stacks, 
-    currently in beta version.
+    [Experimental] Utility to deploy and download Databricks resource stacks.
     """
     pass
 

--- a/tests/configure/test_config.py
+++ b/tests/configure/test_config.py
@@ -87,7 +87,7 @@ def test_provide_api_client_invalid():
         click.echo(x)
 
     result = CliRunner().invoke(test_command, ['--x', '1'])
-    assert result.exit_code == -1
+    assert result.exit_code == 1
     assert isinstance(result.exception, InvalidConfigurationError)
 
 


### PR DESCRIPTION
the PR makes it clear that stack cli is in beta version

also, small change is made in tests/configure/test_config.py to deal with the recent change on the exit_code of Exception in CLICK 7.0:
https://github.com/pallets/click/commit/3dfbb984214ff86e35b27672e37b9889eba71004#diff-637edab3f8e0763a9874d17879193dc9L295