### PR TITLE
Add support for dbfs to dbfs copies

### DIFF
--- a/databricks_cli/dbfs/cli.py
+++ b/databricks_cli/dbfs/cli.py
@@ -102,8 +102,7 @@ def cp_cli(api_client, recursive, overwrite, src, dst):
     """
     Copy files to and from DBFS.
 
-    Note that this function will fail if the src and dst are both on the local filesystem
-    or if they are both DBFS paths.
+    Note that this function will fail if the src and dst are both on the local filesystem.
 
     For non-recursive copies, if the dst is a directory, the file will be placed inside the
     directory. For example ``dbfs cp dbfs:/apple.txt .`` will create a file at `./apple.txt`.


### PR DESCRIPTION
Hi all,

This PR enables copying files from dbfs locations to other dbfs locations by using a temp file/dir on the local filesystem as a stepping stone.

Cheers,
Daniel