### PR TITLE
Fix URL construction in the ApiClient class

### DIFF
--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -74,8 +74,8 @@ class ApiClient(object):
         self.session.mount('https://', TlsV1HttpAdapter())
 
         parsed_url = urlparse(host)
-        scheme = parsed_url[0]
-        hostname = parsed_url[1]
+        scheme = parsed_url.scheme
+        hostname = parsed_url.hostname
         self.url = "%s://%s/api/%s" % (scheme, hostname, apiVersion)
         if user is not None and password is not None:
             encoded_auth = (user + ":" + password).encode()

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -39,6 +39,7 @@ import pprint
 from . import version
 
 from requests.adapters import HTTPAdapter
+from six.moves.urllib.parse import urlparse
 
 try:
     from requests.packages.urllib3.poolmanager import PoolManager
@@ -72,7 +73,10 @@ class ApiClient(object):
         self.session = requests.Session()
         self.session.mount('https://', TlsV1HttpAdapter())
 
-        self.url = "%s/api/%s" % (host, apiVersion)
+        parsed_url = urlparse(host)
+        scheme = parsed_url[0]
+        hostname = parsed_url[1]
+        self.url = "%s://%s/api/%s" % (scheme, hostname, apiVersion)
         if user is not None and password is not None:
             encoded_auth = (user + ":" + password).encode()
             user_header_data = "Basic " + base64.standard_b64encode(encoded_auth).decode()
@@ -108,7 +112,6 @@ class ApiClient(object):
             warnings.simplefilter("ignore", exceptions.InsecureRequestWarning)
             resp = self.session.request(method, self.url + path, data = json.dumps(data),
                 verify = self.verify, headers = headers)
-
         try:
             resp.raise_for_status()
         except requests.exceptions.HTTPError as e:

--- a/tests/configure/test_config.py
+++ b/tests/configure/test_config.py
@@ -136,7 +136,7 @@ def test_command_headers():
     def test_command(api_client, x): # noqa
         click.echo(json.dumps(api_client.default_headers))
 
-    with mock.patch("databricks_cli.configure.provider.DatabricksConfig") as config_mock:
+    with mock.patch("databricks_cli.configure.config.get_config") as config_mock:
         with mock.patch("uuid.uuid1") as uuid_mock:
             config_mock.return_value = DatabricksConfig.from_token(TEST_HOST, TEST_TOKEN)
             uuid_mock.return_value = '1234'

--- a/tests/sdk/test_api_client.py
+++ b/tests/sdk/test_api_client.py
@@ -61,6 +61,17 @@ def test_content_from_server_on_error(m):
         client.perform_query('GET', '/endpoint')
         assert error_message_contains in e.value.message
 
-def test_api_client_url_with_queryparams():
+def test_api_client_url_parsing():
+    client = ApiClient(host='https://databricks.com')
+    assert client.url == 'https://databricks.com/api/2.0'
+
     client = ApiClient(host='https://databricks.com/?o=123')
     assert client.url == 'https://databricks.com/api/2.0'
+
+    client = ApiClient(host='https://databricks.com?o=123')
+    assert client.url == 'https://databricks.com/api/2.0'
+
+    # NOTE: this technically is not possible since we validate that the "host" has a prefix of https:// in
+    # databricks_cli.configure.cli
+    client = ApiClient(host='http://databricks.com')
+    assert client.url == 'http://databricks.com/api/2.0'

--- a/tests/sdk/test_api_client.py
+++ b/tests/sdk/test_api_client.py
@@ -60,3 +60,7 @@ def test_content_from_server_on_error(m):
     with pytest.raises(requests.exceptions.HTTPError) as e:
         client.perform_query('GET', '/endpoint')
         assert error_message_contains in e.value.message
+
+def test_api_client_url_with_queryparams():
+    client = ApiClient(host='https://databricks.com/?o=123')
+    assert client.url == 'https://databricks.com/api/2.0'


### PR DESCRIPTION
Should close https://github.com/databricks/databricks-cli/issues/174.

In that issue, we construct incorrect URLs when the `host` parameter to `ApiClient` looks like `https://westus.azuredatabricks.net/?o=2291051382977284`.