### PR TITLE
require configparser only in python < 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'requests>=2.17.3',
         'tabulate>=0.7.7',
         'six>=1.10.0',
-        'configparser >= 0.3.5',
+        'configparser>=0.3.5;python_version < "3.6"',
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
configparser comes in default python >= 3.6

See below for corresponding issue on the Arch Linux package: https://github.com/acxz/pkgbuilds/issues/21 and https://github.com/acxz/pkgbuilds/issues/20

TLDR: users should not be forced to install configparser from the pypi when it is included in default for python versions >= 3.6. This PR ensures that only for versions below 3.6 this requirement is kept.