### PR TITLE
Add 'init_scripts' optional argument

### DIFF
--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -215,9 +215,9 @@ class ClusterService(object):
     def create_cluster(self, num_workers=None, autoscale=None, cluster_name=None, spark_version=None,
                        spark_conf=None, aws_attributes=None, node_type_id=None,
                        driver_node_type_id=None, ssh_public_keys=None, custom_tags=None,
-                       cluster_log_conf=None, spark_env_vars=None, autotermination_minutes=None,
-                       enable_elastic_disk=None, cluster_source=None, instance_pool_id=None,
-                       headers=None):
+                       cluster_log_conf=None, init_scripts=None, spark_env_vars=None,
+                       autotermination_minutes=None, enable_elastic_disk=None, cluster_source=None,
+                       instance_pool_id=None, headers=None):
         _data = {}
         if num_workers is not None:
             _data['num_workers'] = num_workers
@@ -247,6 +247,8 @@ class ClusterService(object):
             _data['cluster_log_conf'] = cluster_log_conf
             if not isinstance(cluster_log_conf, dict):
                 raise TypeError('Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
+        if init_scripts is not None:
+            _data['init_scripts'] = init_scripts
         if spark_env_vars is not None:
             _data['spark_env_vars'] = spark_env_vars
         if autotermination_minutes is not None:
@@ -303,9 +305,9 @@ class ClusterService(object):
     def edit_cluster(self, cluster_id, num_workers=None, autoscale=None, cluster_name=None,
                      spark_version=None, spark_conf=None, aws_attributes=None, node_type_id=None,
                      driver_node_type_id=None, ssh_public_keys=None, custom_tags=None,
-                     cluster_log_conf=None, spark_env_vars=None, autotermination_minutes=None,
-                     enable_elastic_disk=None, cluster_source=None, instance_pool_id=None,
-                     headers=None):
+                     cluster_log_conf=None, init_scripts=None, spark_env_vars=None,
+                     autotermination_minutes=None, enable_elastic_disk=None, cluster_source=None,
+                     instance_pool_id=None, headers=None):
         _data = {}
         if cluster_id is not None:
             _data['cluster_id'] = cluster_id
@@ -337,6 +339,8 @@ class ClusterService(object):
             _data['cluster_log_conf'] = cluster_log_conf
             if not isinstance(cluster_log_conf, dict):
                 raise TypeError('Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
+        if init_scripts is not None:
+            _data['init_scripts'] = init_scripts
         if spark_env_vars is not None:
             _data['spark_env_vars'] = spark_env_vars
         if autotermination_minutes is not None:


### PR DESCRIPTION
This fixes issue #264.

Note that the 'init_scripts' argument was added previously to 'edit_cluster', but (inadvertently?) removed later.

This change adds it to both 'create_cluster' and 'edit_cluster'.