### PR TITLE
Add cluster events CLI

### DIFF
--- a/databricks_cli/clusters/api.py
+++ b/databricks_cli/clusters/api.py
@@ -63,5 +63,6 @@ class ClusterApi(object):
     def permanent_delete(self, cluster_id):
         return self.client.permanent_delete_cluster(cluster_id)
 
-    def cluster_events(self, cluster_id):
-        return self.client.cluster_events(cluster_id)
+    def cluster_events(self, cluster_id, start_time, end_time, order, event_types, offset, limit):
+        return self.client.cluster_events(cluster_id, start_time, end_time, order, event_types,
+                                          offset, limit)

--- a/databricks_cli/clusters/api.py
+++ b/databricks_cli/clusters/api.py
@@ -62,3 +62,6 @@ class ClusterApi(object):
 
     def permanent_delete(self, cluster_id):
         return self.client.permanent_delete_cluster(cluster_id)
+
+    def cluster_events(self, cluster_id):
+        return self.client.cluster_events(cluster_id)

--- a/databricks_cli/clusters/api.py
+++ b/databricks_cli/clusters/api.py
@@ -63,6 +63,6 @@ class ClusterApi(object):
     def permanent_delete(self, cluster_id):
         return self.client.permanent_delete_cluster(cluster_id)
 
-    def cluster_events(self, cluster_id, start_time, end_time, order, event_types, offset, limit):
-        return self.client.cluster_events(cluster_id, start_time, end_time, order, event_types,
-                                          offset, limit)
+    def get_events(self, cluster_id, start_time, end_time, order, event_types, offset, limit):
+        return self.client.get_events(cluster_id, start_time, end_time, order, event_types,
+                                      offset, limit)

--- a/databricks_cli/clusters/cli.py
+++ b/databricks_cli/clusters/cli.py
@@ -288,7 +288,7 @@ def permanent_delete_cli(api_client, cluster_id):
               help="The end time in epoch milliseconds. If unprovided, returns events up to the "
                    "current time")
 @click.option('--order', required=False, default=None,
-              help="The order to list events in; either ASC or DESC. Defaults to DESC (most recent first).")
+              help="The order to list events in; either ASC or DESC. Defaults to DESC (most recent first)")
 @click.option('--event-type', required=False, default=None,
               help="An event types to filter on (specify multiple event types by passing "
                    "the --event-type option multiple times). If empty, all event types "

--- a/databricks_cli/clusters/cli.py
+++ b/databricks_cli/clusters/cli.py
@@ -265,6 +265,20 @@ def permanent_delete_cli(api_client, cluster_id):
     ClusterApi(api_client).permanent_delete(cluster_id)
 
 
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.option('--cluster-id', required=True, type=ClusterIdClickType(),
+              help=ClusterIdClickType.help)
+@debug_option
+@profile_option
+@eat_exceptions
+@provide_api_client
+def cluster_events_cli(api_client, cluster_id):
+    """
+    Gets events for a Spark cluster.
+    """
+    click.echo(pretty_format(ClusterApi(api_client).cluster_events(cluster_id)))
+
+
 @click.group(context_settings=CONTEXT_SETTINGS,
              short_help='Utility to interact with Databricks clusters.')
 @click.option('--version', '-v', is_flag=True, callback=print_version_callback,
@@ -291,3 +305,5 @@ clusters_group.add_command(list_zones_cli, name='list-zones')
 clusters_group.add_command(list_node_types_cli, name='list-node-types')
 clusters_group.add_command(spark_versions_cli, name='spark-versions')
 clusters_group.add_command(permanent_delete_cli, name='permanent-delete')
+clusters_group.add_command(cluster_events_cli, name='events')
+

--- a/databricks_cli/clusters/cli.py
+++ b/databricks_cli/clusters/cli.py
@@ -287,7 +287,7 @@ def permanent_delete_cli(api_client, cluster_id):
               help="The end time in epoch milliseconds. If unprovided, returns events up to the "
                    "current time")
 @click.option('--order', required=False, default=None,
-              help="The order to list events in; either ASC or DESC. Defaults to DESC.")
+              help="The order to list events in; either ASC or DESC. Defaults to DESC (most recent first).")
 @click.option('--event-type', required=False, default=None,
               help="An event types to filter on (specify multiple event types by passing "
                    "the --event-type option multiple times). If empty, all event types "
@@ -309,7 +309,7 @@ def cluster_events_cli(api_client, cluster_id, start_time, end_time, order, even
     """
     Gets events for a Spark cluster.
     """
-    events_json = ClusterApi(api_client).cluster_events(
+    events_json = ClusterApi(api_client).get_events(
         cluster_id=cluster_id, start_time=start_time, end_time=end_time, order=order,
         event_types=event_type, offset=offset, limit=limit)
     if OutputClickType.is_json(output):

--- a/databricks_cli/clusters/cli.py
+++ b/databricks_cli/clusters/cli.py
@@ -288,7 +288,8 @@ def permanent_delete_cli(api_client, cluster_id):
               help="The end time in epoch milliseconds. If unprovided, returns events up to the "
                    "current time")
 @click.option('--order', required=False, default=None,
-              help="The order to list events in; either ASC or DESC. Defaults to DESC (most recent first)")
+              help="The order to list events in; either ASC or DESC. Defaults to DESC "
+                   "(most recent first).")
 @click.option('--event-type', required=False, default=None,
               help="An event types to filter on (specify multiple event types by passing "
                    "the --event-type option multiple times). If empty, all event types "

--- a/databricks_cli/clusters/cli.py
+++ b/databricks_cli/clusters/cli.py
@@ -176,8 +176,9 @@ def _clusters_to_table(clusters_json):
 
 def _cluster_events_to_table(events_json):
     ret = []
-    timezone = time.tzname[time.daylight]
     for event in events_json.get('events', []):
+        timestamp = event['timestamp'] / 1000
+        timezone = time.tzname[time.localtime(timestamp).tm_isdst]
         formatted_time = "%s %s" % (
             datetime.fromtimestamp(event['timestamp'] / 1000.).strftime('%Y-%m-%d %H:%M:%S'),
             timezone)

--- a/databricks_cli/clusters/cli.py
+++ b/databricks_cli/clusters/cli.py
@@ -268,15 +268,37 @@ def permanent_delete_cli(api_client, cluster_id):
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--cluster-id', required=True, type=ClusterIdClickType(),
               help=ClusterIdClickType.help)
+@click.option('--start-time', required=False, default=None,
+              help="The start time in epoch milliseconds. If unprovided, returns events starting "
+                   "from the beginning of time.")
+@click.option('--end-time', required=False, default=None,
+              help="The end time in epoch milliseconds. If unprovided, returns events up to the "
+                   "current time")
+@click.option('--order', required=False, default=None,
+              help="The order to list events in; either ASC or DESC. Defaults to DESC.")
+@click.option('--event-type', required=False, default=None,
+              help="An event types to filter on (specify multiple event types by passing "
+                   "the --event-type option multiple times). If empty, all event types "
+                   "are returned.", multiple=True)
+@click.option('--offset', required=False, default=None,
+              help="The offset in the result set. Defaults to 0 (no offset). When an offset is "
+                   "specified and the results are requested in descending order, the end_time "
+                   "field is required.")
+@click.option('--limit', required=False, default=None,
+              help="The maximum number of events to include in a page of events. Defaults to 50, "
+                   "and maximum allowed value is 500.")
 @debug_option
 @profile_option
 @eat_exceptions
 @provide_api_client
-def cluster_events_cli(api_client, cluster_id):
+def cluster_events_cli(api_client, cluster_id, start_time, end_time, order, event_type, offset,
+                       limit):
     """
     Gets events for a Spark cluster.
     """
-    click.echo(pretty_format(ClusterApi(api_client).cluster_events(cluster_id)))
+    click.echo(pretty_format(ClusterApi(api_client).cluster_events(
+        cluster_id=cluster_id, start_time=start_time, end_time=end_time, order=order,
+        event_types=event_type, offset=offset, limit=limit)))
 
 
 @click.group(context_settings=CONTEXT_SETTINGS,
@@ -306,4 +328,3 @@ clusters_group.add_command(list_node_types_cli, name='list-node-types')
 clusters_group.add_command(spark_versions_cli, name='spark-versions')
 clusters_group.add_command(permanent_delete_cli, name='permanent-delete')
 clusters_group.add_command(cluster_events_cli, name='events')
-

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -212,24 +212,6 @@ class ClusterService(object):
 
         return self.client.perform_query('GET', '/clusters/list', data=_data, headers=headers)
 
-    def cluster_events(self, cluster_id, start_time, end_time, order, event_types, offset, limit,
-                       headers=None):
-        _data = {'cluster_id': cluster_id}
-        if start_time is not None:
-            _data["start_time"] = start_time
-        if end_time is not None:
-            _data["end_time"] = end_time
-        if order is not None:
-            _data["order"] = order
-        if event_types is not None:
-            _data["event_types"] = event_types
-        if offset is not None:
-            _data["offset"] = offset
-        if limit is not None:
-            _data["limit"] = limit
-        return self.client.perform_query(
-            'POST', '/clusters/events', data=_data, headers=headers)
-
     def create_cluster(self, num_workers=None, autoscale=None, cluster_name=None, spark_version=None,
                        spark_conf=None, aws_attributes=None, node_type_id=None,
                        driver_node_type_id=None, ssh_public_keys=None, custom_tags=None,

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -212,6 +212,10 @@ class ClusterService(object):
 
         return self.client.perform_query('GET', '/clusters/list', data=_data, headers=headers)
 
+    def cluster_events(self, cluster_id, headers=None):
+        _data = {'cluster_id': cluster_id}
+        return self.client.perform_query('POST', '/clusters/events', data=_data, headers=headers)
+
     def create_cluster(self, num_workers=None, autoscale=None, cluster_name=None, spark_version=None,
                        spark_conf=None, aws_attributes=None, node_type_id=None,
                        driver_node_type_id=None, ssh_public_keys=None, custom_tags=None,

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -212,9 +212,23 @@ class ClusterService(object):
 
         return self.client.perform_query('GET', '/clusters/list', data=_data, headers=headers)
 
-    def cluster_events(self, cluster_id, headers=None):
+    def cluster_events(self, cluster_id, start_time, end_time, order, event_types, offset, limit,
+                       headers=None):
         _data = {'cluster_id': cluster_id}
-        return self.client.perform_query('POST', '/clusters/events', data=_data, headers=headers)
+        if start_time is not None:
+            _data["start_time"] = start_time
+        if end_time is not None:
+            _data["end_time"] = end_time
+        if order is not None:
+            _data["order"] = order
+        if event_types is not None:
+            _data["event_types"] = event_types
+        if offset is not None:
+            _data["offset"] = offset
+        if limit is not None:
+            _data["limit"] = limit
+        return self.client.perform_query(
+            'POST', '/clusters/events', data=_data, headers=headers)
 
     def create_cluster(self, num_workers=None, autoscale=None, cluster_name=None, spark_version=None,
                        spark_conf=None, aws_attributes=None, node_type_id=None,

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'requests>=2.17.3',
         'tabulate>=0.7.7',
         'six>=1.10.0',
-        'configparser >= 0.3.5'
+        'configparser >= 0.3.5',
     ],
     entry_points='''
         [console_scripts]

--- a/tests/clusters/test_cli.py
+++ b/tests/clusters/test_cli.py
@@ -166,5 +166,4 @@ def test_cluster_events_output_json(cluster_api_mock):
         cluster_api_mock.cluster_events.return_value = EVENTS_RETURN
         runner = CliRunner()
         runner.invoke(cli.cluster_events_cli, ['--cluster-id', CLUSTER_ID, '--output', 'json'])
-        assert cluster_api_mock.cluster_events.call_args[0][0] == CLUSTER_ID
         assert echo_mock.call_args[0][0] == pretty_format(EVENTS_RETURN)

--- a/tests/clusters/test_cli.py
+++ b/tests/clusters/test_cli.py
@@ -165,5 +165,6 @@ def test_cluster_events_output_json(cluster_api_mock):
     with mock.patch('databricks_cli.clusters.cli.click.echo') as echo_mock:
         cluster_api_mock.cluster_events.return_value = EVENTS_RETURN
         runner = CliRunner()
-        runner.invoke(cli.cluster_events_cli, ['--cluster-id', 'abc', '--output', 'json'])
+        runner.invoke(cli.cluster_events_cli, ['--cluster-id', CLUSTER_ID, '--output', 'json'])
+        assert cluster_api_mock.cluster_events.call_args[0][0] == CLUSTER_ID
         assert echo_mock.call_args[0][0] == pretty_format(EVENTS_RETURN)

--- a/tests/clusters/test_cli.py
+++ b/tests/clusters/test_cli.py
@@ -176,5 +176,6 @@ def test_cluster_events_output_table(cluster_api_mock):
     stdout = runner.invoke(cli.cluster_events_cli, ['--cluster-id', CLUSTER_ID]).stdout
     stdout_lines = stdout.split('\n')
     print(stdout_lines)
-    # Check that the timestamp 1559334105421 matches the table format!
-    assert any(['2019-05-31 13:21:45 PDT  AUTOSCALING_STATS_REPORT' in l for l in stdout_lines])
+    # Check that the timestamp 1559334105421 gets converted to the right time! It's hard to do an
+    # exact match because of time zones.
+    assert any(['2019-05-31' in l for l in stdout_lines])

--- a/tests/clusters/test_cli.py
+++ b/tests/clusters/test_cli.py
@@ -175,7 +175,6 @@ def test_cluster_events_output_table(cluster_api_mock):
     runner = CliRunner()
     stdout = runner.invoke(cli.cluster_events_cli, ['--cluster-id', CLUSTER_ID]).stdout
     stdout_lines = stdout.split('\n')
-    print(stdout_lines)
     # Check that the timestamp 1559334105421 gets converted to the right time! It's hard to do an
     # exact match because of time zones.
     assert any(['2019-05-31' in l for l in stdout_lines])

--- a/tests/clusters/test_cli.py
+++ b/tests/clusters/test_cli.py
@@ -163,7 +163,18 @@ def test_list_clusters_output_json(cluster_api_mock):
 @provide_conf
 def test_cluster_events_output_json(cluster_api_mock):
     with mock.patch('databricks_cli.clusters.cli.click.echo') as echo_mock:
-        cluster_api_mock.cluster_events.return_value = EVENTS_RETURN
+        cluster_api_mock.get_events.return_value = EVENTS_RETURN
         runner = CliRunner()
         runner.invoke(cli.cluster_events_cli, ['--cluster-id', CLUSTER_ID, '--output', 'json'])
         assert echo_mock.call_args[0][0] == pretty_format(EVENTS_RETURN)
+
+
+@provide_conf
+def test_cluster_events_output_table(cluster_api_mock):
+    cluster_api_mock.get_events.return_value = EVENTS_RETURN
+    runner = CliRunner()
+    stdout = runner.invoke(cli.cluster_events_cli, ['--cluster-id', CLUSTER_ID]).stdout
+    stdout_lines = stdout.split('\n')
+    print(stdout_lines)
+    # Check that the timestamp 1559334105421 matches the table format!
+    assert any(['2019-05-31 13:21:45 PDT  AUTOSCALING_STATS_REPORT' in l for l in stdout_lines])

--- a/tests/clusters/test_cli.py
+++ b/tests/clusters/test_cli.py
@@ -118,6 +118,28 @@ LIST_RETURN = {
     }]
 }
 
+EVENTS_RETURN = {
+    "events": [
+        {
+            "cluster_id": "0524-220842-flub264",
+            "timestamp": 1559334105421,
+            "type": "AUTOSCALING_STATS_REPORT",
+            "details": {
+                "autoscaling_stats": {
+                    "total_instance_seconds": 6530,
+                    "unused_instance_seconds": 6530
+                }
+            }
+        },
+    ],
+    "next_page": {
+        "cluster_id": "0524-220842-flub264",
+        "end_time": 1562624262942,
+        "offset": 50
+    },
+    "total_count": 87
+}
+
 
 @provide_conf
 def test_list_jobs(cluster_api_mock):
@@ -136,3 +158,12 @@ def test_list_clusters_output_json(cluster_api_mock):
         runner = CliRunner()
         runner.invoke(cli.list_cli, ['--output', 'json'])
         assert echo_mock.call_args[0][0] == pretty_format(LIST_RETURN)
+
+
+@provide_conf
+def test_cluster_events_output_json(cluster_api_mock):
+    with mock.patch('databricks_cli.clusters.cli.click.echo') as echo_mock:
+        cluster_api_mock.cluster_events.return_value = EVENTS_RETURN
+        runner = CliRunner()
+        runner.invoke(cli.list_cli, ['--output', 'json'])
+        assert echo_mock.call_args[0][0] == pretty_format(EVENTS_RETURN)

--- a/tests/clusters/test_cli.py
+++ b/tests/clusters/test_cli.py
@@ -165,5 +165,5 @@ def test_cluster_events_output_json(cluster_api_mock):
     with mock.patch('databricks_cli.clusters.cli.click.echo') as echo_mock:
         cluster_api_mock.cluster_events.return_value = EVENTS_RETURN
         runner = CliRunner()
-        runner.invoke(cli.list_cli, ['--output', 'json'])
+        runner.invoke(cli.cluster_events_cli, ['--cluster-id', 'abc', '--output', 'json'])
         assert echo_mock.call_args[0][0] == pretty_format(EVENTS_RETURN)

--- a/tox-requirements.txt
+++ b/tox-requirements.txt
@@ -7,7 +7,7 @@ mock==2.0.0
 decorator==4.2.1
 rstcheck==3.2
 pytest-cov==2.5.1
-# Pin docutils version to address https://github.com/pywbem/pywbem/issues/1788
+# Pin docutils version to address https://sourceforge.net/p/docutils/bugs/365/
 docutils==0.14
 codecov
 requests_mock==1.5.2

--- a/tox-requirements.txt
+++ b/tox-requirements.txt
@@ -7,5 +7,7 @@ mock==2.0.0
 decorator==4.2.1
 rstcheck==3.2
 pytest-cov==2.5.1
+# Pin docutils version to address https://github.com/pywbem/pywbem/issues/1788
+docutils==0.14
 codecov
 requests_mock==1.5.2


### PR DESCRIPTION
Adds CLI for the [cluster events REST API](https://docs.databricks.com/api/latest/clusters.html#events). 

Example output (mimics the output format of the clusters UI by default):
```
$ databricks clusters events --cluster-id 0717-061054-beech1 --profile demo --limit 4
$ databricks clusters events --cluster-id 0717-061054-beech1 --profile demo --limit 4
2019-07-18 00:23:47 PDT  TERMINATING     {'reason': {'code': 'INACTIVITY', 'parameters': {'inactivity_duration_min': '60'}}}
2019-07-17 22:09:49 PDT  DRIVER_HEALTHY  {}
2019-07-17 22:09:32 PDT  RUNNING         {'current_num_workers': 0, 'target_num_workers': 0}
2019-07-17 22:07:13 PDT  STARTING        {'user': 'sid.murching@databricks.com'}
```

Full REST API JSON output is available by specifying `--output json`:
```
{
  "events": [
    {
      "cluster_id": "0717-061054-beech1",
      "timestamp": 1563434627634,
      "type": "TERMINATING",
      "details": {
        "reason": {
          "code": "INACTIVITY",
          "parameters": {
            "inactivity_duration_min": "60"
          }
        }
      }
    },
    {
      "cluster_id": "0717-061054-beech1",
      "timestamp": 1563426589300,
      "type": "DRIVER_HEALTHY",
      "details": {}
    },
    {
      "cluster_id": "0717-061054-beech1",
      "timestamp": 1563426572019,
      "type": "RUNNING",
      "details": {
        "current_num_workers": 0,
        "target_num_workers": 0
      }
    }
  ],
  "next_page": {
    "cluster_id": "0717-061054-beech1",
    "end_time": 1563434627634,
    "offset": 3,
    "limit": 3
  },
  "total_count": 16
}
```