### PR TITLE
[DATA-8793] Fix stack deploy when the job_id in status.json are not found in Databricks workspace

### DIFF
--- a/databricks_cli/stack/api.py
+++ b/databricks_cli/stack/api.py
@@ -292,9 +292,9 @@ class StackApi(object):
         try:
             self.jobs_client.reset_job({'job_id': job_id, 'new_settings': job_settings})
         except HTTPError:
-            click.echo('Warning: Job ID could not be found in the workspace while the status '
-                       'file still contains the Job ID {}. Please resolve the inconsistency '
-                       'before proceeding. Aborting job reset ...'.format(job_id))
+            raise StackError('Warning: Job ID could not be found in the workspace while the status '
+                             'file still contains the Job ID {}. Please resolve the inconsistency '
+                             'before proceeding. Aborting stack deployment ...'.format(job_id))
 
 
 def _deploy_workspace(self, resource_properties, databricks_id, overwrite):

--- a/databricks_cli/stack/api.py
+++ b/databricks_cli/stack/api.py
@@ -292,12 +292,11 @@ class StackApi(object):
         try:
             self.jobs_client.reset_job({'job_id': job_id, 'new_settings': job_settings})
         except HTTPError:
-            raise StackError('Warning: Job ID could not be found in the workspace while the status '
-                             'file still contains the Job ID {}. Please resolve the inconsistency '
+            raise StackError('Job ID could not be found in the workspace while the status file '
+                             'still contains the Job ID {}. Please resolve the inconsistency '
                              'before proceeding. Aborting stack deployment ...'.format(job_id))
 
-
-def _deploy_workspace(self, resource_properties, databricks_id, overwrite):
+    def _deploy_workspace(self, resource_properties, databricks_id, overwrite):
         """
         Deploy workspace asset.
 

--- a/databricks_cli/stack/api.py
+++ b/databricks_cli/stack/api.py
@@ -300,8 +300,8 @@ class StackApi(object):
                                    headers=headers)
         except HTTPError:
             raise StackError('Job ID could not be found in the workspace while the status file '
-                             'still contains the Job ID {}. Please remove or make necessary changes to '
-                             'the current status file to resolve this inconsistency '
+                             'still contains the Job ID {}. Please remove or make necessary '
+                             'changes to the current status file to resolve this inconsistency '
                              'before proceeding. Aborting stack deployment ...'.format(job_id))
             
     def _deploy_workspace(self, resource_properties, databricks_id, overwrite, headers=None):

--- a/databricks_cli/stack/api.py
+++ b/databricks_cli/stack/api.py
@@ -24,6 +24,7 @@
 import os
 import json
 from datetime import datetime
+from requests.exceptions import HTTPError
 
 import click
 
@@ -288,10 +289,15 @@ class StackApi(object):
         :param job_settings: job settings to update the job with.
         :param job_id: physical job_id of job in databricks server.
         """
+        try:
+            self.jobs_client.reset_job({'job_id': job_id, 'new_settings': job_settings})
+        except HTTPError:
+            click.echo('Warning: Job ID could not be found in the workspace while the status '
+                       'file still contains the Job ID {}. Please resolve the inconsistency '
+                       'before proceeding. Aborting job reset ...'.format(job_id))
 
-        self.jobs_client.reset_job({'job_id': job_id, 'new_settings': job_settings})
 
-    def _deploy_workspace(self, resource_properties, databricks_id, overwrite):
+def _deploy_workspace(self, resource_properties, databricks_id, overwrite):
         """
         Deploy workspace asset.
 

--- a/databricks_cli/stack/api.py
+++ b/databricks_cli/stack/api.py
@@ -297,13 +297,13 @@ class StackApi(object):
         """
         try:
             self.jobs_client.reset_job({'job_id': job_id, 'new_settings': job_settings},
-                                   headers=headers)
+                                       headers=headers)
         except HTTPError:
             raise StackError('Job ID could not be found in the workspace while the status file '
                              'still contains the Job ID {}. Please remove or make necessary '
                              'changes to the current status file to resolve this inconsistency '
                              'before proceeding. Aborting stack deployment ...'.format(job_id))
-            
+
     def _deploy_workspace(self, resource_properties, databricks_id, overwrite, headers=None):
         """
         Deploy workspace asset.

--- a/databricks_cli/stack/api.py
+++ b/databricks_cli/stack/api.py
@@ -300,7 +300,8 @@ class StackApi(object):
                                    headers=headers)
         except HTTPError:
             raise StackError('Job ID could not be found in the workspace while the status file '
-                             'still contains the Job ID {}. Please resolve the inconsistency '
+                             'still contains the Job ID {}. Please remove or make necessary changes to '
+                             'the current status file to resolve this inconsistency '
                              'before proceeding. Aborting stack deployment ...'.format(job_id))
             
     def _deploy_workspace(self, resource_properties, databricks_id, overwrite, headers=None):

--- a/databricks_cli/stack/api.py
+++ b/databricks_cli/stack/api.py
@@ -299,10 +299,10 @@ class StackApi(object):
             self.jobs_client.reset_job({'job_id': job_id, 'new_settings': job_settings},
                                        headers=headers)
         except HTTPError:
-            raise StackError('Job ID could not be found in the workspace while the status file '
-                             'still contains the Job ID {}. Please remove or make necessary '
-                             'changes to the current status file to resolve this inconsistency '
-                             'before proceeding. Aborting stack deployment ...'.format(job_id))
+            raise StackError('Job ID {} in stack status could not be found in the workspace. '
+                             'Please remove or make necessary changes to the current stack status '
+                             'to resolve this inconsistency before proceeding. Aborting '
+                             'stack deployment ...'.format(job_id))
 
     def _deploy_workspace(self, resource_properties, databricks_id, overwrite, headers=None):
         """

--- a/tests/stack/test_api.py
+++ b/tests/stack/test_api.py
@@ -247,11 +247,11 @@ class TestStackApi(object):
         # databricks_id, create another job.
         deleted_job_settings = TEST_JOB_DELETED_SETTINGS
         databricks_id_deleted = {api.JOBS_RESOURCE_JOB_ID: job_id_deleted}
-        # Job reset is aborted. Warning message about the inconsistency should appear
+        # Job reset is aborted. Error message about the inconsistency should appear
         with pytest.raises(StackError):
             stack_api._deploy_job(deleted_job_settings, databricks_id_deleted)
 
-def test_deploy_workspace(self, stack_api, tmpdir):
+    def test_deploy_workspace(self, stack_api, tmpdir):
         """
             stack_api._deploy_workspace should call certain workspace client functions depending
             on object_type and error when object_type is defined incorrectly.

--- a/tests/stack/test_api.py
+++ b/tests/stack/test_api.py
@@ -242,7 +242,9 @@ class TestStackApi(object):
         # TEST CASE 5
         # If a databricks_id is not found in workspace, then abort
         nonexisting_job_settings = TEST_JOB_NONEXISTING_SETTINGS
-        nonexisting_databricks_id = {api.JOBS_RESOURCE_JOB_ID: stack_api.jobs_client.nonexisting_job_id}
+        nonexisting_databricks_id = {
+            api.JOBS_RESOURCE_JOB_ID: stack_api.jobs_client.nonexisting_job_id
+        }
         # Job deployment is aborted. Error message about the inconsistency should appear
         with pytest.raises(StackError):
             stack_api._deploy_job(nonexisting_job_settings, nonexisting_databricks_id)

--- a/tests/stack/test_api.py
+++ b/tests/stack/test_api.py
@@ -143,6 +143,7 @@ TEST_STATUS = {
                          ]
 }
 
+
 class _TestJobsClient(object):
     def __init__(self):
         self.jobs_in_databricks = {}
@@ -155,7 +156,7 @@ class _TestJobsClient(object):
             raise HTTPError('Job not Found')
         else:
             return self.jobs_in_databricks[job_id]
-          
+
     def reset_job(self, data, headers=None):
         if data[api.JOBS_RESOURCE_JOB_ID] == self.deleted_job_id:
             raise HTTPError('Job ID could not be found in the workspace while '

--- a/tests/stack/test_api.py
+++ b/tests/stack/test_api.py
@@ -143,12 +143,11 @@ TEST_STATUS = {
                          ]
 }
 
-job_id_deleted = 111
-
 class _TestJobsClient(object):
     def __init__(self):
         self.jobs_in_databricks = {}
         self.available_job_id = [1234, 12345]
+        self.deleted_job_id = 111
 
     def get_job(self, job_id, headers=None):
         if job_id not in self.jobs_in_databricks:
@@ -158,8 +157,10 @@ class _TestJobsClient(object):
             return self.jobs_in_databricks[job_id]
           
     def reset_job(self, data, headers=None):
-        if data[api.JOBS_RESOURCE_JOB_ID] == job_id_deleted:
-            raise HTTPError
+        if data[api.JOBS_RESOURCE_JOB_ID] == self.deleted_job_id:
+            raise HTTPError('Job ID could not be found in the workspace while '
+                            'the status file still contains the Job ID {}'
+                            .format(self.deleted_job_id))
         elif data[api.JOBS_RESOURCE_JOB_ID] not in self.jobs_in_databricks:
             raise HTTPError('Job Not Found')
         self.jobs_in_databricks[data[api.JOBS_RESOURCE_JOB_ID]]['job_settings'] = \
@@ -245,7 +246,7 @@ class TestStackApi(object):
         # If a databricks_id is deleted from the workspace while the status file contains that
         # databricks_id, create another job.
         deleted_job_settings = TEST_JOB_DELETED_SETTINGS
-        databricks_id_deleted = {api.JOBS_RESOURCE_JOB_ID: job_id_deleted}
+        databricks_id_deleted = {api.JOBS_RESOURCE_JOB_ID: stack_api.jobs_client.deleted_job_id}
         # Job reset is aborted. Error message about the inconsistency should appear
         with pytest.raises(StackError):
             stack_api._deploy_job(deleted_job_settings, databricks_id_deleted)


### PR DESCRIPTION
1. Make changes to abort the deployment and print out a warning message when there is discrepancy between job_id's existence in status file and deletion from workspace. Then it is up to the user to either delete the current status files or pulling the latest status file from other version control sources (e.g. github).
2. Add Test Case #5 to make sure this fix works. 