### PR TITLE
Add support for DBFS partial deletes

### DIFF
--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -27,8 +27,8 @@ import os
 import shutil
 import tempfile
 
-import click
 import re
+import click
 
 from requests.exceptions import HTTPError
 

--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -69,7 +69,7 @@ class FileInfo(object):
 class DbfsErrorCodes(object):
     RESOURCE_DOES_NOT_EXIST = 'RESOURCE_DOES_NOT_EXIST'
     RESOURCE_ALREADY_EXISTS = 'RESOURCE_ALREADY_EXISTS'
-    REQUEST_LIMIT_EXCEEDED = 'REQUEST_LIMIT_EXCEEDED'
+    PARTIAL_DELETE = 'PARTIAL_DELETE'
 
 
 class DbfsApi(object):
@@ -130,8 +130,9 @@ class DbfsApi(object):
                 self.client.delete(dbfs_path.absolute_path, recursive=recursive, headers=headers)
             except HTTPError as e:
                 # Handle partial delete exceptions and retry until all the files have been deleted
-                if (e.response.status_code == 429 and
-                        e.response.json()['error_code'] == DbfsErrorCodes.REQUEST_LIMIT_EXCEEDED):
+                if (e.response.status_code == 503 and
+                        e.response.json()['error_code'] == DbfsErrorCodes.PARTIAL_DELETE):
+                    click.echo("Partial delete. Response: {}".format(e.response.json()))
                     continue
                 else:
                     raise e

--- a/tests/dbfs/test_api.py
+++ b/tests/dbfs/test_api.py
@@ -48,6 +48,13 @@ def get_resource_does_not_exist_exception():
     return requests.exceptions.HTTPError(response=response)
 
 
+def get_temporarily_unavailable_exception():
+    response = requests.Response()
+    response.status_code = 503
+    response._content = ('{{"error_code": "{}"}}'.format(api.DbfsErrorCodes.TEMPORARILY_UNAVAILABLE)).encode() #  NOQA
+    return requests.exceptions.HTTPError(response=response)
+
+
 def get_partial_delete_exception():
     response = requests.Response()
     response.status_code = 503
@@ -174,7 +181,26 @@ class TestDbfsApi(object):
             click_mock.echo.assert_called_with('a', nl=False)
 
     def test_partial_delete(self, dbfs_api):
-        e = get_partial_delete_exception()
-        # Simulate 3 partial deletes followed by a full successful delete
-        dbfs_api.client.delete = mock.Mock(side_effect=[e, e, e, None])
+        e_partial_delete = get_partial_delete_exception()
+        e_temporarily_unavailable = get_temporarily_unavailable_exception()
+        # Simulate partial deletes and 503 exceptions followed by a full successful delete
+        exception_sequence = [e_temporarily_unavailable, e_partial_delete, e_partial_delete] + \
+                             [e_temporarily_unavailable] * api.DELETE_MAX_CONSECUTIVE_503_ERRORS + \
+                             [e_partial_delete, None]
+        dbfs_api.client.delete = mock.Mock(side_effect=exception_sequence)
         dbfs_api.delete(DbfsPath('dbfs:/whatever-doesnt-matter'), recursive=True)
+
+    def test_partial_delete_service_unavailable(self, dbfs_api):
+        e_partial_delete = get_partial_delete_exception()
+        e_temporarily_unavailable = get_temporarily_unavailable_exception()
+        # Simulate more than api.DELETE_MAX_CONSECUTIVE_503_ERRORS 503 errors that are not partial
+        # deletes (error_code != PARTIAL_DELETE)
+        exception_sequence = \
+            [e_partial_delete] + \
+            [e_temporarily_unavailable] * (api.DELETE_MAX_CONSECUTIVE_503_ERRORS + 1) + \
+            [e_partial_delete, None]
+        dbfs_api.client.delete = mock.Mock(side_effect=exception_sequence)
+        with pytest.raises(e_temporarily_unavailable.__class__) as thrown:
+            dbfs_api.delete(DbfsPath('dbfs:/whatever-doesnt-matter'), recursive=True)
+        # Should raise the same e_temporarily_unavailable exception instance
+        assert thrown.value == e_temporarily_unavailable

--- a/tests/dbfs/test_api.py
+++ b/tests/dbfs/test_api.py
@@ -188,6 +188,7 @@ class TestDbfsApi(object):
                              [e_temporarily_unavailable] * api.DELETE_MAX_CONSECUTIVE_503_ERRORS + \
                              [e_partial_delete, None]
         dbfs_api.client.delete = mock.Mock(side_effect=exception_sequence)
+        dbfs_api.delete_retry_delay_millis = 1
         dbfs_api.delete(DbfsPath('dbfs:/whatever-doesnt-matter'), recursive=True)
 
     def test_partial_delete_service_unavailable(self, dbfs_api):
@@ -200,6 +201,7 @@ class TestDbfsApi(object):
             [e_temporarily_unavailable] * (api.DELETE_MAX_CONSECUTIVE_503_ERRORS + 1) + \
             [e_partial_delete, None]
         dbfs_api.client.delete = mock.Mock(side_effect=exception_sequence)
+        dbfs_api.delete_retry_delay_millis = 1
         with pytest.raises(e_temporarily_unavailable.__class__) as thrown:
             dbfs_api.delete(DbfsPath('dbfs:/whatever-doesnt-matter'), recursive=True)
         # Should raise the same e_temporarily_unavailable exception instance

--- a/tests/dbfs/test_api.py
+++ b/tests/dbfs/test_api.py
@@ -48,15 +48,11 @@ def get_resource_does_not_exist_exception():
     return requests.exceptions.HTTPError(response=response)
 
 
-def get_request_limit_exceeded_exception():
-    response = requests.Response()
-    response.status_code = 429
-    response._content = ('{{"error_code": "{}","message": ""}}'.format(api.DbfsErrorCodes.REQUEST_LIMIT_EXCEEDED)).encode() #  NOQA
-    return requests.exceptions.HTTPError(response=response)
-
-
 def get_partial_delete_exception():
-    return get_request_limit_exceeded_exception()
+    response = requests.Response()
+    response.status_code = 503
+    response._content = ('{{"error_code": "{}","message": ""}}'.format(api.DbfsErrorCodes.PARTIAL_DELETE)).encode() #  NOQA
+    return requests.exceptions.HTTPError(response=response)
 
 
 class TestFileInfo(object):


### PR DESCRIPTION
Introduce retry logic for handling `DBFS` partial deletes that occur as a result of a recursive delete with limit. A partial delete means that not all the contents in the directory were deleted because the limit was reached.

Tested with unit tests and manually.