### PR TITLE
[ML-8575] Extend stack CLI to support html format

### DIFF
--- a/databricks_cli/workspace/types.py
+++ b/databricks_cli/workspace/types.py
@@ -30,7 +30,7 @@ class WorkspaceLanguage(object):
     SQL = 'SQL'
     R = 'R'
     ALL = [SCALA, PYTHON, SQL, R]
-    EXTENSIONS = ['.scala', '.py', '.sql', '.SQL', '.r', '.R', '.ipynb']
+    EXTENSIONS = ['.scala', '.py', '.sql', '.SQL', '.r', '.R', '.ipynb', '.html']
 
     @classmethod
     def to_language_and_format(cls, path):
@@ -45,6 +45,8 @@ class WorkspaceLanguage(object):
             return (cls.R, WorkspaceFormat.SOURCE)
         elif ext == '.ipynb':
             return (cls.PYTHON, WorkspaceFormat.JUPYTER)
+        elif ext == '.html':
+            return (None, WorkspaceFormat.HTML)
 
     @classmethod
     def to_extension(cls, language):

--- a/tests/stack/test_api.py
+++ b/tests/stack/test_api.py
@@ -271,6 +271,8 @@ class TestStackApi(object):
             os.path.dirname(test_workspace_nb_properties[api.WORKSPACE_RESOURCE_SOURCE_PATH]))
         with open(test_workspace_nb_properties[api.WORKSPACE_RESOURCE_SOURCE_PATH], 'w') as f:
             f.write("print('test')\n")
+
+
         test_workspace_dir_properties = TEST_WORKSPACE_DIR_PROPERTIES.copy()
         test_workspace_dir_properties.update(
             {api.WORKSPACE_RESOURCE_SOURCE_PATH: os.path.join(tmpdir.strpath,
@@ -300,6 +302,13 @@ class TestStackApi(object):
             test_workspace_nb_properties[api.WORKSPACE_RESOURCE_PATH]
         assert nb_databricks_id == {api.WORKSPACE_RESOURCE_PATH:
                                     test_workspace_nb_properties[api.WORKSPACE_RESOURCE_PATH]}
+
+        # Test Input of Workspace notebook with html source
+        test_workspace_nb_properties.update(
+            {api.WORKSPACE_RESOURCE_SOURCE_PATH: 'test/notebook.html'})
+        nb_databricks_id = \
+            stack_api._deploy_workspace(test_workspace_nb_properties, None, True)
+        assert stack_api.workspace_client.import_workspace.call_args[0][0] == 'test/notebook.html'
 
         # Should raise error if resource object_type doesn't match actually is in filesystem.
         test_workspace_dir_properties.update(

--- a/tests/stack/test_api.py
+++ b/tests/stack/test_api.py
@@ -271,8 +271,6 @@ class TestStackApi(object):
             os.path.dirname(test_workspace_nb_properties[api.WORKSPACE_RESOURCE_SOURCE_PATH]))
         with open(test_workspace_nb_properties[api.WORKSPACE_RESOURCE_SOURCE_PATH], 'w') as f:
             f.write("print('test')\n")
-
-
         test_workspace_dir_properties = TEST_WORKSPACE_DIR_PROPERTIES.copy()
         test_workspace_dir_properties.update(
             {api.WORKSPACE_RESOURCE_SOURCE_PATH: os.path.join(tmpdir.strpath,


### PR DESCRIPTION
Add html support in `to_language_and_format`.
Add test for deploy workspace with html format.
Manually tested with stack deploy. I can upload html notebook and create job.