### PR TITLE
Improve error message

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ To isolate dependencies from your global python installation, it is important to
 Another option would be to use docker directly, i.e. 
 ```bash
 docker run -it -v `echo $PWD`:/root python:3.6.8 bash
+docker run -it -v `echo $PWD`:/root python:2.7.12 bash
+
 ```
 
 - `pip install -e .`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,11 @@ Setting up the dev environment
 To isolate dependencies from your global python installation, it is important to use a tool like
 [virtualenv](https://virtualenv.pypa.io/en/stable/). With `virtualenv` you can install the dev environment by doing the following.
 
+Another option would be to use docker directly, i.e. 
+```bash
+docker run -it -v `echo $PWD`:/root python:3.6.8 bash
+```
+
 - `pip install -e .`
 - `pip install -r dev-requirements.txt`
 - `pip install -r tox-requirements.txt`

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -34,6 +34,7 @@ import warnings
 import requests
 import ssl
 import copy
+import pprint
 
 from . import version
 
@@ -111,5 +112,11 @@ class ApiClient(object):
         try:
             resp.raise_for_status()
         except requests.exceptions.HTTPError as e:
-            raise e
+            message = e.args[0]
+            try:
+                reason = pprint.pformat(json.loads(resp.content), indent=2)
+                message += '\n Response from server: \n {}'.format(reason)
+            except json.decoder.JSONDecodeError:
+                pass
+            raise requests.exceptions.HTTPError(message, response=e.response)
         return resp.json()

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -114,9 +114,9 @@ class ApiClient(object):
         except requests.exceptions.HTTPError as e:
             message = e.args[0]
             try:
-                reason = pprint.pformat(json.loads(resp.content), indent=2)
+                reason = pprint.pformat(json.loads(resp.text), indent=2)
                 message += '\n Response from server: \n {}'.format(reason)
-            except json.decoder.JSONDecodeError:
+            except ValueError:
                 pass
             raise requests.exceptions.HTTPError(message, response=e.response)
         return resp.json()

--- a/tests/sdk/test_api_client.py
+++ b/tests/sdk/test_api_client.py
@@ -57,5 +57,6 @@ def test_content_from_server_on_error(m):
     m.get('https://databricks.com/api/2.0/endpoint', status_code=400, text=json.dumps(data))
     client = ApiClient(user='apple', password='banana', host='https://databricks.com')
     error_message_contains = "{'cucumber': 'dade'}"
-    with pytest.raises(requests.exceptions.HTTPError, match=error_message_contains):
+    with pytest.raises(requests.exceptions.HTTPError) as e:
         client.perform_query('GET', '/endpoint')
+        assert error_message_contains in e.value.message

--- a/tests/sdk/test_api_client.py
+++ b/tests/sdk/test_api_client.py
@@ -20,6 +20,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
+
+import pytest
+import requests
+import requests_mock
 
 from databricks_cli.sdk.api_client import ApiClient
 
@@ -29,3 +34,28 @@ def test_api_client_constructor():
     client = ApiClient(user='apple', password='banana', host='https://databricks.com')
     # echo -n "apple:banana" | base64
     assert client.default_headers['Authorization'] == 'Basic YXBwbGU6YmFuYW5h'
+
+@pytest.fixture()
+def m():
+    with requests_mock.Mocker() as m:
+        yield m
+
+def test_simple_request(m):
+    data = {'cucumber': 'dade'}
+    m.get('https://databricks.com/api/2.0/endpoint', text=json.dumps(data))
+    client = ApiClient(user='apple', password='banana', host='https://databricks.com')
+    assert client.perform_query('GET', '/endpoint') == data
+
+def test_no_content_from_server_on_error(m):
+    m.get('https://databricks.com/api/2.0/endpoint', status_code=400, text='some html message')
+    client = ApiClient(user='apple', password='banana', host='https://databricks.com')
+    with pytest.raises(requests.exceptions.HTTPError):
+        client.perform_query('GET', '/endpoint')
+
+def test_content_from_server_on_error(m):
+    data = {'cucumber': 'dade'}
+    m.get('https://databricks.com/api/2.0/endpoint', status_code=400, text=json.dumps(data))
+    client = ApiClient(user='apple', password='banana', host='https://databricks.com')
+    error_message_contains = "{'cucumber': 'dade'}"
+    with pytest.raises(requests.exceptions.HTTPError, match=error_message_contains):
+        client.perform_query('GET', '/endpoint')

--- a/tox-requirements.txt
+++ b/tox-requirements.txt
@@ -2,9 +2,10 @@
 prospector[with_pyroma]==0.12.7
 pylint==1.8.2
 pep8-naming==0.5.0
-pytest==3.2.1
+pytest==3.8.1
 mock==2.0.0
 decorator==4.2.1
 rstcheck==3.2
-pytest-cov
+pytest-cov==2.5.1
 codecov
+requests_mock==1.5.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py36
 
 [testenv]
 # https://github.com/codecov/codecov-python/blob/5b9d539a6a09bc84501b381b563956295478651a/README.md#using-tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py27, py36
 
 [testenv]
 # https://github.com/codecov/codecov-python/blob/5b9d539a6a09bc84501b381b563956295478651a/README.md#using-tox


### PR DESCRIPTION
Currently the databricks CLI (and SDK) do not return any useful messages when the server returns a 400. Most often this is the result of an invalid json configuration when creating jobs, runs, clusters etc.

The only way to currently figure out what is wrong in the json is to use the REST API directly (e.g. using `curl`).

This PR aims to add the meaningful message that the server provides to the output of the CLI and SDK.