### PR TITLE
Pipelines CLI Fixes

### DIFF
--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -74,9 +74,7 @@ def deploy_cli(api_client, spec_arg, spec):
         click.echo("Updating spec at {} with id: {}".format(src, pipeline_id))
         spec_obj['id'] = pipeline_id
         _write_spec(src, spec_obj)
-    msg = _validate_pipeline_id(spec_obj['id'])
-    if msg is not None:
-        error_and_quit(msg)
+    _validate_pipeline_id(spec_obj['id'])
     PipelinesApi(api_client).deploy(spec_obj)
 
     pipeline_id = spec_obj['id']
@@ -215,9 +213,7 @@ def _get_pipeline_id(spec_arg, spec, pipeline_id):
     if bool(spec_arg) or bool(spec):
         src = spec_arg if bool(spec_arg) else spec
         pipeline_id = _read_spec(src)["id"]
-    msg = _validate_pipeline_id(pipeline_id)
-    if msg is not None:
-        error_and_quit(msg)
+    _validate_pipeline_id(pipeline_id)
     return pipeline_id
 
 
@@ -226,11 +222,11 @@ def _validate_pipeline_id(pipeline_id):
     Checks if the pipeline_id only contain -, _ and alphanumeric characters
     """
     if len(pipeline_id) == 0:
-        return u'Empty pipeline id provided'
+        error_and_quit(u'Empty pipeline id provided')
     if not set(pipeline_id) <= PIPELINE_ID_PERMITTED_CHARACTERS:
         message = u'Pipeline id {} has invalid character(s)\n'.format(pipeline_id)
         message += u'Valid characters are: _ - a-z A-Z 0-9'
-        return message
+        error_and_quit(message)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS,

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -117,6 +117,7 @@ def delete_cli(api_client, spec_arg, spec, pipeline_id):
     """
     pipeline_id = _get_pipeline_id(spec_arg=spec_arg, spec=spec, pipeline_id=pipeline_id)
     PipelinesApi(api_client).delete(pipeline_id)
+    click.echo("Pipeline {} successfully deleted".format(pipeline_id))
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
@@ -178,6 +179,7 @@ def reset_cli(api_client, spec_arg, spec, pipeline_id):
     """
     pipeline_id = _get_pipeline_id(spec_arg=spec_arg, spec=spec, pipeline_id=pipeline_id)
     PipelinesApi(api_client).reset(pipeline_id)
+    click.echo("Pipeline {} successfully reset".format(pipeline_id))
 
 
 def _read_spec(src):

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -22,13 +22,12 @@
 # limitations under the License.
 
 import os
-import six
 import uuid
 import json
 
-if six.PY2:
+try:
     from urlparse import urlparse, urljoin
-elif six.PY3:
+except ImportError:
     from urllib.parse import urlparse, urljoin
 
 import click

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -226,10 +226,10 @@ def _validate_pipeline_id(pipeline_id):
     Checks if the pipeline_id only contain -, _ and alphanumeric characters
     """
     if len(pipeline_id) == 0:
-        return 'Empty pipeline id provided'
+        return u'Empty pipeline id provided'
     if not set(pipeline_id) <= PIPELINE_ID_PERMITTED_CHARACTERS:
-        message = 'Pipeline id {} has invalid character(s)\n'.format(pipeline_id)
-        message += "Valid characters are: _ - a-z A-Z 0-9"
+        message = u'Pipeline id {} has invalid character(s)\n'.format(pipeline_id)
+        message += u'Valid characters are: _ - a-z A-Z 0-9'
         return message
 
 

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -33,7 +33,7 @@ except ImportError:
 import click
 
 from databricks_cli.click_types import PipelineSpecClickType, PipelineIdClickType
-from databricks_cli.utils import pipelines_exception_eater, CONTEXT_SETTINGS, pretty_format
+from databricks_cli.utils import pipelines_exception_eater, CONTEXT_SETTINGS, pretty_format, error_and_quit
 from databricks_cli.version import print_version_callback, version
 from databricks_cli.pipelines.api import PipelinesApi
 from databricks_cli.configure.config import provide_api_client, profile_option, debug_option
@@ -177,9 +177,12 @@ def _read_spec(src):
     """
     extension = os.path.splitext(src)[1]
     if extension.lower() == '.json' or True:
-        with open(src, 'r') as f:
-            data = f.read()
-        return json.loads(data)
+        try:
+            with open(src, 'r') as f:
+                data = f.read()
+            return json.loads(data)
+        except json.JSONDecodeError as e:
+            error_and_quit("Invalid JSON provided in spec\n{}".format(e))
     else:
         raise RuntimeError('The provided file extension for the spec is not supported')
 

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -40,6 +40,11 @@ from databricks_cli.configure.config import provide_api_client, profile_option, 
 from databricks_cli.utils import pipelines_exception_eater, CONTEXT_SETTINGS, pretty_format, \
     error_and_quit
 
+try:
+    json_parse_exception = json.decoder.JSONDecodeError
+except AttributeError:  # Python 2
+    json_parse_exception = ValueError
+
 PIPELINE_ID_PERMITTED_CHARACTERS = set(string.ascii_letters + string.digits + '-_')
 
 
@@ -186,7 +191,7 @@ def _read_spec(src):
             with open(src, 'r') as f:
                 data = f.read()
             return json.loads(data)
-        except json.JSONDecodeError as e:
+        except json_parse_exception as e:
             error_and_quit("Invalid JSON provided in spec\n{}".format(e))
     else:
         raise RuntimeError('The provided file extension for the spec is not supported')

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -33,7 +33,7 @@ except ImportError:
 import click
 
 from databricks_cli.click_types import PipelineSpecClickType, PipelineIdClickType
-from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS, pretty_format
+from databricks_cli.utils import pipelines_exception_eater, CONTEXT_SETTINGS, pretty_format
 from databricks_cli.version import print_version_callback, version
 from databricks_cli.pipelines.api import PipelinesApi
 from databricks_cli.configure.config import provide_api_client, profile_option, debug_option
@@ -45,7 +45,7 @@ from databricks_cli.configure.config import provide_api_client, profile_option, 
 @click.option('--spec', default=None, type=PipelineSpecClickType(), help=PipelineSpecClickType.help)
 @debug_option
 @profile_option
-@eat_exceptions
+@pipelines_exception_eater
 @provide_api_client
 def deploy_cli(api_client, spec_arg, spec):
     """
@@ -86,7 +86,7 @@ def deploy_cli(api_client, spec_arg, spec):
               help=PipelineIdClickType.help)
 @debug_option
 @profile_option
-@eat_exceptions
+@pipelines_exception_eater
 @provide_api_client
 def delete_cli(api_client, spec_arg, spec, pipeline_id):
     """
@@ -117,7 +117,7 @@ def delete_cli(api_client, spec_arg, spec, pipeline_id):
               help=PipelineIdClickType.help)
 @debug_option
 @profile_option
-@eat_exceptions
+@pipelines_exception_eater
 @provide_api_client
 def get_cli(api_client, spec_arg, spec, pipeline_id):
     """
@@ -147,7 +147,7 @@ def get_cli(api_client, spec_arg, spec, pipeline_id):
               help=PipelineIdClickType.help)
 @debug_option
 @profile_option
-@eat_exceptions
+@pipelines_exception_eater
 @provide_api_client
 def reset_cli(api_client, spec_arg, spec, pipeline_id):
     """

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -117,7 +117,7 @@ def delete_cli(api_client, spec_arg, spec, pipeline_id):
     """
     pipeline_id = _get_pipeline_id(spec_arg=spec_arg, spec=spec, pipeline_id=pipeline_id)
     PipelinesApi(api_client).delete(pipeline_id)
-    click.echo("Pipeline {} successfully deleted".format(pipeline_id))
+    click.echo("Pipeline {} deleted".format(pipeline_id))
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
@@ -179,7 +179,7 @@ def reset_cli(api_client, spec_arg, spec, pipeline_id):
     """
     pipeline_id = _get_pipeline_id(spec_arg=spec_arg, spec=spec, pipeline_id=pipeline_id)
     PipelinesApi(api_client).reset(pipeline_id)
-    click.echo("Pipeline {} successfully reset".format(pipeline_id))
+    click.echo("Reset triggered for pipeline {}".format(pipeline_id))
 
 
 def _read_spec(src):

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -176,7 +176,7 @@ def _read_spec(src):
     if the format is supported.
     """
     extension = os.path.splitext(src)[1]
-    if extension.lower() == '.json' or True:
+    if extension.lower() == '.json':
         try:
             with open(src, 'r') as f:
                 data = f.read()

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -21,8 +21,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import six
 from json import loads as json_loads
 import os
+
+if six.PY2:
+    from urlparse import urlparse, urljoin
+elif six.PY3:
+    from urllib.parse import urlparse, urljoin
 
 import click
 
@@ -60,6 +66,11 @@ def deploy_cli(api_client, spec_arg, spec):
     src = spec_arg if bool(spec_arg) else spec
     spec_obj = _read_spec(src)
     PipelinesApi(api_client).deploy(spec_obj)
+
+    pipeline_id = spec_obj['id']
+    base_url = "{0.scheme}://{0.netloc}/".format(urlparse(api_client.url))
+    pipeline_url = urljoin(base_url, "#joblist/pipelines/{}".format(pipeline_id))
+    click.echo(pipeline_url)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -33,10 +33,11 @@ except ImportError:
 import click
 
 from databricks_cli.click_types import PipelineSpecClickType, PipelineIdClickType
-from databricks_cli.utils import pipelines_exception_eater, CONTEXT_SETTINGS, pretty_format, error_and_quit
 from databricks_cli.version import print_version_callback, version
 from databricks_cli.pipelines.api import PipelinesApi
 from databricks_cli.configure.config import provide_api_client, profile_option, debug_option
+from databricks_cli.utils import pipelines_exception_eater, CONTEXT_SETTINGS, pretty_format, \
+    error_and_quit
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,

--- a/databricks_cli/utils.py
+++ b/databricks_cli/utils.py
@@ -88,7 +88,7 @@ def error_and_quit(message):
     context_object = ctx.ensure_object(ContextObject)
     if context_object.debug_mode:
         traceback.print_exc()
-    click.echo('Error: {}'.format(message))
+    click.echo(u'Error: {}'.format(message))
     sys.exit(1)
 
 

--- a/databricks_cli/utils.py
+++ b/databricks_cli/utils.py
@@ -68,13 +68,15 @@ def pipelines_exception_eater(function):
             if exception.response.status_code == 401:
                 error_and_quit('Your authentication information may be incorrect. Please '
                                + 'reconfigure with ``dbfs configure``')
-
-            elif exception.response.status_code == 400:
-                exp_context = json_loads(exception.response.content.decode('utf-8'))
-                message = exp_context['error_code'] + '\n' + exp_context['message']
-                error_and_quit(message)
             else:
-                error_and_quit(exception.response.content)
+                try:
+                    exp_context = json_loads(exception.response.content.decode('utf-8'))
+                    message = exception.response.content
+                    if 'error_code' in exp_context and 'message' in exp_context:
+                        message = exp_context['error_code'] + '\n' + exp_context['message']
+                    error_and_quit(message)
+                except Exception:  # noqa
+                    error_and_quit(exception.response.content)
         except Exception as exception:  # noqa
             if not DEBUG_MODE:
                 error_and_quit('{}: {}'.format(type(exception).__name__, str(exception)))

--- a/databricks_cli/utils.py
+++ b/databricks_cli/utils.py
@@ -55,6 +55,11 @@ def eat_exceptions(function):
 
 
 def pipelines_exception_eater(function):
+    """
+    Formats error messages from the pipelines API while keeping the existing
+    behavior of eat_exception
+    """
+
     @six.wraps(function)
     def decorator(*args, **kwargs):
         try:
@@ -66,8 +71,7 @@ def pipelines_exception_eater(function):
 
             elif exception.response.status_code == 400:
                 exp_context = json_loads(exception.response.content.decode('utf-8'))
-                message = "Error: {}\n".format((exp_context['error_code']))
-                message += exp_context['message']
+                message = exp_context['error_code'] + '\n' + exp_context['message']
                 error_and_quit(message)
             else:
                 error_and_quit(exception.response.content)

--- a/tests/pipelines/test_cli.py
+++ b/tests/pipelines/test_cli.py
@@ -257,3 +257,12 @@ def test_get_cli_no_id(pipelines_api_mock):
     result = runner.invoke(cli.get_cli, [])
     assert result.exit_code == 1
     assert pipelines_api_mock.get.call_count == 0
+
+
+def test_validate_pipeline_id():
+    unicode_string = b'pipeline_id-\xe2\x9d\x8c-123'.decode('utf-8')
+    assert cli._validate_pipeline_id(unicode_string) is False
+    assert cli._validate_pipeline_id('pipeline_id-?-123') is False
+    assert cli._validate_pipeline_id('pipeline_id-\\-\'-123') is False
+    assert cli._validate_pipeline_id('pipeline_id-/-123') is False
+    assert cli._validate_pipeline_id('pipeline_id-ac345cd1')

--- a/tests/pipelines/test_cli.py
+++ b/tests/pipelines/test_cli.py
@@ -125,7 +125,7 @@ def test_delete_cli_incorrect_parameters(pipelines_api_mock, tmpdir):
 
 
 @provide_conf
-def test_deploy_spec_updated_with_id_if_pipeline_id_not_in_spec(pipelines_api_mock, tmpdir):  # noqa
+def test_deploy_spec_updated_with_id_if_pipeline_id_not_in_spec(pipelines_api_mock, tmpdir):
     path = tmpdir.join('/spec.json').strpath
     spec_with_no_id = '{"name": "no id"}'
     with open(path, 'w') as f:
@@ -138,7 +138,7 @@ def test_deploy_spec_updated_with_id_if_pipeline_id_not_in_spec(pipelines_api_mo
 
 
 @provide_conf
-def test_deploy_spec_pipeline_id_is_not_changed_if_provided_in_spec(pipelines_api_mock, tmpdir):  # noqa
+def test_deploy_spec_pipeline_id_is_not_changed_if_provided_in_spec(pipelines_api_mock, tmpdir):
     path = tmpdir.join('/spec.json').strpath
     with open(path, 'w') as f:
         f.write(DEPLOY_SPEC)

--- a/tests/pipelines/test_cli.py
+++ b/tests/pipelines/test_cli.py
@@ -125,7 +125,7 @@ def test_delete_cli_incorrect_parameters(pipelines_api_mock, tmpdir):
 
 
 @provide_conf
-def test_deploy_spec_updated_with_id_if_pipeline_id_not_in_spec(pipelines_api_mock, tmpdir):
+def test_deploy_spec_updated_with_id_if_pipeline_id_not_in_spec(tmpdir):
     path = tmpdir.join('/spec.json').strpath
     spec_with_no_id = '{"name": "no id"}'
     with open(path, 'w') as f:
@@ -138,7 +138,7 @@ def test_deploy_spec_updated_with_id_if_pipeline_id_not_in_spec(pipelines_api_mo
 
 
 @provide_conf
-def test_deploy_spec_pipeline_id_is_not_changed_if_provided_in_spec(pipelines_api_mock, tmpdir):
+def test_deploy_spec_pipeline_id_is_not_changed_if_provided_in_spec(tmpdir):
     path = tmpdir.join('/spec.json').strpath
     with open(path, 'w') as f:
         f.write(DEPLOY_SPEC)

--- a/tests/pipelines/test_cli.py
+++ b/tests/pipelines/test_cli.py
@@ -25,9 +25,9 @@
 
 import json
 
-import click
 import mock
 import pytest
+from click import Context, Command
 from click.testing import CliRunner
 
 import databricks_cli.pipelines.cli as cli
@@ -51,7 +51,7 @@ def click_ctx():
     A dummy Click context to allow testing of methods that raise exceptions. Fixes Click capturing
     actual exceptions and raising its own `RuntimeError: There is no active click context`.
     """
-    return click.Context(click.Command('cmd'))
+    return Context(Command('cmd'))
 
 
 @provide_conf

--- a/tests/pipelines/test_cli.py
+++ b/tests/pipelines/test_cli.py
@@ -125,6 +125,19 @@ def test_delete_cli_incorrect_parameters(pipelines_api_mock, tmpdir):
 
 
 @provide_conf
+def test_deploy_spec_updated_with_id_if_pipeline_id_not_in_spec(pipelines_api_mock, tmpdir):  # noqa
+    path = tmpdir.join('/spec.json').strpath
+    spec_with_no_id = '{"name": "no id"}'
+    with open(path, 'w') as f:
+        f.write(spec_with_no_id)
+    runner = CliRunner()
+    runner.invoke(cli.deploy_cli, ['--spec', path])
+    with open(path, 'r') as f:
+        updated_spec = json.loads(f.read())
+    assert 'id' in updated_spec
+
+
+@provide_conf
 def test_deploy_delete_cli_incorrect_spec_extension(pipelines_api_mock, tmpdir):
     path = tmpdir.join('/spec.wrong_ext').strpath
     with open(path, 'w') as f:

--- a/tests/pipelines/test_cli.py
+++ b/tests/pipelines/test_cli.py
@@ -24,8 +24,9 @@
 # pylint:disable=redefined-outer-name
 
 import json
-import mock
+
 import click
+import mock
 import pytest
 from click.testing import CliRunner
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,6 +33,7 @@ def test_eat_exceptions_normal_case():
     """
     If no exceptions, this wrapper should do nothing.
     """
+
     @utils.eat_exceptions
     def test_function(x):
         return x
@@ -50,9 +51,72 @@ def test_eat_exceptions_401():
             resp = Response()
             resp.status_code = 401
             raise HTTPError(response=resp)
+
         test_function()
         assert error_and_quit_mock.call_count == 1
         assert 'Your authentication information' in error_and_quit_mock.call_args[0][0]
+
+
+def test_pipelines_exception_eater_normal_case():
+    """
+    If no exceptions, this wrapper should do nothing.
+    """
+
+    @utils.pipelines_exception_eater
+    def test_function(x):
+        return x
+
+    assert test_function(1) == 1
+
+
+def test_pipelines_exception_eater_http_error_401():
+    """
+    If wrapped function returns 401 HTTPError, then print special error message.
+    """
+    with mock.patch('databricks_cli.utils.error_and_quit') as error_and_quit_mock:
+        @utils.pipelines_exception_eater
+        def test_function():
+            resp = Response()
+            resp.status_code = 401
+            raise HTTPError(response=resp)
+
+        test_function()
+        assert error_and_quit_mock.call_count == 1
+        print(error_and_quit_mock.call_args)
+        assert 'Your authentication information' in error_and_quit_mock.call_args[0][0]
+
+
+def test_pipelines_exception_eater_non_401_http_error():
+    """
+    If wrapped function returns a non 401 HTTPError, then try to parse json response
+    to print a formatted error message.
+    """
+    with mock.patch('databricks_cli.utils.error_and_quit') as error_and_quit_mock:
+        @utils.pipelines_exception_eater
+        def test_function(content):
+            resp = Response()
+            resp.status_code = 400
+            resp._content_consumed = True
+            resp._content = content
+            raise HTTPError(response=resp)
+
+        test_function(content=b'{"error_code":"TEST_ERROR_CODE","message":"test message"}')
+        assert error_and_quit_mock.call_count == 1
+        assert 'TEST_ERROR_CODE\ntest message' == error_and_quit_mock.call_args[0][0]
+        test_function(content=b'{"message":"test message"}')
+        assert error_and_quit_mock.call_count == 2
+        assert b'{"message":"test message"}' == error_and_quit_mock.call_args[0][0]
+
+
+def test_pipelines_exception_eater_non_http_error_exceptions():
+    with mock.patch('databricks_cli.utils.error_and_quit') as error_and_quit_mock:
+        @utils.pipelines_exception_eater
+        def test_function():
+            raise ValueError('value error test message')
+
+        test_function()
+        assert error_and_quit_mock.call_count == 1
+        assert 'ValueError: value error test message' == error_and_quit_mock.call_args[0][0]
 
 
 def test_json_cli_base_both_args():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -82,7 +82,6 @@ def test_pipelines_exception_eater_http_error_401():
 
         test_function()
         assert error_and_quit_mock.call_count == 1
-        print(error_and_quit_mock.call_args)
         assert 'Your authentication information' in error_and_quit_mock.call_args[0][0]
 
 
@@ -102,10 +101,10 @@ def test_pipelines_exception_eater_non_401_http_error():
 
         test_function(content=b'{"error_code":"TEST_ERROR_CODE","message":"test message"}')
         assert error_and_quit_mock.call_count == 1
-        assert 'TEST_ERROR_CODE\ntest message' == error_and_quit_mock.call_args[0][0]
+        assert error_and_quit_mock.call_args[0][0] == 'TEST_ERROR_CODE\ntest message'
         test_function(content=b'{"message":"test message"}')
         assert error_and_quit_mock.call_count == 2
-        assert b'{"message":"test message"}' == error_and_quit_mock.call_args[0][0]
+        assert error_and_quit_mock.call_args[0][0] == b'{"message":"test message"}'
 
 
 def test_pipelines_exception_eater_non_http_error_exceptions():
@@ -116,7 +115,7 @@ def test_pipelines_exception_eater_non_http_error_exceptions():
 
         test_function()
         assert error_and_quit_mock.call_count == 1
-        assert 'ValueError: value error test message' == error_and_quit_mock.call_args[0][0]
+        assert error_and_quit_mock.call_args[0][0] == 'ValueError: value error test message'
 
 
 def test_json_cli_base_both_args():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37
+envlist = py27, py36
 
 [testenv]
 # https://github.com/codecov/codecov-python/blob/5b9d539a6a09bc84501b381b563956295478651a/README.md#using-tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py37
 
 [testenv]
 # https://github.com/codecov/codecov-python/blob/5b9d539a6a09bc84501b381b563956295478651a/README.md#using-tox


### PR DESCRIPTION
This PR makes the following changes to the Pipelines CLI:

A successful spec deployment prints the URL to the pipeline.
If the provided spec file does not have an ID, one is generated and the spec file is updated with the new ID.
Adds a new exception eater to print cleaner error messages from the pipelines API
Adds exception handing for specs with invalid json
A validation check for pipeline id: only -, _ and alphanumeric characters are allowed
Testing:
Unit Tests
Manually verified deployment URLs, new exception formatting, validation of pipeline ids

Continues from https://github.com/databricks/databricks-cli/pull/296 addressing PR comments, for some reason I was able to push straight to main and repo and can no longer can.