### PR TITLE
remove NOTE section from jobs reset doc

### DIFF
--- a/databricks_cli/jobs/cli.py
+++ b/databricks_cli/jobs/cli.py
@@ -71,11 +71,6 @@ def reset_cli(api_client, json_file, json, job_id):
 
     The specification for the json option can be found
     https://docs.databricks.com/api/latest/jobs.html#jobsjobsettings
-
-    NOTE. The json parameter described above is not the same as what is normally POSTed
-    in the request body to the reset endpoint. Instead it is the object
-    defined in the top level "new_settings" field. The job ID is provided
-    by the --job-id option.
     """
     if not bool(json_file) ^ bool(json):
         raise RuntimeError('Either --json-file or --json should be provided')


### PR DESCRIPTION
We have had reports from our users that the note section in the doc
for "databricks jobs reset" is confusing and hence we would like to
remove it. We feel the doc in itself without the note is clear enough.