### PR TITLE
Fix uninstall all libraries so it doesn't throw INTERNAL_ERROR

### DIFF
--- a/databricks_cli/libraries/cli.py
+++ b/databricks_cli/libraries/cli.py
@@ -239,6 +239,8 @@ def uninstall_cli(api_client, cluster_id, all, jar, egg, whl, maven_coordinates,
         libraries_api = LibrariesApi(api_client)
         library_statuses = libraries_api.cluster_status(cluster_id).get('library_statuses', [])
         libraries = [l_status['library'] for l_status in library_statuses]
+        if len(libraries) == 0:
+            return
         libraries_api.uninstall_libraries(cluster_id, libraries)
         _uninstall_cli_exit_help(cluster_id)
         return

--- a/tests/libraries/test_cli.py
+++ b/tests/libraries/test_cli.py
@@ -262,6 +262,20 @@ def test_uninstall_cli_all(libraries_api_mock):
 
 
 @provide_conf
+def test_uninstall_cli_all_for_no_libraries(libraries_api_mock):
+    runner = CliRunner()
+    libraries_api_mock.cluster_status.return_value = {
+        "library_statuses": [
+        ],
+        "cluster_id": TEST_CLUSTER_ID,
+    }
+    runner.invoke(cli.uninstall_cli, [
+        '--cluster-id', TEST_CLUSTER_ID,
+        '--all'])
+    libraries_api_mock.uninstall_libraries.assert_not_called()
+
+
+@provide_conf
 def test_uninstall_cli_jar(libraries_api_mock):
     test_jar = 'dbfs:/test.jar'
     runner = CliRunner()


### PR DESCRIPTION
Currently using `databricks libraries uninstall --all --cluster-id <ID>` will blow up if the cluster has no libraries installed. We should fix this by not trying to uninstall an empty list of libraries.