### PR TITLE
change physical_id to databricks_id in stack CLI

### DIFF
--- a/databricks_cli/stack/api.py
+++ b/databricks_cli/stack/api.py
@@ -176,7 +176,7 @@ class StackApi(object):
             click.echo('Deploying job "{}" with properties: \n{}'.format(resource_id, json.dumps(
                 resource_properties, indent=2, separators=(',', ': '))))
             new_databricks_id, deploy_output = self._deploy_job(resource_properties,
-                                                              databricks_id)
+                                                                databricks_id)
         elif resource_service == WORKSPACE_SERVICE:
             click.echo(
                 'Deploying workspace asset "{}" with properties \n{}'
@@ -186,8 +186,8 @@ class StackApi(object):
             )
             overwrite = kwargs.get('overwrite', False)
             new_databricks_id, deploy_output = self._deploy_workspace(resource_properties,
-                                                                    databricks_id,
-                                                                    overwrite)
+                                                                        databricks_id,
+                                                                        overwrite)
         elif resource_service == DBFS_SERVICE:
             click.echo(
                 'Deploying DBFS asset "{}" with properties \n{}'.format(
@@ -196,8 +196,8 @@ class StackApi(object):
             )
             overwrite = kwargs.get('overwrite', False)
             new_databricks_id, deploy_output = self._deploy_dbfs(resource_properties,
-                                                               databricks_id,
-                                                               overwrite)
+                                                                    databricks_id,
+                                                                    overwrite)
         else:
             raise StackError('Resource service "{}" not supported'.format(resource_service))
 

--- a/databricks_cli/stack/api.py
+++ b/databricks_cli/stack/api.py
@@ -186,8 +186,8 @@ class StackApi(object):
             )
             overwrite = kwargs.get('overwrite', False)
             new_databricks_id, deploy_output = self._deploy_workspace(resource_properties,
-                                                                        databricks_id,
-                                                                        overwrite)
+                                                                      databricks_id,
+                                                                      overwrite)
         elif resource_service == DBFS_SERVICE:
             click.echo(
                 'Deploying DBFS asset "{}" with properties \n{}'.format(
@@ -196,8 +196,8 @@ class StackApi(object):
             )
             overwrite = kwargs.get('overwrite', False)
             new_databricks_id, deploy_output = self._deploy_dbfs(resource_properties,
-                                                                    databricks_id,
-                                                                    overwrite)
+                                                                 databricks_id,
+                                                                 overwrite)
         else:
             raise StackError('Resource service "{}" not supported'.format(resource_service))
 

--- a/databricks_cli/stack/api.py
+++ b/databricks_cli/stack/api.py
@@ -54,7 +54,7 @@ RESOURCE_SERVICE = 'service'
 RESOURCE_PROPERTIES = 'properties'
 
 # Resource Status Fields
-RESOURCE_PHYSICAL_ID = 'physical_id'
+RESOURCE_DATABRICKS_ID = 'databricks_id'
 RESOURCE_DEPLOY_OUTPUT = 'deploy_output'
 RESOURCE_DEPLOY_TIMESTAMP = 'timestamp'
 CLI_VERSION_KEY = 'cli_version'
@@ -160,23 +160,23 @@ class StackApi(object):
         ex. {'id': 'example-resource', 'service': 'jobs', 'properties': {...}}
         :param resource_status: A dict of the resource's deployment info from the last
         deployment. Will be None if this is the first deployment.
-        ex. {'id': 'example-resource', 'service': 'jobs', 'physical_id': {...}}
+        ex. {'id': 'example-resource', 'service': 'jobs', 'databricks_id': {...}}
         :return: dict resource_status- A dictionary of deployment information of the
         resource to be stored at deploy time. It includes the resource id of the resource along
         with the physical id and deploy output of the resource.
-        ex. {'id': 'example-resource', 'service': 'jobs', 'physical_id': {'job_id': 123},
+        ex. {'id': 'example-resource', 'service': 'jobs', 'databricks_id': {'job_id': 123},
         'timestamp': 123456789, 'deploy_output': {..}}
         """
         resource_id = resource_config.get(RESOURCE_ID)
         resource_service = resource_config.get(RESOURCE_SERVICE)
         resource_properties = resource_config.get(RESOURCE_PROPERTIES)
-        physical_id = resource_status.get(RESOURCE_PHYSICAL_ID) if resource_status else None
+        databricks_id = resource_status.get(RESOURCE_DATABRICKS_ID) if resource_status else None
 
         if resource_service == JOBS_SERVICE:
             click.echo('Deploying job "{}" with properties: \n{}'.format(resource_id, json.dumps(
                 resource_properties, indent=2, separators=(',', ': '))))
-            new_physical_id, deploy_output = self._deploy_job(resource_properties,
-                                                              physical_id)
+            new_databricks_id, deploy_output = self._deploy_job(resource_properties,
+                                                              databricks_id)
         elif resource_service == WORKSPACE_SERVICE:
             click.echo(
                 'Deploying workspace asset "{}" with properties \n{}'
@@ -185,8 +185,8 @@ class StackApi(object):
                 )
             )
             overwrite = kwargs.get('overwrite', False)
-            new_physical_id, deploy_output = self._deploy_workspace(resource_properties,
-                                                                    physical_id,
+            new_databricks_id, deploy_output = self._deploy_workspace(resource_properties,
+                                                                    databricks_id,
                                                                     overwrite)
         elif resource_service == DBFS_SERVICE:
             click.echo(
@@ -195,8 +195,8 @@ class StackApi(object):
                 )
             )
             overwrite = kwargs.get('overwrite', False)
-            new_physical_id, deploy_output = self._deploy_dbfs(resource_properties,
-                                                               physical_id,
+            new_databricks_id, deploy_output = self._deploy_dbfs(resource_properties,
+                                                               databricks_id,
                                                                overwrite)
         else:
             raise StackError('Resource service "{}" not supported'.format(resource_service))
@@ -206,7 +206,7 @@ class StackApi(object):
                                RESOURCE_DEPLOY_TIMESTAMP:
                                    # Milliseconds since epoch.
                                    int(time.mktime(datetime.now().timetuple()) * MS_SEC),
-                               RESOURCE_PHYSICAL_ID: new_physical_id,
+                               RESOURCE_DATABRICKS_ID: new_databricks_id,
                                RESOURCE_DEPLOY_OUTPUT: deploy_output}
         return new_resource_status
 
@@ -236,31 +236,31 @@ class StackApi(object):
             click.echo('Resource service "{}" not supported for download. '
                        'skipping.'.format(resource_service))
 
-    def _deploy_job(self, resource_properties, physical_id=None):
+    def _deploy_job(self, resource_properties, databricks_id=None):
         """
         Deploys a job resource by either creating a job if the job isn't kept track of through
-        the physical_id of the job or updating an existing job. The job is created or updated using
-        the the settings specified in the inputted job_settings.
+        the databricks_id of the job or updating an existing job. The job is created or updated
+        using the the settings specified in the inputted job_settings.
 
         :param resource_properties: A dict of the Databricks JobSettings data structure
-        :param physical_id: A dict object containing 'job_id' field of job identifier in Databricks
-        server
+        :param databricks_id: A dict object containing 'job_id' field of job identifier in
+        Databricks server
 
-        :return: tuple of (physical_id, deploy_output), where physical_id contains a 'job_id' field
-        of the physical job_id of the job on databricks. deploy_output is the output of the job
-        from databricks when a GET request is called for it.
+        :return: tuple of (databricks_id, deploy_output), where databricks_id contains a 'job_id'
+        field of the physical job_id of the job on databricks. deploy_output is the output of the
+        job from databricks when a GET request is called for it.
         """
         job_settings = resource_properties  # resource_properties of jobs are solely job settings.
 
-        if physical_id:
-            job_id = physical_id.get(JOBS_RESOURCE_JOB_ID)
+        if databricks_id:
+            job_id = databricks_id.get(JOBS_RESOURCE_JOB_ID)
             self._update_job(job_settings, job_id)
         else:
             job_id = self._put_job(job_settings)
         click.echo("Job deployed on Databricks with Job ID {}".format(job_id))
-        physical_id = {JOBS_RESOURCE_JOB_ID: job_id}
+        databricks_id = {JOBS_RESOURCE_JOB_ID: job_id}
         deploy_output = self.jobs_client.get_job(job_id)
-        return physical_id, deploy_output
+        return databricks_id, deploy_output
 
     def _put_job(self, job_settings):
         """
@@ -302,19 +302,19 @@ class StackApi(object):
 
         self.jobs_client.reset_job({'job_id': job_id, 'new_settings': job_settings})
 
-    def _deploy_workspace(self, resource_properties, physical_id, overwrite):
+    def _deploy_workspace(self, resource_properties, databricks_id, overwrite):
         """
         Deploy workspace asset.
 
         :param resource_properties: dict of properties for the workspace asset. Must contain the
         'source_path', 'path' and 'object_type' fields.
-        :param physical_id: dict containing physical identifier of workspace asset on databricks.
+        :param databricks_id: dict containing physical identifier of workspace asset on databricks.
         Should contain the field 'path'.
         :param overwrite: Whether or not to overwrite the contents of workspace notebooks.
-        :return: (dict, dict) of (physical_id, deploy_output). physical_id is the physical ID for
-        the stack status that contains the workspace path of the notebook or directory on datbricks.
-        deploy_output is the initial information about the asset on databricks at deploy time
-        returned by the REST API.
+        :return: (dict, dict) of (databricks_id, deploy_output). databricks_id is the physical ID
+        for the stack status that contains the workspace path of the notebook or directory on
+        datbricks. deploy_output is the initial information about the asset on databricks at deploy
+        time returned by the REST API.
         """
         local_path = resource_properties.get(WORKSPACE_RESOURCE_SOURCE_PATH)
         workspace_path = resource_properties.get(WORKSPACE_RESOURCE_PATH)
@@ -348,14 +348,15 @@ class StackApi(object):
             # Shouldn't reach here because of verification of object_type above.
             assert False
 
-        if physical_id and physical_id[WORKSPACE_RESOURCE_PATH] != workspace_path:
-            # physical_id['path'] is the workspace path from the last deployment. Alert when changed
+        if databricks_id and databricks_id[WORKSPACE_RESOURCE_PATH] != workspace_path:
+            # databricks_id['path'] is the workspace path from the last deployment. Alert when
+            # changed
             click.echo("Workspace asset had path changed from {} to {}"
-                       .format(physical_id[WORKSPACE_RESOURCE_PATH], workspace_path))
-        new_physical_id = {WORKSPACE_RESOURCE_PATH: workspace_path}
+                       .format(databricks_id[WORKSPACE_RESOURCE_PATH], workspace_path))
+        new_databricks_id = {WORKSPACE_RESOURCE_PATH: workspace_path}
         deploy_output = self.workspace_client.client.get_status(workspace_path)
 
-        return new_physical_id, deploy_output
+        return new_databricks_id, deploy_output
 
     def _download_workspace(self, resource_properties, overwrite):
         """
@@ -388,16 +389,16 @@ class StackApi(object):
             raise StackError('Invalid value for "{}" field: {}'
                              .format(WORKSPACE_RESOURCE_OBJECT_TYPE, object_type))
 
-    def _deploy_dbfs(self, resource_properties, physical_id, overwrite):
+    def _deploy_dbfs(self, resource_properties, databricks_id, overwrite):
         """
         Deploy dbfs asset.
 
         :param resource_properties: dict of properties for the dbfs asset. Must contain the
         'source_path', 'path' and 'is_dir' fields.
-        :param physical_id: dict containing physical identifier of dbfs asset on Databricks.
+        :param databricks_id: dict containing physical identifier of dbfs asset on Databricks.
         Should contain the field 'path'.
         :param overwrite: Whether or not to overwrite the contents of dbfs files.
-        :return: (dict, dict) of (physical_id, deploy_output). physical_id is a dict that
+        :return: (dict, dict) of (databricks_id, deploy_output). databricks_id is a dict that
         contains the dbfs path of the file on Databricks.
         ex.{"path":"dbfs:/path/in/dbfs"}
         deploy_output is the initial information about the dbfs asset at deploy time
@@ -420,14 +421,14 @@ class StackApi(object):
             click.echo('Uploading file from {} to DBFS at {}'.format(local_path, dbfs_path))
             self.dbfs_client.cp(recursive=False, overwrite=overwrite, src=local_path, dst=dbfs_path)
 
-        if physical_id and physical_id[DBFS_RESOURCE_PATH] != dbfs_path:
-            # physical_id['path'] is the dbfs path from the last deployment. Alert when changed
+        if databricks_id and databricks_id[DBFS_RESOURCE_PATH] != dbfs_path:
+            # databricks_id['path'] is the dbfs path from the last deployment. Alert when changed
             click.echo("Dbfs asset had path changed from {} to {}"
-                       .format(physical_id[DBFS_RESOURCE_PATH], dbfs_path))
-        new_physical_id = {DBFS_RESOURCE_PATH: dbfs_path}
+                       .format(databricks_id[DBFS_RESOURCE_PATH], dbfs_path))
+        new_databricks_id = {DBFS_RESOURCE_PATH: dbfs_path}
         deploy_output = self.dbfs_client.client.get_status(dbfs_path)
 
-        return new_physical_id, deploy_output
+        return new_databricks_id, deploy_output
 
     def _validate_config(self, stack_config):
         """
@@ -493,20 +494,20 @@ class StackApi(object):
             resource_id = resource_status.get(RESOURCE_ID)
             click.echo('Validating fields in resource status of resource with ID "{}"'
                        .format(resource_id))
-            self._assert_fields_in_dict([RESOURCE_SERVICE, RESOURCE_PHYSICAL_ID,
+            self._assert_fields_in_dict([RESOURCE_SERVICE, RESOURCE_DATABRICKS_ID,
                                          RESOURCE_DEPLOY_OUTPUT], resource_status)
 
             resource_service = resource_status.get(RESOURCE_SERVICE)
-            resource_physical_id = resource_status.get(RESOURCE_PHYSICAL_ID)
+            resource_databricks_id = resource_status.get(RESOURCE_DATABRICKS_ID)
 
             click.echo('Validating fields in "{}" of {} resource status'
-                       .format(RESOURCE_PHYSICAL_ID, resource_service))
+                       .format(RESOURCE_DATABRICKS_ID, resource_service))
             if resource_service == JOBS_SERVICE:
-                self._assert_fields_in_dict([JOBS_RESOURCE_JOB_ID], resource_physical_id)
+                self._assert_fields_in_dict([JOBS_RESOURCE_JOB_ID], resource_databricks_id)
             elif resource_service == WORKSPACE_SERVICE:
-                self._assert_fields_in_dict([WORKSPACE_RESOURCE_PATH], resource_physical_id)
+                self._assert_fields_in_dict([WORKSPACE_RESOURCE_PATH], resource_databricks_id)
             elif resource_service == DBFS_SERVICE:
-                self._assert_fields_in_dict([DBFS_RESOURCE_PATH], resource_physical_id)
+                self._assert_fields_in_dict([DBFS_RESOURCE_PATH], resource_databricks_id)
             else:
                 raise StackError("{} not a valid resource status service".format(resource_service))
 

--- a/tests/stack/test_api.py
+++ b/tests/stack/test_api.py
@@ -45,7 +45,7 @@ TEST_JOB_RESOURCE = {
     api.RESOURCE_SERVICE: api.JOBS_SERVICE,
     api.RESOURCE_PROPERTIES: TEST_JOB_SETTINGS
 }
-TEST_JOB_PHYSICAL_ID = {api.JOBS_RESOURCE_JOB_ID: 1234}
+TEST_JOB_DATABRICKS_ID = {api.JOBS_RESOURCE_JOB_ID: 1234}
 TEST_WORKSPACE_NB_PROPERTIES = {
     api.WORKSPACE_RESOURCE_SOURCE_PATH: 'test/notebook.py',
     api.WORKSPACE_RESOURCE_PATH: '/test/notebook.py',
@@ -56,8 +56,8 @@ TEST_WORKSPACE_DIR_PROPERTIES = {
     api.WORKSPACE_RESOURCE_PATH: '/test/dir',
     api.WORKSPACE_RESOURCE_OBJECT_TYPE: workspace_api.DIRECTORY
 }
-TEST_WORKSPACE_NB_PHYSICAL_ID = {api.WORKSPACE_RESOURCE_PATH: '/test/notebook.py'}
-TEST_WORKSPACE_DIR_PHYSICAL_ID = {api.WORKSPACE_RESOURCE_PATH: '/test/dir'}
+TEST_WORKSPACE_NB_DATABRICKS_ID = {api.WORKSPACE_RESOURCE_PATH: '/test/notebook.py'}
+TEST_WORKSPACE_DIR_DATABRICKS_ID = {api.WORKSPACE_RESOURCE_PATH: '/test/dir'}
 TEST_DBFS_FILE_PROPERTIES = {
     api.DBFS_RESOURCE_SOURCE_PATH: 'test.jar',
     api.DBFS_RESOURCE_PATH: 'dbfs:/test/test.jar',
@@ -68,8 +68,8 @@ TEST_DBFS_DIR_PROPERTIES = {
     api.DBFS_RESOURCE_PATH: 'dbfs:/test/dir',
     api.DBFS_RESOURCE_IS_DIR: True
 }
-TEST_DBFS_FILE_PHYSICAL_ID = {api.DBFS_RESOURCE_PATH: 'dbfs:/test/test.jar'}
-TEST_DBFS_DIR_PHYSICAL_ID = {api.DBFS_RESOURCE_PATH: 'dbfs:/test/dir'}
+TEST_DBFS_FILE_DATABRICKS_ID = {api.DBFS_RESOURCE_PATH: 'dbfs:/test/test.jar'}
+TEST_DBFS_DIR_DATABRICKS_ID = {api.DBFS_RESOURCE_PATH: 'dbfs:/test/dir'}
 TEST_RESOURCE_ID = 'test job'
 TEST_RESOURCE_WORKSPACE_NB_ID = 'test notebook'
 TEST_RESOURCE_WORKSPACE_DIR_ID = 'test directory'
@@ -98,31 +98,31 @@ TEST_DBFS_DIR_RESOURCE = {
 TEST_JOB_STATUS = {
     api.RESOURCE_ID: TEST_RESOURCE_ID,
     api.RESOURCE_SERVICE: api.JOBS_SERVICE,
-    api.RESOURCE_PHYSICAL_ID: TEST_JOB_PHYSICAL_ID,
+    api.RESOURCE_DATABRICKS_ID: TEST_JOB_DATABRICKS_ID,
     api.RESOURCE_DEPLOY_OUTPUT: {}
 }
 TEST_WORKSPACE_NB_STATUS = {
     api.RESOURCE_ID: TEST_RESOURCE_WORKSPACE_NB_ID,
     api.RESOURCE_SERVICE: api.WORKSPACE_SERVICE,
-    api.RESOURCE_PHYSICAL_ID: TEST_WORKSPACE_NB_PHYSICAL_ID,
+    api.RESOURCE_DATABRICKS_ID: TEST_WORKSPACE_NB_DATABRICKS_ID,
     api.RESOURCE_DEPLOY_OUTPUT: {}
 }
 TEST_WORKSPACE_DIR_STATUS = {
     api.RESOURCE_ID: TEST_RESOURCE_WORKSPACE_DIR_ID,
     api.RESOURCE_SERVICE: api.WORKSPACE_SERVICE,
-    api.RESOURCE_PHYSICAL_ID: TEST_WORKSPACE_DIR_PHYSICAL_ID,
+    api.RESOURCE_DATABRICKS_ID: TEST_WORKSPACE_DIR_DATABRICKS_ID,
     api.RESOURCE_DEPLOY_OUTPUT: {}
 }
 TEST_DBFS_FILE_STATUS = {
     api.RESOURCE_ID: TEST_RESOURCE_DBFS_FILE_ID,
     api.RESOURCE_SERVICE: api.DBFS_SERVICE,
-    api.RESOURCE_PHYSICAL_ID: TEST_DBFS_FILE_PHYSICAL_ID,
+    api.RESOURCE_DATABRICKS_ID: TEST_DBFS_FILE_DATABRICKS_ID,
     api.RESOURCE_DEPLOY_OUTPUT: {}
 }
 TEST_DBFS_DIR_STATUS = {
     api.RESOURCE_ID: TEST_RESOURCE_DBFS_DIR_ID,
     api.RESOURCE_SERVICE: api.DBFS_SERVICE,
-    api.RESOURCE_PHYSICAL_ID: TEST_DBFS_DIR_PHYSICAL_ID,
+    api.RESOURCE_DATABRICKS_ID: TEST_DBFS_DIR_DATABRICKS_ID,
     api.RESOURCE_DEPLOY_OUTPUT: {}
 }
 TEST_STACK = {
@@ -196,53 +196,54 @@ def stack_api():
 class TestStackApi(object):
     def test_deploy_job(self, stack_api):
         """
-            stack_api._deploy_job should create a new job when 1) A physical_id is not given and
+            stack_api._deploy_job should create a new job when 1) A databricks_id is not given and
             a job with the same name does not exist in the settings.
 
-            stack_api._deploy_job should reset/update an existing job when 1) A physical_id is given
-            2) A physical_id is not given but one job with the same name exists.
+            stack_api._deploy_job should reset/update an existing job when 1) A databricks_id is
+            given
+            2) A databricks_id is not given but one job with the same name exists.
 
-            A StackError should be raised when 1) A physical_id is not given but there are multiple
-            jobs with the same name that exist.
+            A StackError should be raised when 1) A databricks_id is not given but there are
+            multiple jobs with the same name that exist.
         """
         test_job_settings = TEST_JOB_SETTINGS
         # Different name than TEST_JOB_SETTINGS
         alt_test_job_settings = {api.JOBS_RESOURCE_NAME: 'alt test job'}
         stack_api.jobs_client = _TestJobsClient()
         # TEST CASE 1:
-        # stack_api._deploy_job should create job if physical_id not given job doesn't exist
-        res_physical_id_1, res_deploy_output_1 = stack_api._deploy_job(test_job_settings)
-        assert stack_api.jobs_client.get_job(res_physical_id_1[api.JOBS_RESOURCE_JOB_ID]) == \
+        # stack_api._deploy_job should create job if databricks_id not given job doesn't exist
+        res_databricks_id_1, res_deploy_output_1 = stack_api._deploy_job(test_job_settings)
+        assert stack_api.jobs_client.get_job(res_databricks_id_1[api.JOBS_RESOURCE_JOB_ID]) == \
             res_deploy_output_1
         assert res_deploy_output_1[api.JOBS_RESOURCE_JOB_ID] == \
-            res_physical_id_1[api.JOBS_RESOURCE_JOB_ID]
+            res_databricks_id_1[api.JOBS_RESOURCE_JOB_ID]
         assert test_job_settings == res_deploy_output_1['job_settings']
 
         # TEST CASE 2:
-        # stack_api._deploy_job should reset job if physical_id given.
-        res_physical_id_2, res_deploy_output_2 = stack_api._deploy_job(alt_test_job_settings,
-                                                                       res_physical_id_1)
+        # stack_api._deploy_job should reset job if databricks_id given.
+        res_databricks_id_2, res_deploy_output_2 = stack_api._deploy_job(alt_test_job_settings,
+                                                                       res_databricks_id_1)
         # physical job id not changed from last update
-        assert res_physical_id_2[api.JOBS_RESOURCE_JOB_ID] == \
-            res_physical_id_1[api.JOBS_RESOURCE_JOB_ID]
+        assert res_databricks_id_2[api.JOBS_RESOURCE_JOB_ID] == \
+            res_databricks_id_1[api.JOBS_RESOURCE_JOB_ID]
         assert res_deploy_output_2[api.JOBS_RESOURCE_JOB_ID] == \
-            res_physical_id_2[api.JOBS_RESOURCE_JOB_ID]
+            res_databricks_id_2[api.JOBS_RESOURCE_JOB_ID]
         assert alt_test_job_settings == res_deploy_output_2['job_settings']
 
         # TEST CASE 3:
-        # stack_api._deploy_job should reset job if a physical_id not given, but job with same name
-        # found
+        # stack_api._deploy_job should reset job if a databricks_id not given, but job with same
+        # name found
         alt_test_job_settings['new_property'] = 'new_property_value'
-        res_physical_id_3, res_deploy_output_3 = stack_api._deploy_job(alt_test_job_settings)
+        res_databricks_id_3, res_deploy_output_3 = stack_api._deploy_job(alt_test_job_settings)
         # physical job id not changed from last update
-        assert res_physical_id_3[api.JOBS_RESOURCE_JOB_ID] == \
-            res_physical_id_2[api.JOBS_RESOURCE_JOB_ID]
+        assert res_databricks_id_3[api.JOBS_RESOURCE_JOB_ID] == \
+            res_databricks_id_2[api.JOBS_RESOURCE_JOB_ID]
         assert res_deploy_output_3[api.JOBS_RESOURCE_JOB_ID] == \
-            res_physical_id_3[api.JOBS_RESOURCE_JOB_ID]
+            res_databricks_id_3[api.JOBS_RESOURCE_JOB_ID]
         assert alt_test_job_settings == res_deploy_output_3['job_settings']
 
         # TEST CASE 4
-        # If a physical_id is not given but there is already multiple jobs of the same name in
+        # If a databricks_id is not given but there is already multiple jobs of the same name in
         # databricks, an error should be raised
         # Add new job with different physical id but same name settings as alt_test_job_settings
         stack_api.jobs_client.jobs_in_databricks[123] = {
@@ -283,26 +284,26 @@ class TestStackApi(object):
         os.makedirs(test_workspace_dir_properties[api.WORKSPACE_RESOURCE_SOURCE_PATH])
 
         # Test Input of Workspace directory properties.
-        dir_physical_id, dir_deploy_output = \
+        dir_databricks_id, dir_deploy_output = \
             stack_api._deploy_workspace(test_workspace_dir_properties, None, True)
         stack_api.workspace_client.import_workspace_dir.assert_called_once()
         assert stack_api.workspace_client.import_workspace_dir.call_args[0][0] == \
             test_workspace_dir_properties[api.WORKSPACE_RESOURCE_SOURCE_PATH]
         assert stack_api.workspace_client.import_workspace_dir.call_args[0][1] == \
             test_workspace_dir_properties[api.WORKSPACE_RESOURCE_PATH]
-        assert dir_physical_id == {
+        assert dir_databricks_id == {
             api.WORKSPACE_RESOURCE_PATH: test_workspace_dir_properties[api.WORKSPACE_RESOURCE_PATH]}
         assert dir_deploy_output == test_deploy_output
 
         # Test Input of Workspace notebook properties.
-        nb_physical_id, nb_deploy_output = \
+        nb_databricks_id, nb_deploy_output = \
             stack_api._deploy_workspace(test_workspace_nb_properties, None, True)
         stack_api.workspace_client.import_workspace.assert_called_once()
         assert stack_api.workspace_client.import_workspace.call_args[0][0] == \
             test_workspace_nb_properties[api.WORKSPACE_RESOURCE_SOURCE_PATH]
         assert stack_api.workspace_client.import_workspace.call_args[0][1] == \
             test_workspace_nb_properties[api.WORKSPACE_RESOURCE_PATH]
-        assert nb_physical_id == {api.WORKSPACE_RESOURCE_PATH:
+        assert nb_databricks_id == {api.WORKSPACE_RESOURCE_PATH:
                                   test_workspace_nb_properties[api.WORKSPACE_RESOURCE_PATH]}
         assert nb_deploy_output == test_deploy_output
 
@@ -342,7 +343,7 @@ class TestStackApi(object):
                                                              api.DBFS_RESOURCE_SOURCE_PATH])})
         os.makedirs(test_dbfs_dir_properties[api.DBFS_RESOURCE_SOURCE_PATH])
 
-        dir_physical_id, dir_deploy_output = \
+        dir_databricks_id, dir_deploy_output = \
             stack_api._deploy_dbfs(test_dbfs_dir_properties, None, True)
         assert stack_api.dbfs_client.cp.call_count == 1
         assert stack_api.dbfs_client.cp.call_args[1]['recursive'] is True
@@ -351,11 +352,11 @@ class TestStackApi(object):
             test_dbfs_dir_properties[api.DBFS_RESOURCE_SOURCE_PATH]
         assert stack_api.dbfs_client.cp.call_args[1]['dst'] == \
             test_dbfs_dir_properties[api.DBFS_RESOURCE_PATH]
-        assert dir_physical_id == {api.DBFS_RESOURCE_PATH:
+        assert dir_databricks_id == {api.DBFS_RESOURCE_PATH:
                                    test_dbfs_dir_properties[api.DBFS_RESOURCE_PATH]}
         assert dir_deploy_output == test_deploy_output
 
-        nb_physical_id, nb_deploy_output = \
+        nb_databricks_id, nb_deploy_output = \
             stack_api._deploy_dbfs(test_dbfs_file_properties, None, True)
         assert stack_api.dbfs_client.cp.call_count == 2
         assert stack_api.dbfs_client.cp.call_args[1]['recursive'] is False
@@ -364,7 +365,7 @@ class TestStackApi(object):
             test_dbfs_file_properties[api.DBFS_RESOURCE_SOURCE_PATH]
         assert stack_api.dbfs_client.cp.call_args[1]['dst'] == \
             test_dbfs_file_properties[api.DBFS_RESOURCE_PATH]
-        assert nb_physical_id == {api.DBFS_RESOURCE_PATH:
+        assert nb_databricks_id == {api.DBFS_RESOURCE_PATH:
                                   test_dbfs_file_properties[api.DBFS_RESOURCE_PATH]}
         assert nb_deploy_output == test_deploy_output
 
@@ -382,35 +383,35 @@ class TestStackApi(object):
         # TODO(alinxie) Change this test to directly call stack_api.deploy
         # A job resource should have _deploy_resource call on _deploy_job
         stack_api._deploy_job = mock.MagicMock()
-        test_job_physical_id = {api.JOBS_RESOURCE_JOB_ID: 12345}
-        stack_api._deploy_job.return_value = (test_job_physical_id, {})
-        test_job_resource_status = {api.RESOURCE_PHYSICAL_ID: test_job_physical_id}
+        test_job_databricks_id = {api.JOBS_RESOURCE_JOB_ID: 12345}
+        stack_api._deploy_job.return_value = (test_job_databricks_id, {})
+        test_job_resource_status = {api.RESOURCE_DATABRICKS_ID: test_job_databricks_id}
         new_resource_status = stack_api._deploy_resource(TEST_JOB_RESOURCE,
                                                          resource_status=test_job_resource_status)
         assert api.RESOURCE_ID in new_resource_status
-        assert api.RESOURCE_PHYSICAL_ID in new_resource_status
+        assert api.RESOURCE_DATABRICKS_ID in new_resource_status
         assert api.RESOURCE_DEPLOY_OUTPUT in new_resource_status
         assert api.RESOURCE_SERVICE in new_resource_status
         stack_api._deploy_job.assert_called()
         assert stack_api._deploy_job.call_args[0][0] == TEST_JOB_RESOURCE[api.RESOURCE_PROPERTIES]
-        assert stack_api._deploy_job.call_args[0][1] == test_job_physical_id
+        assert stack_api._deploy_job.call_args[0][1] == test_job_databricks_id
 
         # A workspace resource should have _deploy_resource call on _deploy_workspace
         stack_api._deploy_workspace = mock.MagicMock()
-        test_workspace_physical_id = {api.WORKSPACE_RESOURCE_PATH: '/test/path'}
-        stack_api._deploy_workspace.return_value = (test_workspace_physical_id, {})
-        test_workspace_resource_status = {api.RESOURCE_PHYSICAL_ID: test_workspace_physical_id}
+        test_workspace_databricks_id = {api.WORKSPACE_RESOURCE_PATH: '/test/path'}
+        stack_api._deploy_workspace.return_value = (test_workspace_databricks_id, {})
+        test_workspace_resource_status = {api.RESOURCE_DATABRICKS_ID: test_workspace_databricks_id}
         stack_api._deploy_resource(TEST_WORKSPACE_NB_RESOURCE,
                                    resource_status=test_workspace_resource_status,
                                    overwrite=True)
         stack_api._deploy_workspace.assert_called()
         assert stack_api._deploy_workspace.call_args[0][0] == \
             TEST_WORKSPACE_NB_RESOURCE[api.RESOURCE_PROPERTIES]
-        assert stack_api._deploy_workspace.call_args[0][1] == test_workspace_physical_id
+        assert stack_api._deploy_workspace.call_args[0][1] == test_workspace_databricks_id
 
         # A dbfs resource should have _deploy_resource call on _deploy_workspace
         stack_api._deploy_dbfs = mock.MagicMock()
-        stack_api._deploy_dbfs.return_value = (TEST_DBFS_FILE_PHYSICAL_ID, {})
+        stack_api._deploy_dbfs.return_value = (TEST_DBFS_FILE_DATABRICKS_ID, {})
         stack_api._deploy_resource(TEST_DBFS_FILE_RESOURCE,
                                    resource_status=TEST_DBFS_FILE_STATUS,
                                    overwrite_dbfs=True)
@@ -418,7 +419,7 @@ class TestStackApi(object):
         assert stack_api._deploy_dbfs.call_args[0][0] == \
             TEST_DBFS_FILE_RESOURCE[api.RESOURCE_PROPERTIES]
         assert stack_api._deploy_dbfs.call_args[0][1] == \
-            TEST_DBFS_FILE_STATUS[api.RESOURCE_PHYSICAL_ID]
+            TEST_DBFS_FILE_STATUS[api.RESOURCE_DATABRICKS_ID]
 
         # If there is a nonexistent type, raise a StackError.
         resource_badtype = {

--- a/tests/stack/test_api.py
+++ b/tests/stack/test_api.py
@@ -222,7 +222,7 @@ class TestStackApi(object):
         # TEST CASE 2:
         # stack_api._deploy_job should reset job if databricks_id given.
         res_databricks_id_2, res_deploy_output_2 = stack_api._deploy_job(alt_test_job_settings,
-                                                                            res_databricks_id_1)
+                                                                         res_databricks_id_1)
         # physical job id not changed from last update
         assert res_databricks_id_2[api.JOBS_RESOURCE_JOB_ID] == \
             res_databricks_id_1[api.JOBS_RESOURCE_JOB_ID]
@@ -353,7 +353,7 @@ class TestStackApi(object):
         assert stack_api.dbfs_client.cp.call_args[1]['dst'] == \
             test_dbfs_dir_properties[api.DBFS_RESOURCE_PATH]
         assert dir_databricks_id == {api.DBFS_RESOURCE_PATH:
-                                        test_dbfs_dir_properties[api.DBFS_RESOURCE_PATH]}
+                                     test_dbfs_dir_properties[api.DBFS_RESOURCE_PATH]}
         assert dir_deploy_output == test_deploy_output
 
         nb_databricks_id, nb_deploy_output = \
@@ -366,7 +366,7 @@ class TestStackApi(object):
         assert stack_api.dbfs_client.cp.call_args[1]['dst'] == \
             test_dbfs_file_properties[api.DBFS_RESOURCE_PATH]
         assert nb_databricks_id == {api.DBFS_RESOURCE_PATH:
-                                        test_dbfs_file_properties[api.DBFS_RESOURCE_PATH]}
+                                    test_dbfs_file_properties[api.DBFS_RESOURCE_PATH]}
         assert nb_deploy_output == test_deploy_output
 
         # Should raise error if resource properties is_dir field isn't consistent with whether the

--- a/tests/stack/test_api.py
+++ b/tests/stack/test_api.py
@@ -222,7 +222,7 @@ class TestStackApi(object):
         # TEST CASE 2:
         # stack_api._deploy_job should reset job if databricks_id given.
         res_databricks_id_2, res_deploy_output_2 = stack_api._deploy_job(alt_test_job_settings,
-                                                                       res_databricks_id_1)
+                                                                            res_databricks_id_1)
         # physical job id not changed from last update
         assert res_databricks_id_2[api.JOBS_RESOURCE_JOB_ID] == \
             res_databricks_id_1[api.JOBS_RESOURCE_JOB_ID]
@@ -304,7 +304,7 @@ class TestStackApi(object):
         assert stack_api.workspace_client.import_workspace.call_args[0][1] == \
             test_workspace_nb_properties[api.WORKSPACE_RESOURCE_PATH]
         assert nb_databricks_id == {api.WORKSPACE_RESOURCE_PATH:
-                                  test_workspace_nb_properties[api.WORKSPACE_RESOURCE_PATH]}
+                                    test_workspace_nb_properties[api.WORKSPACE_RESOURCE_PATH]}
         assert nb_deploy_output == test_deploy_output
 
         # Should raise error if resource object_type doesn't match actually is in filesystem.
@@ -353,7 +353,7 @@ class TestStackApi(object):
         assert stack_api.dbfs_client.cp.call_args[1]['dst'] == \
             test_dbfs_dir_properties[api.DBFS_RESOURCE_PATH]
         assert dir_databricks_id == {api.DBFS_RESOURCE_PATH:
-                                   test_dbfs_dir_properties[api.DBFS_RESOURCE_PATH]}
+                                        test_dbfs_dir_properties[api.DBFS_RESOURCE_PATH]}
         assert dir_deploy_output == test_deploy_output
 
         nb_databricks_id, nb_deploy_output = \
@@ -366,7 +366,7 @@ class TestStackApi(object):
         assert stack_api.dbfs_client.cp.call_args[1]['dst'] == \
             test_dbfs_file_properties[api.DBFS_RESOURCE_PATH]
         assert nb_databricks_id == {api.DBFS_RESOURCE_PATH:
-                                  test_dbfs_file_properties[api.DBFS_RESOURCE_PATH]}
+                                        test_dbfs_file_properties[api.DBFS_RESOURCE_PATH]}
         assert nb_deploy_output == test_deploy_output
 
         # Should raise error if resource properties is_dir field isn't consistent with whether the


### PR DESCRIPTION
this PR implements the changes on naming, as we agree to use "databricks_id" to represent the identifier of the deployed resource in the resource status after the stack is deployed.