### PR TITLE
Use IPython directly in config provider to avoid circular import of PythonShell

### DIFF
--- a/databricks_cli/__init__.py
+++ b/databricks_cli/__init__.py
@@ -26,9 +26,9 @@
 
 
 def initialize_cli_for_databricks_notebooks():
-    import PythonShell
+    import IPython
     from databricksCli import init_databricks_cli_config_provider
-    init_databricks_cli_config_provider(PythonShell.IPython.get_ipython().user_ns.entry_point)
+    init_databricks_cli_config_provider(IPython.get_ipython().user_ns.entry_point)
 
 try:
     # Initialize custom config provider which is available in Databricks notebooks.


### PR DESCRIPTION
Tested manually