### PR TITLE
Add dbc format support to workspace api

### DIFF
--- a/databricks_cli/workspace/types.py
+++ b/databricks_cli/workspace/types.py
@@ -30,23 +30,27 @@ class WorkspaceLanguage(object):
     SQL = 'SQL'
     R = 'R'
     ALL = [SCALA, PYTHON, SQL, R]
-    EXTENSIONS = ['.scala', '.py', '.sql', '.SQL', '.r', '.R', '.ipynb', '.html']
+    EXTENSIONS = ['.scala', '.py', '.sql', '.SQL', '.r', '.R', '.ipynb', '.html', '.dbc']
 
     @classmethod
     def to_language_and_format(cls, path):
         ext = cls.get_extension(path).lower()
+        language_and_format = (None, None)
         if ext == '.scala':
-            return (cls.SCALA, WorkspaceFormat.SOURCE)
+            language_and_format = (cls.SCALA, WorkspaceFormat.SOURCE)
         elif ext == '.py':
-            return (cls.PYTHON, WorkspaceFormat.SOURCE)
+            language_and_format = (cls.PYTHON, WorkspaceFormat.SOURCE)
         elif ext == '.sql':
-            return (cls.SQL, WorkspaceFormat.SOURCE)
+            language_and_format = (cls.SQL, WorkspaceFormat.SOURCE)
         elif ext == '.r':
-            return (cls.R, WorkspaceFormat.SOURCE)
+            language_and_format = (cls.R, WorkspaceFormat.SOURCE)
         elif ext == '.ipynb':
-            return (cls.PYTHON, WorkspaceFormat.JUPYTER)
+            language_and_format = (cls.PYTHON, WorkspaceFormat.JUPYTER)
         elif ext == '.html':
-            return (None, WorkspaceFormat.HTML)
+            language_and_format = (None, WorkspaceFormat.HTML)
+        elif ext == '.dbc':
+            language_and_format = (None, WorkspaceFormat.DBC)
+        return language_and_format
 
     @classmethod
     def to_extension(cls, language):

--- a/tests/stack/test_api.py
+++ b/tests/stack/test_api.py
@@ -308,6 +308,13 @@ class TestStackApi(object):
             stack_api._deploy_workspace(test_workspace_nb_properties, None, True)
         assert stack_api.workspace_client.import_workspace.call_args[0][0] == 'test/notebook.html'
 
+        # Test Input of Workspace notebook with dbc source
+        test_workspace_nb_properties.update(
+            {api.WORKSPACE_RESOURCE_SOURCE_PATH: 'test/notebook.dbc'})
+        nb_databricks_id = \
+            stack_api._deploy_workspace(test_workspace_nb_properties, None, True)
+        assert stack_api.workspace_client.import_workspace.call_args[0][0] == 'test/notebook.dbc'
+
         # Should raise error if resource object_type doesn't match actually is in filesystem.
         test_workspace_dir_properties.update(
             {api.WORKSPACE_RESOURCE_OBJECT_TYPE: workspace_api.NOTEBOOK})


### PR DESCRIPTION
This PR adds supports for dbc format to workspace api so that we can use databricks cli to upload dbc notebooks to databricks workspace.
Reformatted the return statements to make linter happy of `too many return statements`.