### PR TITLE
Add dbfs cat cli option

### DIFF
--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -225,8 +225,8 @@ class DbfsApi(object):
                            'with dbfs:/')
         elif DbfsPath.is_valid(src) and DbfsPath.is_valid(dst):
             with TempDir() as temp_dir:
-                # Always copy to <temp_dir>/temp since this will work no matter if it's a recursive or a non-recursive
-                # copy.
+                # Always copy to <temp_dir>/temp since this will work no matter if it's a
+                # recursive or a non-recursive copy.
                 temp_path = temp_dir.path('temp')
                 self.cp(recursive, True, src, temp_path)
                 self.cp(recursive, overwrite, temp_path, dst)

--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -234,6 +234,15 @@ class DbfsApi(object):
         else:
             assert False, 'not reached'
 
+    def cat(self, src):
+        temp_path = self._create_local_temp_path(False)
+        try:
+            self.cp(False, True, src, temp_path)
+            with open(temp_path) as f:
+                click.echo(f.read(), nl=False)
+        finally:
+            self._remove_local_temp_path(False, temp_path)
+
     def _create_local_temp_path(self, recursive):
         # create a temp file/dir to store the data
         if recursive:

--- a/databricks_cli/dbfs/cli.py
+++ b/databricks_cli/dbfs/cli.py
@@ -145,9 +145,23 @@ def dbfs_group():
     pass
 
 
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.argument('src')
+@debug_option
+@profile_option
+@eat_exceptions
+@provide_api_client
+def cat_cli(api_client, src):
+    """
+    Show the contents of a file. Does not work for directories.
+    """
+    DbfsApi(api_client).cat(src)
+
+
 dbfs_group.add_command(configure_cli, name='configure')
 dbfs_group.add_command(ls_cli, name='ls')
 dbfs_group.add_command(mkdirs_cli, name='mkdirs')
 dbfs_group.add_command(rm_cli, name='rm')
 dbfs_group.add_command(cp_cli, name='cp')
 dbfs_group.add_command(mv_cli, name='mv')
+dbfs_group.add_command(cat_cli, name='cat')

--- a/databricks_cli/dbfs/cli.py
+++ b/databricks_cli/dbfs/cli.py
@@ -102,8 +102,7 @@ def cp_cli(api_client, recursive, overwrite, src, dst):
     """
     Copy files to and from DBFS.
 
-    Note that this function will fail if the src and dst are both on the local filesystem
-    or if they are both DBFS paths.
+    Note that this function will fail if the src and dst are both on the local filesystem.
 
     For non-recursive copies, if the dst is a directory, the file will be placed inside the
     directory. For example ``dbfs cp dbfs:/apple.txt .`` will create a file at `./apple.txt`.

--- a/tests/dbfs/test_api.py
+++ b/tests/dbfs/test_api.py
@@ -151,3 +151,17 @@ class TestDbfsApi(object):
 
         with open(test_file_path, 'r') as f:
             assert f.read() == 'x'
+
+    def test_cat(self, dbfs_api):
+        dbfs_api.client.get_status.return_value = {
+            'path': '/test',
+            'is_dir': False,
+            'file_size': 1
+        }
+        dbfs_api.client.read.return_value = {
+            'bytes_read': 1,
+            'data': b64encode(b'a'),
+        }
+        with mock.patch('databricks_cli.dbfs.api.click') as click_mock:
+            dbfs_api.cat('dbfs:/whatever-doesnt-matter')
+            click_mock.echo.assert_called_with('a', nl=False)


### PR DESCRIPTION
Hi all,

This PR adds the option to `cat` a file on on dbfs. It re-uses some of the functionality implemented in #225 (so there is some overlap). 

Cheers,
Daniel