### PR TITLE
Support writeStatus flag in resource configuration in stack API

### DIFF
--- a/databricks_cli/stack/api.py
+++ b/databricks_cli/stack/api.py
@@ -50,7 +50,7 @@ STACK_DEPLOYED = 'deployed_resources'  # For Stack Status
 # Resource Fields
 RESOURCE_ID = 'id'
 RESOURCE_SERVICE = 'service'
-WRITE_STATUS = 'writeStatus'
+RESOURCE_WRITE_STATUS = 'writeStatus'
 RESOURCE_PROPERTIES = 'properties'
 
 # Resource Status Fields
@@ -123,7 +123,7 @@ class StackApi(object):
                                                         headers=headers,
                                                         **kwargs)
 
-            if resource_config.get(WRITE_STATUS, True):
+            if resource_config.get(RESOURCE_WRITE_STATUS, True):
                 resource_statuses.append(new_resource_status)
             click.echo('#' * 80)
 

--- a/databricks_cli/stack/api.py
+++ b/databricks_cli/stack/api.py
@@ -50,6 +50,7 @@ STACK_DEPLOYED = 'deployed_resources'  # For Stack Status
 # Resource Fields
 RESOURCE_ID = 'id'
 RESOURCE_SERVICE = 'service'
+WRITE_STATUS = 'writeStatus'
 RESOURCE_PROPERTIES = 'properties'
 
 # Resource Status Fields
@@ -121,7 +122,9 @@ class StackApi(object):
                                                         resource_status,
                                                         headers=headers,
                                                         **kwargs)
-            resource_statuses.append(new_resource_status)
+
+            if resource_config.get(WRITE_STATUS, True):
+                resource_statuses.append(new_resource_status)
             click.echo('#' * 80)
 
         new_stack_status = {STACK_NAME: stack_name,

--- a/examples/stack/notebook-job-project/project-stack-config.json
+++ b/examples/stack/notebook-job-project/project-stack-config.json
@@ -16,8 +16,8 @@
       "properties": {
         "name": "[Databricks] Stack CLI Example: Hello",
         "new_cluster": {
-          "spark_version": "4.0.x-scala2.11",
-          "node_type_id": "Standard_F16s",
+          "spark_version": "6.5.x-scala2.11",
+          "node_type_id": "Standard_F4s",
           "num_workers": 1
         },
         "timeout_seconds": 1200,

--- a/tests/stack/test_api.py
+++ b/tests/stack/test_api.py
@@ -135,7 +135,7 @@ TEST_STACK = {
         {
             api.RESOURCE_ID: "NoStatusResource",
             api.RESOURCE_SERVICE: api.DBFS_SERVICE,
-            "writeStatus": False,
+            api.RESOURCE_WRITE_STATUS: False,
             api.RESOURCE_PROPERTIES:  {
                 api.DBFS_RESOURCE_SOURCE_PATH: 'test.jar',
                 api.DBFS_RESOURCE_PATH: 'dbfs:/test/test-no-status.jar',

--- a/tests/stack/test_api.py
+++ b/tests/stack/test_api.py
@@ -126,11 +126,23 @@ TEST_DBFS_DIR_STATUS = {
 }
 TEST_STACK = {
     api.STACK_NAME: "test-stack",
-    api.STACK_RESOURCES: [TEST_JOB_RESOURCE,
-                          TEST_WORKSPACE_NB_RESOURCE,
-                          TEST_WORKSPACE_DIR_RESOURCE,
-                          TEST_DBFS_FILE_RESOURCE,
-                          TEST_DBFS_DIR_RESOURCE]
+    api.STACK_RESOURCES: [
+        TEST_JOB_RESOURCE,
+        TEST_WORKSPACE_NB_RESOURCE,
+        TEST_WORKSPACE_DIR_RESOURCE,
+        TEST_DBFS_FILE_RESOURCE,
+        TEST_DBFS_DIR_RESOURCE,
+        {
+            api.RESOURCE_ID: "NoStatusResource",
+            api.RESOURCE_SERVICE: api.DBFS_SERVICE,
+            "writeStatus": False,
+            api.RESOURCE_PROPERTIES:  {
+                api.DBFS_RESOURCE_SOURCE_PATH: 'test.jar',
+                api.DBFS_RESOURCE_PATH: 'dbfs:/test/test-no-status.jar',
+                api.DBFS_RESOURCE_IS_DIR: False
+            }
+        }
+    ]
 }
 TEST_STATUS = {
     api.STACK_NAME: "test-stack",


### PR DESCRIPTION
This PR adds the `writeStatus` flag to resource configuration for stack CLI.

Users can specify `writeStatus` to `false` if they do not want to persist the status of the corresponding resource.