### PR TITLE
Add a CredentialProvider reading from TaskContext in Spark Executors.

### DIFF
--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -215,11 +215,12 @@ class SparkTaskContextConfigProvider(DatabricksConfigProvider):
         context = self._get_spark_task_context_or_none()
         if context is not None:
             host = context.getLocalProperty("spark.databricks.api.url")
-       	    token = context.getLocalProperty("spark.databricks.token")
+            token = context.getLocalProperty("spark.databricks.token")
             config = DatabricksConfig.from_token(host=host, token=token)
             if config.is_valid:
                 return config
         return None
+
 
 class EnvironmentVariableConfigProvider(DatabricksConfigProvider):
     """Loads from system environment variables."""

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -211,20 +211,20 @@ class SparkTaskContextConfigProvider(DatabricksConfigProvider):
             return TaskContext.get()
         except ImportError:
             return None
-    
+  
     @classmethod
     def set_ignore_insecure(cls, x):
-        from pyspark import SparkContext        
+        from pyspark import SparkContext  # pylint: disable=import-error      
         new_val = "True" if x else None
         SparkContext._active_spark_context.setLocalProperty("spark.databricks.ignoreTls", new_val)
-    
+ 
     def get_config(self):
         context = self._get_spark_task_context_or_none()
         if context is not None:
             host = context.getLocalProperty("spark.databricks.api.url")
             token = context.getLocalProperty("spark.databricks.token")
-            ignoreTls = context.getLocalProperty("spark.databricks.ignoreTls")
-            config = DatabricksConfig.from_token(host=host, token=token, insecure=ignoreTls)
+            insecure = context.getLocalProperty("spark.databricks.ignoreTls")
+            config = DatabricksConfig.from_token(host=host, token=token, insecure=insecure)
             if config.is_valid:
                 return config
         return None

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -211,13 +211,20 @@ class SparkTaskContextConfigProvider(DatabricksConfigProvider):
             return TaskContext.get()
         except ImportError:
             return None
-
+    
+    @classmethod
+    def set_ignore_insecure(cls, x):
+        from pyspark import SparkContext        
+        new_val = "True" is x else None
+        SparkContext._active_spark_context.setLocalProperty("spark.databricks.ignoreTls", new_val)
+    
     def get_config(self):
         context = self._get_spark_task_context_or_none()
         if context is not None:
             host = context.getLocalProperty("spark.databricks.api.url")
             token = context.getLocalProperty("spark.databricks.token")
-            config = DatabricksConfig.from_token(host=host, token=token)
+            ignoreTls = context.getLocalProperty("spark.databricks.ignoreTls")
+            config = DatabricksConfig.from_token(host=host, token=token, insecure=ignoreTls)
             if config.is_valid:
                 return config
         return None

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -203,7 +203,7 @@ class DefaultConfigProvider(DatabricksConfigProvider):
 
 class SparkTaskContextConfigProvider(DatabricksConfigProvider):
     """Loads credentials from Spark TaskContext if running in a Spark Executor."""
-    
+
     @staticmethod
     def _get_spark_task_context_or_none():
         try:

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -206,7 +206,7 @@ class SparkTaskContextConfigProvider(DatabricksConfigProvider):
     @staticmethod
     def _get_spark_task_context_or_none():
         try:
-            from pyspark import TaskContext
+            from pyspark import TaskContext  # pylint: disable=import-error
             return TaskContext.get()
         except:
             return None

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -215,7 +215,7 @@ class SparkTaskContextConfigProvider(DatabricksConfigProvider):
     @classmethod
     def set_ignore_insecure(cls, x):
         from pyspark import SparkContext        
-        new_val = "True" is x else None
+        new_val = "True" if x else None
         SparkContext._active_spark_context.setLocalProperty("spark.databricks.ignoreTls", new_val)
     
     def get_config(self):

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -213,7 +213,7 @@ class SparkTaskContextConfigProvider(DatabricksConfigProvider):
             return None
 
     @classmethod
-    def set_ignore_insecure(cls, x):
+    def set_insecure(cls, x):
         from pyspark import SparkContext  # pylint: disable=import-error      
         new_val = "True" if x else None
         SparkContext._active_spark_context.setLocalProperty("spark.databricks.ignoreTls", new_val)

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -212,8 +212,8 @@ class SparkTaskContextConfigProvider(DatabricksConfigProvider):
         except ImportError:
             return None
 
-    @classmethod
-    def set_insecure(cls, x):
+    @staticmethod
+    def set_insecure(x):
         from pyspark import SparkContext  # pylint: disable=import-error      
         new_val = "True" if x else None
         SparkContext._active_spark_context.setLocalProperty("spark.databricks.ignoreTls", new_val)

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -211,13 +211,13 @@ class SparkTaskContextConfigProvider(DatabricksConfigProvider):
             return TaskContext.get()
         except ImportError:
             return None
-  
+
     @classmethod
     def set_ignore_insecure(cls, x):
         from pyspark import SparkContext  # pylint: disable=import-error      
         new_val = "True" if x else None
         SparkContext._active_spark_context.setLocalProperty("spark.databricks.ignoreTls", new_val)
- 
+
     def get_config(self):
         context = self._get_spark_task_context_or_none()
         if context is not None:

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -200,6 +200,7 @@ class DefaultConfigProvider(DatabricksConfigProvider):
                 return config
         return None
 
+
 class SparkTaskContextConfigProvider(DatabricksConfigProvider):
     """Loads credentials from Spark TaskContext if running in a Spark Executor."""
     
@@ -208,7 +209,7 @@ class SparkTaskContextConfigProvider(DatabricksConfigProvider):
         try:
             from pyspark import TaskContext  # pylint: disable=import-error
             return TaskContext.get()
-        except:
+        except ImportError:
             return None
 
     def get_config(self):

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -135,7 +135,11 @@ def test_get_config_uses_default_profile():
 
 
 def test_get_config_uses_task_context_variable():
-    class TaskContextMock:
+    class TaskContextMock(object):
+        
+        def __init__(self):
+            pass
+
         def getLocalProperty(self, x):  # NOQA
             if x == "spark.databricks.api.url":
                 return "url"
@@ -143,6 +147,7 @@ def test_get_config_uses_task_context_variable():
                 return "token"
             else:
                 raise Exception("should not get here.")
+
     ctx_class = ("databricks_cli.configure.provider.SparkTaskContextConfigProvider."
                  "_get_spark_task_context_or_none")
     with patch(ctx_class) as get_context_mock:

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -136,7 +136,7 @@ def test_get_config_uses_default_profile():
 
 def test_get_config_uses_task_context_variable():
     class TaskContextMock(object):
-        
+ 
         def __init__(self):
             pass
 

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -145,9 +145,7 @@ def test_get_config_uses_task_context_variable():
                 raise Exception("should not get here.")
     ctx_class = "databricks_cli.configure.provider.SparkTaskContextConfigProvider._get_spark_task_context_or_none"
     with patch(ctx_class) as get_context_mock:
-        def get_context(*args, **kwargs):
-            return TaskContextMock()
-        get_context_mock.side_effect = get_context
+        get_context_mock.return_value = TaskContextMock()
         config = get_config()
         assert config.host == "url"
         assert config.token == "token"

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -157,7 +157,7 @@ def test_get_config_uses_task_context_variable():
         config = get_config()
         assert config.host == "url"
         assert config.token == "token"
-        assert config.insecure = "True"
+        assert config.insecure == "True"
         assert config.username is None
         assert config.password is None
 

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -136,7 +136,7 @@ def test_get_config_uses_default_profile():
 
 def test_get_config_uses_task_context_variable():
     class TaskContextMock(object):
- 
+
         def __init__(self):
             pass
 
@@ -145,6 +145,8 @@ def test_get_config_uses_task_context_variable():
                 return "url"
             elif x == "spark.databricks.token":
                 return "token"
+            elif x == "spark.databricks.ignoreTls":
+                return "True"
             else:
                 raise Exception("should not get here.")
 
@@ -155,6 +157,7 @@ def test_get_config_uses_task_context_variable():
         config = get_config()
         assert config.host == "url"
         assert config.token == "token"
+        assert config.insecure = "True"
         assert config.username is None
         assert config.password is None
 

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -28,7 +28,8 @@ import pytest
 
 from databricks_cli.configure.provider import DatabricksConfig, DEFAULT_SECTION, \
     update_and_persist_config, get_config_for_profile, get_config, \
-    set_config_provider, ProfileConfigProvider, _get_path, DatabricksConfigProvider
+    set_config_provider, ProfileConfigProvider, _get_path, DatabricksConfigProvider,\
+    SparkTaskContextConfigProvider
 from databricks_cli.utils import InvalidConfigurationError
 
 
@@ -152,6 +153,10 @@ def test_get_config_uses_task_context_variable():
         assert config.token == "token"
         assert config.username is None
         assert config.password is None
+
+
+def test_task_context_provider_does_not_break_stuff():
+   assert SparkTaskContextConfigProvider().get_config() is None
 
 
 def test_get_config_uses_env_variable():

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -136,7 +136,7 @@ def test_get_config_uses_default_profile():
 
 def test_get_config_uses_task_context_variable():
     class TaskContextMock:
-        def getLocalProperty(self, x):  # pylint: disable=function-lowercase
+        def getLocalProperty(self, x):  # NOQA
             if x == "spark.databricks.api.url":
                 return "url"
             elif x == "spark.databricks.token":

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -136,14 +136,15 @@ def test_get_config_uses_default_profile():
 
 def test_get_config_uses_task_context_variable():
     class TaskContextMock:
-        def getLocalProperty(self, x):
+        def getLocalProperty(self, x):  # pylint: disable=function-lowercase
             if x == "spark.databricks.api.url":
                 return "url"
             elif x == "spark.databricks.token":
                 return "token"
             else:
                 raise Exception("should not get here.")
-    ctx_class = "databricks_cli.configure.provider.SparkTaskContextConfigProvider._get_spark_task_context_or_none"
+    ctx_class = ("databricks_cli.configure.provider.SparkTaskContextConfigProvider."
+                 "_get_spark_task_context_or_none")
     with patch(ctx_class) as get_context_mock:
         get_context_mock.return_value = TaskContextMock()
         config = get_config()
@@ -154,7 +155,7 @@ def test_get_config_uses_task_context_variable():
 
 
 def test_task_context_provider_does_not_break_stuff():
-   assert SparkTaskContextConfigProvider().get_config() is None
+    assert SparkTaskContextConfigProvider().get_config() is None
 
 
 def test_get_config_uses_env_variable():


### PR DESCRIPTION
This PR adds ability to pass db config via TaskContext when running in Spark. 