### PR TITLE
Fix boolean query parameters to GET requests

### DIFF
--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -111,7 +111,8 @@ class ApiClient(object):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", exceptions.InsecureRequestWarning)
             if method == 'GET':
-                resp = self.session.request(method, self.url + path, params = data,
+                translated_data = {k: _translate_boolean_to_query_param(data[k]) for k in data}
+                resp = self.session.request(method, self.url + path, params = translated_data,
                     verify = self.verify, headers = headers)
             else:
                 resp = self.session.request(method, self.url + path, data = json.dumps(data),
@@ -127,3 +128,13 @@ class ApiClient(object):
                 pass
             raise requests.exceptions.HTTPError(message, response=e.response)
         return resp.json()
+
+
+def _translate_boolean_to_query_param(value):
+    assert not isinstance(value, list), 'The value of the data dict cannot be a list'
+    if isinstance(value, bool):
+        if value:
+            return 'true'
+        else:
+            return 'false'
+    return value

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -131,7 +131,7 @@ class ApiClient(object):
 
 
 def _translate_boolean_to_query_param(value):
-    assert not isinstance(value, list), 'The value of the data dict cannot be a list'
+    assert not isinstance(value, list), 'GET parameters cannot pass list of objects'
     if isinstance(value, bool):
         if value:
             return 'true'

--- a/tests/sdk/test_api_client.py
+++ b/tests/sdk/test_api_client.py
@@ -95,7 +95,7 @@ def test_get_request_with_float_param(m):
 
 def test_get_request_with_list_param(m):
     client = ApiClient(user='apple', password='banana', host='https://databricks.com')
-    with pytest.raises(AssertionError, message='cannot be a list'):
+    with pytest.raises(AssertionError, message='cannot pass list of objects'):
         client.perform_query('GET', '/endpoint', {'job_id': ['a','b']})
 
 

--- a/tests/sdk/test_api_client.py
+++ b/tests/sdk/test_api_client.py
@@ -35,6 +35,9 @@ def test_api_client_constructor():
     # echo -n "apple:banana" | base64
     assert client.default_headers['Authorization'] == 'Basic YXBwbGU6YmFuYW5h'
 
+
+requests_mock.mock.case_sensitive = True
+
 @pytest.fixture()
 def m():
     with requests_mock.Mocker() as m:
@@ -60,6 +63,41 @@ def test_content_from_server_on_error(m):
     with pytest.raises(requests.exceptions.HTTPError) as e:
         client.perform_query('GET', '/endpoint')
         assert error_message_contains in e.value.message
+
+
+def test_get_request_with_true_param(m):
+    data = {'cucumber': 'dade'}
+    m.get('https://databricks.com/api/2.0/endpoint?active_only=true', text=json.dumps(data))
+    client = ApiClient(user='apple', password='banana', host='https://databricks.com')
+    assert client.perform_query('GET', '/endpoint', {'active_only': True}) == data
+
+
+def test_get_request_with_false_param(m):
+    data = {'cucumber': 'dade'}
+    m.get('https://databricks.com/api/2.0/endpoint?active_only=false', text=json.dumps(data))
+    client = ApiClient(user='apple', password='banana', host='https://databricks.com')
+    assert client.perform_query('GET', '/endpoint', {'active_only': False}) == data
+
+
+def test_get_request_with_int_param(m):
+    data = {'cucumber': 'dade'}
+    m.get('https://databricks.com/api/2.0/endpoint?job_id=0', text=json.dumps(data))
+    client = ApiClient(user='apple', password='banana', host='https://databricks.com')
+    assert client.perform_query('GET', '/endpoint', {'job_id': 0}) == data
+
+
+def test_get_request_with_float_param(m):
+    data = {'cucumber': 'dade'}
+    m.get('https://databricks.com/api/2.0/endpoint?job_id=0.25', text=json.dumps(data))
+    client = ApiClient(user='apple', password='banana', host='https://databricks.com')
+    assert client.perform_query('GET', '/endpoint', {'job_id': 0.25}) == data
+
+
+def test_get_request_with_list_param(m):
+    client = ApiClient(user='apple', password='banana', host='https://databricks.com')
+    with pytest.raises(AssertionError, message='cannot be a list'):
+        client.perform_query('GET', '/endpoint', {'job_id': ['a','b']})
+
 
 def test_api_client_url_parsing():
     client = ApiClient(host='https://databricks.com')


### PR DESCRIPTION
It looks like we broke get requests with boolean parameters in https://github.com/databricks/databricks-cli/pull/213. The reason why is because `request('GET', 'https://databricks.com/endpoint', params={'active_only': True})` gets serialized as

`https://databricks.com/endpoint?active_only=True` instead of `https://databricks.com/endpoint?active_only=true`.

I've also added an assertion that we're not using lists as parameters for get requests. I've audited all our API calls and checked that we're not doing this.