### PR TITLE
[HACKATHON] DBFS Async Deletes

### DIFF
--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -240,9 +240,17 @@ class DbfsApi(object):
             with open(temp_path) as f:
                 click.echo(f.read(), nl=False)
 
+
+
+
+    def delete_async_start(self, dbfs_path, recursive, cluster_id, headers=None):
+        return self.client.delete_async_start(dbfs_path.absolute_path, recursive, cluster_id, headers=headers)
+
     def delete_async_status(self, rm_async_id, headers=None):
         return self.client.delete_async_status(rm_async_id, headers=headers)
 
+    def delete_async_cancel(self, rm_async_id, headers=None):
+        return self.client.delete_async_cancel(rm_async_id, headers=headers)
 
 
 class TempDir(object):

--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -243,14 +243,14 @@ class DbfsApi(object):
 
 
 
-    def delete_async_start(self, dbfs_path, recursive, cluster_id, headers=None):
-        return self.client.delete_async_start(dbfs_path.absolute_path, recursive, cluster_id, headers=headers)
+    def async_delete_start(self, dbfs_path, recursive, cluster_id, headers=None):
+        return self.client.async_delete_start(dbfs_path.absolute_path, recursive, cluster_id, headers=headers)
 
-    def delete_async_status(self, rm_async_id, headers=None):
-        return self.client.delete_async_status(rm_async_id, headers=headers)
+    def async_delete_status(self, async_delete_id=None, limit=None, headers=None):
+        return self.client.async_delete_status(async_delete_id, limit, headers=headers)
 
-    def delete_async_cancel(self, rm_async_id, headers=None):
-        return self.client.delete_async_cancel(rm_async_id, headers=headers)
+    def async_delete_cancel(self, async_delete_id, headers=None):
+        return self.client.async_delete_cancel(async_delete_id, headers=headers)
 
 
 class TempDir(object):

--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -240,6 +240,10 @@ class DbfsApi(object):
             with open(temp_path) as f:
                 click.echo(f.read(), nl=False)
 
+    def delete_async_status(self, rm_async_id, headers=None):
+        return self.client.delete_async_status(rm_async_id, headers=headers)
+
+
 
 class TempDir(object):
     def __init__(self, remove_on_exit=True):

--- a/databricks_cli/dbfs/cli.py
+++ b/databricks_cli/dbfs/cli.py
@@ -292,11 +292,26 @@ def cat_cli(api_client, src):
     DbfsApi(api_client).cat(src)
 
 
+
+@click.group(context_settings=CONTEXT_SETTINGS, short_help='Perform asynchronous DBFS operations.')
+@debug_option
+@profile_option
+@eat_exceptions
+def async_group():
+    """
+    Remove files from dbfs asynchronously.
+    """
+    pass
+
+
+async_group.add_command(rm_async_group, name='rm')
+
+
 dbfs_group.add_command(configure_cli, name='configure')
 dbfs_group.add_command(ls_cli, name='ls')
 dbfs_group.add_command(mkdirs_cli, name='mkdirs')
 dbfs_group.add_command(rm_cli, name='rm')
-dbfs_group.add_command(rm_async_group, name='rm-async')
+dbfs_group.add_command(async_group, name='async')
 dbfs_group.add_command(cp_cli, name='cp')
 dbfs_group.add_command(mv_cli, name='mv')
 dbfs_group.add_command(cat_cli, name='cat')

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -514,6 +514,20 @@ class DbfsService(object):
         return self.client.perform_query('POST', '/dbfs/close', data=_data, headers=headers)
 
 
+
+
+
+
+
+    def delete_async_status(self, rm_async_id=None, headers=None):
+        _data = {}
+        if rm_async_id is not None:
+            _data['delete_job_id'] = rm_async_id
+            return self.client.perform_query('GET', '/dbfs-async/delete/get', data=_data, headers=headers)
+        else:
+            return self.client.perform_query('GET', '/dbfs-async/delete/list', data=_data, headers=headers)
+
+
 class WorkspaceService(object):
     def __init__(self, client):
         self.client = client

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -519,7 +519,7 @@ class DbfsService(object):
 
 
 
-    def delete_async_start(self, dbfs_path, recursive=None, cluster_id=None, headers=None):
+    def async_delete_start(self, dbfs_path, recursive=None, cluster_id=None, headers=None):
         _data = {}
         _data['path'] = dbfs_path
         if recursive is not None:
@@ -528,17 +528,19 @@ class DbfsService(object):
             _data['cluster_id'] = cluster_id
         return self.client.perform_query('POST', '/dbfs-async/delete/submit', data=_data, headers=headers)
 
-    def delete_async_status(self, rm_async_id=None, headers=None):
+    def async_delete_status(self, async_delete_id=None, limit=None, headers=None):
         _data = {}
-        if rm_async_id is not None:
-            _data['delete_job_id'] = rm_async_id
+        if async_delete_id is not None:
+            _data['delete_job_id'] = async_delete_id
             return self.client.perform_query('GET', '/dbfs-async/delete/get', data=_data, headers=headers)
         else:
+            if limit is not None:
+                _data['limit'] = limit
             return self.client.perform_query('GET', '/dbfs-async/delete/list', data=_data, headers=headers)
 
-    def delete_async_cancel(self, rm_async_id, headers=None):
+    def async_delete_cancel(self, async_delete_id, headers=None):
         _data = {}
-        _data['delete_job_id'] = rm_async_id
+        _data['delete_job_id'] = async_delete_id
         return self.client.perform_query('POST', '/dbfs-async/delete/cancel', data=_data, headers=headers)
 
 

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -519,6 +519,15 @@ class DbfsService(object):
 
 
 
+    def delete_async_start(self, dbfs_path, recursive=None, cluster_id=None, headers=None):
+        _data = {}
+        _data['path'] = dbfs_path
+        if recursive is not None:
+            _data['recursive'] = recursive
+        if cluster_id is not None:
+            _data['cluster_id'] = cluster_id
+        return self.client.perform_query('POST', '/dbfs-async/delete/submit', data=_data, headers=headers)
+
     def delete_async_status(self, rm_async_id=None, headers=None):
         _data = {}
         if rm_async_id is not None:
@@ -526,6 +535,14 @@ class DbfsService(object):
             return self.client.perform_query('GET', '/dbfs-async/delete/get', data=_data, headers=headers)
         else:
             return self.client.perform_query('GET', '/dbfs-async/delete/list', data=_data, headers=headers)
+
+    def delete_async_cancel(self, rm_async_id, headers=None):
+        _data = {}
+        _data['delete_job_id'] = rm_async_id
+        return self.client.perform_query('POST', '/dbfs-async/delete/cancel', data=_data, headers=headers)
+
+
+
 
 
 class WorkspaceService(object):


### PR DESCRIPTION
Adds the following commands which forward to the `/dbfs-async` endpoint added in https://github.com/databricks/universe/pull/51985
```
(db_cli_env) adrian@x1e:~/dev/databricks-cli$ db fs async rm
Usage: databricks fs async rm [OPTIONS] COMMAND [ARGS]...

  Remove files from dbfs asynchronously.

Options:
  --debug         Debug Mode. Shows full stack trace on error.
  --profile TEXT  CLI connection profile to use. The default profile is
                  "DEFAULT".

  -h, --help      Show this message and exit.

Commands:
  cancel  Cancel your rm-async request.
  start   Start a rm-async request.
  status  Check the status of your rm-async request(s).
  wait    Wait until your rm-async request is complete.
```