### PR TITLE
    The password provided to configure shouldn't be echo'd.

### DIFF
--- a/databricks_cli/configure/cli.py
+++ b/databricks_cli/configure/cli.py
@@ -85,7 +85,7 @@ def configure_cli(token, insecure, stdin):
     if token:
         _configure_cli_token(profile, insecure_str)
     elif stdin:
-        _configure_cli_stdin()
+        _configure_cli_stdin(profile, insecure_str)
     else:
         _configure_cli_password(profile, insecure_str)
 

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -20,7 +20,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import getpass
 from abc import abstractmethod, ABCMeta
 from configparser import ConfigParser
 import os
@@ -33,7 +33,7 @@ _home = expanduser('~')
 CONFIG_FILE_ENV_VAR = "DATABRICKS_CONFIG_FILE"
 HOST = 'host'
 USERNAME = 'username'
-PASSWORD = 'password' # NOQA
+PASSWORD = 'password'  # NOQA
 TOKEN = 'token'
 INSECURE = 'insecure'
 DEFAULT_SECTION = 'DEFAULT'
@@ -263,10 +263,15 @@ class ProfileConfigProvider(DatabricksConfigProvider):
 
 
 class DatabricksConfig(object):
-    def __init__(self, host, username, password, token, insecure): # noqa
+    def __init__(self, host, username, password, token, insecure):  # noqa
         self.host = host
         self.username = username
-        self.password = password
+
+        if self.password == 'stdin':
+            self.password = getpass.getpass("Password to connect to databricks at [" + self.host + "]: ")
+        else:
+            self.password = password
+
         self.token = token
         self.insecure = insecure
 

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -267,8 +267,10 @@ class DatabricksConfig(object):
         self.host = host
         self.username = username
 
+        self.password = None
         if self.password == 'stdin':
-            self.password = getpass.getpass("Password to connect to databricks at [" + self.host + "]: ")
+            message = 'Password to connect to databricks at [{}]: '.format(self.host)
+            self.password = getpass.getpass(message)
         else:
             self.password = password
 


### PR DESCRIPTION
    Add a --stdin option to configure, so that the password will always be read from stdin instead of stored in a file.