### PR TITLE
Add SparkDriver context provider

### DIFF
--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -242,7 +242,6 @@ class SparkDriverConfigProvider(DatabricksConfigProvider):
         except ImportError:
             return None
 
-
     @staticmethod
     def set_insecure(x):
         from pyspark import SparkContext  # pylint: disable=import-error


### PR DESCRIPTION
In a manner similar to https://github.com/databricks/databricks-cli/pull/232, adds a context provider for pulling Databricks credentials from a Spark driver using SparkContext local properties, plus tests.