### PR TITLE
Address dependencies needed to allow Docker image to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,13 @@ WORKDIR /usr/src/databricks-cli
 COPY . .
 
 RUN pip install --upgrade pip && \
-    pip install -r dev-requirements.txt && \
+    pip install \
+        -r dev-requirements.txt \
+        -r tox-requirements.txt && \
     pip list && \
     ./lint.sh && \
     pip install . && \
-    pytest tests
+    pytest tests && \
+    pip uninstall -y -r tox-requirements.txt
 
 ENTRYPOINT [ "databricks" ]

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,3 @@
-tox==2.9.1
+tox==3.8.6
+click==7.0
+tabulate==0.8.3


### PR DESCRIPTION
This is the smallest patch I could come up with to allow for this to build in Docker. This addresses issue #166. Both _click_ and _tabulate_ are imported in the application directly, so those libraries were added to _dev-requirements.txt_ instead of _tox-requirements.txt_