### PR TITLE
Use create pipeline API

### DIFF
--- a/databricks_cli/pipelines/api.py
+++ b/databricks_cli/pipelines/api.py
@@ -21,9 +21,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from hashlib import sha1
 import os
+import copy
 
 from six.moves import urllib
 
@@ -41,13 +41,13 @@ class PipelinesApi(object):
         self.client = DeltaPipelinesService(api_client)
         self.dbfs_client = DbfsApi(api_client)
 
-    def deploy(self, spec, headers=None):
-        lib_objects = LibraryObject.from_json(spec.get('libraries', []))
-        local_lib_objects, external_lib_objects = \
-            self._identify_local_libraries(lib_objects)
+    def create(self, spec, headers=None):
+        spec = self._upload_libraries_and_update_spec(spec)
+        return self.client.client.perform_query('POST', '/pipelines/'.format(), data=spec,
+                                                headers=headers)
 
-        spec['libraries'] = LibraryObject.to_json(external_lib_objects +
-                                                  self._upload_local_libraries(local_lib_objects))
+    def deploy(self, spec, headers=None):
+        spec = self._upload_libraries_and_update_spec(spec)
         pipeline_id = spec['id']
         self.client.client.perform_query('PUT', '/pipelines/{}'.format(pipeline_id), data=spec,
                                          headers=headers)
@@ -60,6 +60,16 @@ class PipelinesApi(object):
 
     def reset(self, pipeline_id, headers=None):
         self.client.reset(pipeline_id, headers)
+
+    def _upload_libraries_and_update_spec(self, spec):
+        spec = copy.deepcopy(spec)
+        lib_objects = LibraryObject.from_json(spec.get('libraries', []))
+        local_lib_objects, external_lib_objects = \
+            self._identify_local_libraries(lib_objects)
+
+        spec['libraries'] = LibraryObject.to_json(external_lib_objects +
+                                                  self._upload_local_libraries(local_lib_objects))
+        return spec
 
     @staticmethod
     def _identify_local_libraries(lib_objects):

--- a/databricks_cli/pipelines/api.py
+++ b/databricks_cli/pipelines/api.py
@@ -51,6 +51,9 @@ class PipelinesApi(object):
         self.client.client.perform_query('PUT', '/pipelines/{}'.format(pipeline_id), data=spec,
                                          headers=headers)
 
+    def list(self, headers=None):
+        return self.client.client.perform_query("GET", "/pipelines", headers=headers)
+
     def delete(self, pipeline_id, headers=None):
         self.client.delete(pipeline_id, headers)
 

--- a/databricks_cli/pipelines/api.py
+++ b/databricks_cli/pipelines/api.py
@@ -41,18 +41,18 @@ class PipelinesApi(object):
         self.client = DeltaPipelinesService(api_client)
         self.dbfs_client = DbfsApi(api_client)
 
-    def create(self, spec, headers=None):
-        spec = self._upload_libraries_and_update_spec(spec)
-        return self.client.client.perform_query('POST', '/pipelines', data=spec, headers=headers)
+    def create(self, spec, allow_duplicate_names, headers=None):
+        data = self._upload_libraries_and_update_spec(spec)
+        data['allow_duplicate_names'] = allow_duplicate_names
+        return self.client.client.perform_query('POST', '/pipelines', data=data,
+                                                headers=headers)
 
-    def deploy(self, spec, headers=None):
-        spec = self._upload_libraries_and_update_spec(spec)
-        pipeline_id = spec['id']
-        self.client.client.perform_query('PUT', '/pipelines/{}'.format(pipeline_id), data=spec,
+    def deploy(self, spec, allow_duplicate_names, headers=None):
+        data = self._upload_libraries_and_update_spec(spec)
+        data['allow_duplicate_names'] = allow_duplicate_names
+        pipeline_id = data['id']
+        self.client.client.perform_query('PUT', '/pipelines/{}'.format(pipeline_id), data=data,
                                          headers=headers)
-
-    def list(self, headers=None):
-        return self.client.client.perform_query("GET", "/pipelines", headers=headers)
 
     def delete(self, pipeline_id, headers=None):
         self.client.delete(pipeline_id, headers)

--- a/databricks_cli/pipelines/api.py
+++ b/databricks_cli/pipelines/api.py
@@ -43,7 +43,7 @@ class PipelinesApi(object):
 
     def create(self, spec, headers=None):
         spec = self._upload_libraries_and_update_spec(spec)
-        return self.client.client.perform_query('POST', '/pipelines/'.format(), data=spec,
+        return self.client.client.perform_query('POST', '/pipelines'.format(), data=spec,
                                                 headers=headers)
 
     def deploy(self, spec, headers=None):
@@ -64,8 +64,7 @@ class PipelinesApi(object):
     def _upload_libraries_and_update_spec(self, spec):
         spec = copy.deepcopy(spec)
         lib_objects = LibraryObject.from_json(spec.get('libraries', []))
-        local_lib_objects, external_lib_objects = \
-            self._identify_local_libraries(lib_objects)
+        local_lib_objects, external_lib_objects = self._identify_local_libraries(lib_objects)
 
         spec['libraries'] = LibraryObject.to_json(external_lib_objects +
                                                   self._upload_local_libraries(local_lib_objects))

--- a/databricks_cli/pipelines/api.py
+++ b/databricks_cli/pipelines/api.py
@@ -43,8 +43,7 @@ class PipelinesApi(object):
 
     def create(self, spec, headers=None):
         spec = self._upload_libraries_and_update_spec(spec)
-        return self.client.client.perform_query('POST', '/pipelines'.format(), data=spec,
-                                                headers=headers)
+        return self.client.client.perform_query('POST', '/pipelines', data=spec, headers=headers)
 
     def deploy(self, spec, headers=None):
         spec = self._upload_libraries_and_update_spec(spec)

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -21,7 +21,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import os
 import json
 import string

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -21,6 +21,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import os
 import json
 import string
@@ -75,7 +76,7 @@ def deploy_cli(api_client, spec_arg, spec):
     src = spec_arg if bool(spec_arg) else spec
     spec_obj = _read_spec(src)
     if 'id' not in spec_obj:
-        response = PipelinesApi(api_client).create(spec_obj)
+        response = PipelinesApi(api_client).create(copy.deepcopy(spec_obj))
         new_pipeline_id = response['pipeline_id']
         click.echo("Successfully deployed pipeline: {}".format(
             _get_pipeline_url(api_client, new_pipeline_id)))

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -83,7 +83,7 @@ def deploy_cli(api_client, spec_arg, spec):
 
         spec_obj['id'] = new_pipeline_id
         _write_spec(src, spec_obj)
-        click.echo("Updated spec at {} with ID: {}".format(src, new_pipeline_id))
+        click.echo("Updated spec at {} with ID {}".format(src, new_pipeline_id))
     else:
         _validate_pipeline_id(spec_obj['id'])
         PipelinesApi(api_client).deploy(spec_obj)

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -63,6 +63,9 @@ def deploy_cli(api_client, spec_arg, spec, force):
     specification that explains how to run a Delta Pipeline on Databricks. All local libraries
     referenced in the spec are uploaded to DBFS.
 
+    The deploy command creates a new pipeline and adds the ID of this pipeline to your spec if your
+    spec does not already contain an ID.
+
     Usage:
 
     databricks pipelines deploy example.json
@@ -70,6 +73,11 @@ def deploy_cli(api_client, spec_arg, spec, force):
     OR
 
     databricks pipelines deploy --spec example.json
+
+    The deploy command will not create a new pipeline if a pipeline with the same name
+    already exists. You can disable this check by using the --force option.
+
+    databricks pipelines deploy --force --spec example.json
     """
     if bool(spec_arg) == bool(spec):
         raise RuntimeError('The spec should be provided either by an option or argument')

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -801,7 +801,8 @@ class DeltaPipelinesService(object):
         self.client = client
 
     def create(self, id=None, name=None, storage=None, configuration=None, clusters=None,
-               libraries=None, filters=None, headers=None):
+               libraries=None, trigger=None, filters=None, allow_duplicate_names=None,
+               headers=None):
         _data = {}
         if id is not None:
             _data['id'] = id
@@ -815,14 +816,21 @@ class DeltaPipelinesService(object):
             _data['clusters'] = clusters
         if libraries is not None:
             _data['libraries'] = libraries
+        if trigger is not None:
+            _data['trigger'] = trigger
+            if not isinstance(trigger, dict):
+                raise TypeError('Expected databricks.PipelineTrigger() or dict for field trigger')
         if filters is not None:
             _data['filters'] = filters
             if not isinstance(filters, dict):
                 raise TypeError('Expected databricks.Filters() or dict for field filters')
+        if allow_duplicate_names is not None:
+            _data['allow_duplicate_names'] = allow_duplicate_names
         return self.client.perform_query('POST', '/pipelines', data=_data, headers=headers)
 
     def deploy(self, pipeline_id=None, id=None, name=None, storage=None, configuration=None,
-               clusters=None, libraries=None, filters=None, headers=None):
+               clusters=None, libraries=None, trigger=None, filters=None,
+               allow_duplicate_names=None, headers=None):
         _data = {}
         if id is not None:
             _data['id'] = id
@@ -836,11 +844,19 @@ class DeltaPipelinesService(object):
             _data['clusters'] = clusters
         if libraries is not None:
             _data['libraries'] = libraries
+        if trigger is not None:
+            _data['trigger'] = trigger
+            if not isinstance(trigger, dict):
+                raise TypeError('Expected databricks.PipelineTrigger() or dict for field trigger')
         if filters is not None:
             _data['filters'] = filters
             if not isinstance(filters, dict):
                 raise TypeError('Expected databricks.Filters() or dict for field filters')
-        return self.client.perform_query('PUT', '/pipelines/{pipeline_id}'.format(pipeline_id=pipeline_id), data=_data, headers=headers)
+        if allow_duplicate_names is not None:
+            _data['allow_duplicate_names'] = allow_duplicate_names
+        return self.client.perform_query('PUT',
+                                         '/pipelines/{pipeline_id}'.format(pipeline_id=pipeline_id),
+                                         data=_data, headers=headers)
 
     def delete(self, pipeline_id=None, headers=None):
         _data = {}

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -46,8 +46,7 @@ class JobsService(object):
         if email_notifications is not None:
             _data['email_notifications'] = email_notifications
             if not isinstance(email_notifications, dict):
-                raise TypeError(
-                    'Expected databricks.JobEmailNotifications() or dict for field email_notifications')
+                raise TypeError('Expected databricks.JobEmailNotifications() or dict for field email_notifications')
         if timeout_seconds is not None:
             _data['timeout_seconds'] = timeout_seconds
         if max_retries is not None:
@@ -63,23 +62,19 @@ class JobsService(object):
         if notebook_task is not None:
             _data['notebook_task'] = notebook_task
             if not isinstance(notebook_task, dict):
-                raise TypeError(
-                    'Expected databricks.NotebookTask() or dict for field notebook_task')
+                raise TypeError('Expected databricks.NotebookTask() or dict for field notebook_task')
         if spark_jar_task is not None:
             _data['spark_jar_task'] = spark_jar_task
             if not isinstance(spark_jar_task, dict):
-                raise TypeError(
-                    'Expected databricks.SparkJarTask() or dict for field spark_jar_task')
+                raise TypeError('Expected databricks.SparkJarTask() or dict for field spark_jar_task')
         if spark_python_task is not None:
             _data['spark_python_task'] = spark_python_task
             if not isinstance(spark_python_task, dict):
-                raise TypeError(
-                    'Expected databricks.SparkPythonTask() or dict for field spark_python_task')
+                raise TypeError('Expected databricks.SparkPythonTask() or dict for field spark_python_task')
         if spark_submit_task is not None:
             _data['spark_submit_task'] = spark_submit_task
             if not isinstance(spark_submit_task, dict):
-                raise TypeError(
-                    'Expected databricks.SparkSubmitTask() or dict for field spark_submit_task')
+                raise TypeError('Expected databricks.SparkSubmitTask() or dict for field spark_submit_task')
         if max_concurrent_runs is not None:
             _data['max_concurrent_runs'] = max_concurrent_runs
         return self.client.perform_query('POST', '/jobs/create', data=_data, headers=headers)
@@ -101,23 +96,19 @@ class JobsService(object):
         if notebook_task is not None:
             _data['notebook_task'] = notebook_task
             if not isinstance(notebook_task, dict):
-                raise TypeError(
-                    'Expected databricks.NotebookTask() or dict for field notebook_task')
+                raise TypeError('Expected databricks.NotebookTask() or dict for field notebook_task')
         if spark_jar_task is not None:
             _data['spark_jar_task'] = spark_jar_task
             if not isinstance(spark_jar_task, dict):
-                raise TypeError(
-                    'Expected databricks.SparkJarTask() or dict for field spark_jar_task')
+                raise TypeError('Expected databricks.SparkJarTask() or dict for field spark_jar_task')
         if spark_python_task is not None:
             _data['spark_python_task'] = spark_python_task
             if not isinstance(spark_python_task, dict):
-                raise TypeError(
-                    'Expected databricks.SparkPythonTask() or dict for field spark_python_task')
+                raise TypeError('Expected databricks.SparkPythonTask() or dict for field spark_python_task')
         if spark_submit_task is not None:
             _data['spark_submit_task'] = spark_submit_task
             if not isinstance(spark_submit_task, dict):
-                raise TypeError(
-                    'Expected databricks.SparkSubmitTask() or dict for field spark_submit_task')
+                raise TypeError('Expected databricks.SparkSubmitTask() or dict for field spark_submit_task')
         if timeout_seconds is not None:
             _data['timeout_seconds'] = timeout_seconds
         return self.client.perform_query('POST', '/jobs/runs/submit', data=_data, headers=headers)
@@ -201,8 +192,7 @@ class JobsService(object):
         _data = {}
         if run_id is not None:
             _data['run_id'] = run_id
-        return self.client.perform_query('GET', '/jobs/runs/get-output', data=_data,
-                                         headers=headers)
+        return self.client.perform_query('GET', '/jobs/runs/get-output', data=_data, headers=headers)
 
     def export_run(self, run_id, views_to_export=None, headers=None):
         _data = {}
@@ -222,8 +212,7 @@ class ClusterService(object):
 
         return self.client.perform_query('GET', '/clusters/list', data=_data, headers=headers)
 
-    def create_cluster(self, num_workers=None, autoscale=None, cluster_name=None,
-                       spark_version=None,
+    def create_cluster(self, num_workers=None, autoscale=None, cluster_name=None, spark_version=None,
                        spark_conf=None, aws_attributes=None, node_type_id=None,
                        driver_node_type_id=None, ssh_public_keys=None, custom_tags=None,
                        cluster_log_conf=None, init_scripts=None, spark_env_vars=None,
@@ -245,8 +234,7 @@ class ClusterService(object):
         if aws_attributes is not None:
             _data['aws_attributes'] = aws_attributes
             if not isinstance(aws_attributes, dict):
-                raise TypeError(
-                    'Expected databricks.AwsAttributes() or dict for field aws_attributes')
+                raise TypeError('Expected databricks.AwsAttributes() or dict for field aws_attributes')
         if node_type_id is not None:
             _data['node_type_id'] = node_type_id
         if driver_node_type_id is not None:
@@ -258,8 +246,7 @@ class ClusterService(object):
         if cluster_log_conf is not None:
             _data['cluster_log_conf'] = cluster_log_conf
             if not isinstance(cluster_log_conf, dict):
-                raise TypeError(
-                    'Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
+                raise TypeError('Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
         if init_scripts is not None:
             _data['init_scripts'] = init_scripts
         if spark_env_vars is not None:
@@ -283,8 +270,7 @@ class ClusterService(object):
     def list_spark_versions(self, headers=None):
         _data = {}
 
-        return self.client.perform_query('GET', '/clusters/spark-versions', data=_data,
-                                         headers=headers)
+        return self.client.perform_query('GET', '/clusters/spark-versions', data=_data, headers=headers)
 
     def delete_cluster(self, cluster_id, headers=None):
         _data = {}
@@ -296,8 +282,7 @@ class ClusterService(object):
         _data = {}
         if cluster_id is not None:
             _data['cluster_id'] = cluster_id
-        return self.client.perform_query('POST', '/clusters/permanent-delete', data=_data,
-                                         headers=headers)
+        return self.client.perform_query('POST', '/clusters/permanent-delete', data=_data, headers=headers)
 
     def restart_cluster(self, cluster_id, headers=None):
         _data = {}
@@ -341,8 +326,7 @@ class ClusterService(object):
         if aws_attributes is not None:
             _data['aws_attributes'] = aws_attributes
             if not isinstance(aws_attributes, dict):
-                raise TypeError(
-                    'Expected databricks.AwsAttributes() or dict for field aws_attributes')
+                raise TypeError('Expected databricks.AwsAttributes() or dict for field aws_attributes')
         if node_type_id is not None:
             _data['node_type_id'] = node_type_id
         if driver_node_type_id is not None:
@@ -354,8 +338,7 @@ class ClusterService(object):
         if cluster_log_conf is not None:
             _data['cluster_log_conf'] = cluster_log_conf
             if not isinstance(cluster_log_conf, dict):
-                raise TypeError(
-                    'Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
+                raise TypeError('Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
         if init_scripts is not None:
             _data['init_scripts'] = init_scripts
         if spark_env_vars is not None:
@@ -391,8 +374,7 @@ class ClusterService(object):
     def list_node_types(self, headers=None):
         _data = {}
 
-        return self.client.perform_query('GET', '/clusters/list-node-types', data=_data,
-                                         headers=headers)
+        return self.client.perform_query('GET', '/clusters/list-node-types', data=_data, headers=headers)
 
     def list_available_zones(self, headers=None):
         _data = {}
@@ -427,14 +409,12 @@ class ManagedLibraryService(object):
         _data = {}
         if cluster_id is not None:
             _data['cluster_id'] = cluster_id
-        return self.client.perform_query('GET', '/libraries/cluster-status', data=_data,
-                                         headers=headers)
+        return self.client.perform_query('GET', '/libraries/cluster-status', data=_data, headers=headers)
 
     def all_cluster_statuses(self, headers=None):
         _data = {}
 
-        return self.client.perform_query('GET', '/libraries/all-cluster-statuses', data=_data,
-                                         headers=headers)
+        return self.client.perform_query('GET', '/libraries/all-cluster-statuses', data=_data, headers=headers)
 
     def install_libraries(self, cluster_id, libraries=None, headers=None):
         _data = {}
@@ -450,8 +430,7 @@ class ManagedLibraryService(object):
             _data['cluster_id'] = cluster_id
         if libraries is not None:
             _data['libraries'] = libraries
-        return self.client.perform_query('POST', '/libraries/uninstall', data=_data,
-                                         headers=headers)
+        return self.client.perform_query('POST', '/libraries/uninstall', data=_data, headers=headers)
 
 
 class DbfsService(object):
@@ -552,7 +531,7 @@ class WorkspaceService(object):
         return self.client.perform_query('GET', '/workspace/list', data=_data, headers=headers)
 
     def import_workspace(self, path, format=None, language=None, content=None, overwrite=None,
-                         headers=None):
+               headers=None):
         _data = {}
         if path is not None:
             _data['path'] = path
@@ -588,8 +567,7 @@ class WorkspaceService(object):
         _data = {}
         if path is not None:
             _data['path'] = path
-        return self.client.perform_query('GET', '/workspace/get-status', data=_data,
-                                         headers=headers)
+        return self.client.perform_query('GET', '/workspace/get-status', data=_data, headers=headers)
 
 
 class SecretService(object):
@@ -605,15 +583,13 @@ class SecretService(object):
             _data['initial_manage_principal'] = initial_manage_principal
         if scope_backend_type is not None:
             _data['scope_backend_type'] = scope_backend_type
-        return self.client.perform_query('POST', '/secrets/scopes/create', data=_data,
-                                         headers=headers)
+        return self.client.perform_query('POST', '/secrets/scopes/create', data=_data, headers=headers)
 
     def delete_scope(self, scope, headers=None):
         _data = {}
         if scope is not None:
             _data['scope'] = scope
-        return self.client.perform_query('POST', '/secrets/scopes/delete', data=_data,
-                                         headers=headers)
+        return self.client.perform_query('POST', '/secrets/scopes/delete', data=_data, headers=headers)
 
     def list_scopes(self, headers=None):
         _data = {}
@@ -662,8 +638,7 @@ class SecretService(object):
             _data['scope'] = scope
         if principal is not None:
             _data['principal'] = principal
-        return self.client.perform_query('POST', '/secrets/acls/delete', data=_data,
-                                         headers=headers)
+        return self.client.perform_query('POST', '/secrets/acls/delete', data=_data, headers=headers)
 
     def list_acls(self, scope, headers=None):
         _data = {}
@@ -708,8 +683,7 @@ class GroupsService(object):
             _data['group_name'] = group_name
         if parent_name is not None:
             _data['parent_name'] = parent_name
-        return self.client.perform_query('POST', '/groups/remove-member', data=_data,
-                                         headers=headers)
+        return self.client.perform_query('POST', '/groups/remove-member', data=_data, headers=headers)
 
     def get_groups(self, headers=None):
         _data = {}
@@ -741,8 +715,7 @@ class InstancePoolService(object):
     def __init__(self, client):
         self.client = client
 
-    def create_instance_pool(self, instance_pool_name=None, min_idle_instances=None,
-                             max_capacity=None,
+    def create_instance_pool(self, instance_pool_name=None, min_idle_instances=None, max_capacity=None,
                              aws_attributes=None, node_type_id=None, custom_tags=None,
                              idle_instance_autotermination_minutes=None, enable_elastic_disk=None,
                              disk_spec=None, preloaded_spark_versions=None, headers=None):
@@ -756,8 +729,7 @@ class InstancePoolService(object):
         if aws_attributes is not None:
             _data['aws_attributes'] = aws_attributes
             if not isinstance(aws_attributes, dict):
-                raise TypeError(
-                    'Expected databricks.InstancePoolAwsAttributes() or dict for field aws_attributes')
+                raise TypeError('Expected databricks.InstancePoolAwsAttributes() or dict for field aws_attributes')
         if node_type_id is not None:
             _data['node_type_id'] = node_type_id
         if custom_tags is not None:
@@ -772,19 +744,16 @@ class InstancePoolService(object):
                 raise TypeError('Expected databricks.DiskSpec() or dict for field disk_spec')
         if preloaded_spark_versions is not None:
             _data['preloaded_spark_versions'] = preloaded_spark_versions
-        return self.client.perform_query('POST', '/instance-pools/create', data=_data,
-                                         headers=headers)
+        return self.client.perform_query('POST', '/instance-pools/create', data=_data, headers=headers)
 
     def delete_instance_pool(self, instance_pool_id=None, headers=None):
         _data = {}
         if instance_pool_id is not None:
             _data['instance_pool_id'] = instance_pool_id
-        return self.client.perform_query('POST', '/instance-pools/delete', data=_data,
-                                         headers=headers)
+        return self.client.perform_query('POST', '/instance-pools/delete', data=_data, headers=headers)
 
     def edit_instance_pool(self, instance_pool_id, instance_pool_name=None, min_idle_instances=None,
-                           max_capacity=None, aws_attributes=None, node_type_id=None,
-                           custom_tags=None,
+                           max_capacity=None, aws_attributes=None, node_type_id=None, custom_tags=None,
                            idle_instance_autotermination_minutes=None, enable_elastic_disk=None,
                            disk_spec=None, preloaded_spark_versions=None, headers=None):
         _data = {}
@@ -799,8 +768,7 @@ class InstancePoolService(object):
         if aws_attributes is not None:
             _data['aws_attributes'] = aws_attributes
             if not isinstance(aws_attributes, dict):
-                raise TypeError(
-                    'Expected databricks.InstancePoolAwsAttributes() or dict for field aws_attributes')
+                raise TypeError('Expected databricks.InstancePoolAwsAttributes() or dict for field aws_attributes')
         if node_type_id is not None:
             _data['node_type_id'] = node_type_id
         if custom_tags is not None:
@@ -815,8 +783,7 @@ class InstancePoolService(object):
                 raise TypeError('Expected databricks.DiskSpec() or dict for field disk_spec')
         if preloaded_spark_versions is not None:
             _data['preloaded_spark_versions'] = preloaded_spark_versions
-        return self.client.perform_query('POST', '/instance-pools/edit', data=_data,
-                                         headers=headers)
+        return self.client.perform_query('POST', '/instance-pools/edit', data=_data, headers=headers)
 
     def get_instance_pool(self, instance_pool_id=None, headers=None):
         _data = {}
@@ -873,26 +840,20 @@ class DeltaPipelinesService(object):
             _data['filters'] = filters
             if not isinstance(filters, dict):
                 raise TypeError('Expected databricks.Filters() or dict for field filters')
-        return self.client.perform_query('PUT',
-                                         '/pipelines/{pipeline_id}'.format(pipeline_id=pipeline_id),
-                                         data=_data, headers=headers)
+        return self.client.perform_query('PUT', '/pipelines/{pipeline_id}'.format(pipeline_id=pipeline_id), data=_data, headers=headers)
 
     def delete(self, pipeline_id=None, headers=None):
         _data = {}
 
-        return self.client.perform_query('DELETE',
-                                         '/pipelines/{pipeline_id}'.format(pipeline_id=pipeline_id),
-                                         data=_data, headers=headers)
+        return self.client.perform_query('DELETE', '/pipelines/{pipeline_id}'.format(pipeline_id=pipeline_id), data=_data, headers=headers)
 
     def get(self, pipeline_id=None, headers=None):
         _data = {}
 
-        return self.client.perform_query('GET',
-                                         '/pipelines/{pipeline_id}'.format(pipeline_id=pipeline_id),
-                                         data=_data, headers=headers)
+        return self.client.perform_query('GET', '/pipelines/{pipeline_id}'.format(pipeline_id=pipeline_id), data=_data, headers=headers)
 
     def reset(self, pipeline_id=None, headers=None):
         _data = {}
 
-        return self.client.perform_query('POST', '/pipelines/{pipeline_id}/reset'.format(
-            pipeline_id=pipeline_id), data=_data, headers=headers)
+        return self.client.perform_query('POST', '/pipelines/{pipeline_id}/reset'.format(pipeline_id=pipeline_id), data=_data, headers=headers)
+

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -46,7 +46,8 @@ class JobsService(object):
         if email_notifications is not None:
             _data['email_notifications'] = email_notifications
             if not isinstance(email_notifications, dict):
-                raise TypeError('Expected databricks.JobEmailNotifications() or dict for field email_notifications')
+                raise TypeError(
+                    'Expected databricks.JobEmailNotifications() or dict for field email_notifications')
         if timeout_seconds is not None:
             _data['timeout_seconds'] = timeout_seconds
         if max_retries is not None:
@@ -62,19 +63,23 @@ class JobsService(object):
         if notebook_task is not None:
             _data['notebook_task'] = notebook_task
             if not isinstance(notebook_task, dict):
-                raise TypeError('Expected databricks.NotebookTask() or dict for field notebook_task')
+                raise TypeError(
+                    'Expected databricks.NotebookTask() or dict for field notebook_task')
         if spark_jar_task is not None:
             _data['spark_jar_task'] = spark_jar_task
             if not isinstance(spark_jar_task, dict):
-                raise TypeError('Expected databricks.SparkJarTask() or dict for field spark_jar_task')
+                raise TypeError(
+                    'Expected databricks.SparkJarTask() or dict for field spark_jar_task')
         if spark_python_task is not None:
             _data['spark_python_task'] = spark_python_task
             if not isinstance(spark_python_task, dict):
-                raise TypeError('Expected databricks.SparkPythonTask() or dict for field spark_python_task')
+                raise TypeError(
+                    'Expected databricks.SparkPythonTask() or dict for field spark_python_task')
         if spark_submit_task is not None:
             _data['spark_submit_task'] = spark_submit_task
             if not isinstance(spark_submit_task, dict):
-                raise TypeError('Expected databricks.SparkSubmitTask() or dict for field spark_submit_task')
+                raise TypeError(
+                    'Expected databricks.SparkSubmitTask() or dict for field spark_submit_task')
         if max_concurrent_runs is not None:
             _data['max_concurrent_runs'] = max_concurrent_runs
         return self.client.perform_query('POST', '/jobs/create', data=_data, headers=headers)
@@ -96,19 +101,23 @@ class JobsService(object):
         if notebook_task is not None:
             _data['notebook_task'] = notebook_task
             if not isinstance(notebook_task, dict):
-                raise TypeError('Expected databricks.NotebookTask() or dict for field notebook_task')
+                raise TypeError(
+                    'Expected databricks.NotebookTask() or dict for field notebook_task')
         if spark_jar_task is not None:
             _data['spark_jar_task'] = spark_jar_task
             if not isinstance(spark_jar_task, dict):
-                raise TypeError('Expected databricks.SparkJarTask() or dict for field spark_jar_task')
+                raise TypeError(
+                    'Expected databricks.SparkJarTask() or dict for field spark_jar_task')
         if spark_python_task is not None:
             _data['spark_python_task'] = spark_python_task
             if not isinstance(spark_python_task, dict):
-                raise TypeError('Expected databricks.SparkPythonTask() or dict for field spark_python_task')
+                raise TypeError(
+                    'Expected databricks.SparkPythonTask() or dict for field spark_python_task')
         if spark_submit_task is not None:
             _data['spark_submit_task'] = spark_submit_task
             if not isinstance(spark_submit_task, dict):
-                raise TypeError('Expected databricks.SparkSubmitTask() or dict for field spark_submit_task')
+                raise TypeError(
+                    'Expected databricks.SparkSubmitTask() or dict for field spark_submit_task')
         if timeout_seconds is not None:
             _data['timeout_seconds'] = timeout_seconds
         return self.client.perform_query('POST', '/jobs/runs/submit', data=_data, headers=headers)
@@ -192,7 +201,8 @@ class JobsService(object):
         _data = {}
         if run_id is not None:
             _data['run_id'] = run_id
-        return self.client.perform_query('GET', '/jobs/runs/get-output', data=_data, headers=headers)
+        return self.client.perform_query('GET', '/jobs/runs/get-output', data=_data,
+                                         headers=headers)
 
     def export_run(self, run_id, views_to_export=None, headers=None):
         _data = {}
@@ -212,7 +222,8 @@ class ClusterService(object):
 
         return self.client.perform_query('GET', '/clusters/list', data=_data, headers=headers)
 
-    def create_cluster(self, num_workers=None, autoscale=None, cluster_name=None, spark_version=None,
+    def create_cluster(self, num_workers=None, autoscale=None, cluster_name=None,
+                       spark_version=None,
                        spark_conf=None, aws_attributes=None, node_type_id=None,
                        driver_node_type_id=None, ssh_public_keys=None, custom_tags=None,
                        cluster_log_conf=None, init_scripts=None, spark_env_vars=None,
@@ -234,7 +245,8 @@ class ClusterService(object):
         if aws_attributes is not None:
             _data['aws_attributes'] = aws_attributes
             if not isinstance(aws_attributes, dict):
-                raise TypeError('Expected databricks.AwsAttributes() or dict for field aws_attributes')
+                raise TypeError(
+                    'Expected databricks.AwsAttributes() or dict for field aws_attributes')
         if node_type_id is not None:
             _data['node_type_id'] = node_type_id
         if driver_node_type_id is not None:
@@ -246,7 +258,8 @@ class ClusterService(object):
         if cluster_log_conf is not None:
             _data['cluster_log_conf'] = cluster_log_conf
             if not isinstance(cluster_log_conf, dict):
-                raise TypeError('Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
+                raise TypeError(
+                    'Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
         if init_scripts is not None:
             _data['init_scripts'] = init_scripts
         if spark_env_vars is not None:
@@ -270,7 +283,8 @@ class ClusterService(object):
     def list_spark_versions(self, headers=None):
         _data = {}
 
-        return self.client.perform_query('GET', '/clusters/spark-versions', data=_data, headers=headers)
+        return self.client.perform_query('GET', '/clusters/spark-versions', data=_data,
+                                         headers=headers)
 
     def delete_cluster(self, cluster_id, headers=None):
         _data = {}
@@ -282,7 +296,8 @@ class ClusterService(object):
         _data = {}
         if cluster_id is not None:
             _data['cluster_id'] = cluster_id
-        return self.client.perform_query('POST', '/clusters/permanent-delete', data=_data, headers=headers)
+        return self.client.perform_query('POST', '/clusters/permanent-delete', data=_data,
+                                         headers=headers)
 
     def restart_cluster(self, cluster_id, headers=None):
         _data = {}
@@ -326,7 +341,8 @@ class ClusterService(object):
         if aws_attributes is not None:
             _data['aws_attributes'] = aws_attributes
             if not isinstance(aws_attributes, dict):
-                raise TypeError('Expected databricks.AwsAttributes() or dict for field aws_attributes')
+                raise TypeError(
+                    'Expected databricks.AwsAttributes() or dict for field aws_attributes')
         if node_type_id is not None:
             _data['node_type_id'] = node_type_id
         if driver_node_type_id is not None:
@@ -338,7 +354,8 @@ class ClusterService(object):
         if cluster_log_conf is not None:
             _data['cluster_log_conf'] = cluster_log_conf
             if not isinstance(cluster_log_conf, dict):
-                raise TypeError('Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
+                raise TypeError(
+                    'Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
         if init_scripts is not None:
             _data['init_scripts'] = init_scripts
         if spark_env_vars is not None:
@@ -374,7 +391,8 @@ class ClusterService(object):
     def list_node_types(self, headers=None):
         _data = {}
 
-        return self.client.perform_query('GET', '/clusters/list-node-types', data=_data, headers=headers)
+        return self.client.perform_query('GET', '/clusters/list-node-types', data=_data,
+                                         headers=headers)
 
     def list_available_zones(self, headers=None):
         _data = {}
@@ -409,12 +427,14 @@ class ManagedLibraryService(object):
         _data = {}
         if cluster_id is not None:
             _data['cluster_id'] = cluster_id
-        return self.client.perform_query('GET', '/libraries/cluster-status', data=_data, headers=headers)
+        return self.client.perform_query('GET', '/libraries/cluster-status', data=_data,
+                                         headers=headers)
 
     def all_cluster_statuses(self, headers=None):
         _data = {}
 
-        return self.client.perform_query('GET', '/libraries/all-cluster-statuses', data=_data, headers=headers)
+        return self.client.perform_query('GET', '/libraries/all-cluster-statuses', data=_data,
+                                         headers=headers)
 
     def install_libraries(self, cluster_id, libraries=None, headers=None):
         _data = {}
@@ -430,7 +450,8 @@ class ManagedLibraryService(object):
             _data['cluster_id'] = cluster_id
         if libraries is not None:
             _data['libraries'] = libraries
-        return self.client.perform_query('POST', '/libraries/uninstall', data=_data, headers=headers)
+        return self.client.perform_query('POST', '/libraries/uninstall', data=_data,
+                                         headers=headers)
 
 
 class DbfsService(object):
@@ -531,7 +552,7 @@ class WorkspaceService(object):
         return self.client.perform_query('GET', '/workspace/list', data=_data, headers=headers)
 
     def import_workspace(self, path, format=None, language=None, content=None, overwrite=None,
-               headers=None):
+                         headers=None):
         _data = {}
         if path is not None:
             _data['path'] = path
@@ -567,7 +588,8 @@ class WorkspaceService(object):
         _data = {}
         if path is not None:
             _data['path'] = path
-        return self.client.perform_query('GET', '/workspace/get-status', data=_data, headers=headers)
+        return self.client.perform_query('GET', '/workspace/get-status', data=_data,
+                                         headers=headers)
 
 
 class SecretService(object):
@@ -583,13 +605,15 @@ class SecretService(object):
             _data['initial_manage_principal'] = initial_manage_principal
         if scope_backend_type is not None:
             _data['scope_backend_type'] = scope_backend_type
-        return self.client.perform_query('POST', '/secrets/scopes/create', data=_data, headers=headers)
+        return self.client.perform_query('POST', '/secrets/scopes/create', data=_data,
+                                         headers=headers)
 
     def delete_scope(self, scope, headers=None):
         _data = {}
         if scope is not None:
             _data['scope'] = scope
-        return self.client.perform_query('POST', '/secrets/scopes/delete', data=_data, headers=headers)
+        return self.client.perform_query('POST', '/secrets/scopes/delete', data=_data,
+                                         headers=headers)
 
     def list_scopes(self, headers=None):
         _data = {}
@@ -638,7 +662,8 @@ class SecretService(object):
             _data['scope'] = scope
         if principal is not None:
             _data['principal'] = principal
-        return self.client.perform_query('POST', '/secrets/acls/delete', data=_data, headers=headers)
+        return self.client.perform_query('POST', '/secrets/acls/delete', data=_data,
+                                         headers=headers)
 
     def list_acls(self, scope, headers=None):
         _data = {}
@@ -683,7 +708,8 @@ class GroupsService(object):
             _data['group_name'] = group_name
         if parent_name is not None:
             _data['parent_name'] = parent_name
-        return self.client.perform_query('POST', '/groups/remove-member', data=_data, headers=headers)
+        return self.client.perform_query('POST', '/groups/remove-member', data=_data,
+                                         headers=headers)
 
     def get_groups(self, headers=None):
         _data = {}
@@ -715,7 +741,8 @@ class InstancePoolService(object):
     def __init__(self, client):
         self.client = client
 
-    def create_instance_pool(self, instance_pool_name=None, min_idle_instances=None, max_capacity=None,
+    def create_instance_pool(self, instance_pool_name=None, min_idle_instances=None,
+                             max_capacity=None,
                              aws_attributes=None, node_type_id=None, custom_tags=None,
                              idle_instance_autotermination_minutes=None, enable_elastic_disk=None,
                              disk_spec=None, preloaded_spark_versions=None, headers=None):
@@ -729,7 +756,8 @@ class InstancePoolService(object):
         if aws_attributes is not None:
             _data['aws_attributes'] = aws_attributes
             if not isinstance(aws_attributes, dict):
-                raise TypeError('Expected databricks.InstancePoolAwsAttributes() or dict for field aws_attributes')
+                raise TypeError(
+                    'Expected databricks.InstancePoolAwsAttributes() or dict for field aws_attributes')
         if node_type_id is not None:
             _data['node_type_id'] = node_type_id
         if custom_tags is not None:
@@ -744,16 +772,19 @@ class InstancePoolService(object):
                 raise TypeError('Expected databricks.DiskSpec() or dict for field disk_spec')
         if preloaded_spark_versions is not None:
             _data['preloaded_spark_versions'] = preloaded_spark_versions
-        return self.client.perform_query('POST', '/instance-pools/create', data=_data, headers=headers)
+        return self.client.perform_query('POST', '/instance-pools/create', data=_data,
+                                         headers=headers)
 
     def delete_instance_pool(self, instance_pool_id=None, headers=None):
         _data = {}
         if instance_pool_id is not None:
             _data['instance_pool_id'] = instance_pool_id
-        return self.client.perform_query('POST', '/instance-pools/delete', data=_data, headers=headers)
+        return self.client.perform_query('POST', '/instance-pools/delete', data=_data,
+                                         headers=headers)
 
     def edit_instance_pool(self, instance_pool_id, instance_pool_name=None, min_idle_instances=None,
-                           max_capacity=None, aws_attributes=None, node_type_id=None, custom_tags=None,
+                           max_capacity=None, aws_attributes=None, node_type_id=None,
+                           custom_tags=None,
                            idle_instance_autotermination_minutes=None, enable_elastic_disk=None,
                            disk_spec=None, preloaded_spark_versions=None, headers=None):
         _data = {}
@@ -768,7 +799,8 @@ class InstancePoolService(object):
         if aws_attributes is not None:
             _data['aws_attributes'] = aws_attributes
             if not isinstance(aws_attributes, dict):
-                raise TypeError('Expected databricks.InstancePoolAwsAttributes() or dict for field aws_attributes')
+                raise TypeError(
+                    'Expected databricks.InstancePoolAwsAttributes() or dict for field aws_attributes')
         if node_type_id is not None:
             _data['node_type_id'] = node_type_id
         if custom_tags is not None:
@@ -783,7 +815,8 @@ class InstancePoolService(object):
                 raise TypeError('Expected databricks.DiskSpec() or dict for field disk_spec')
         if preloaded_spark_versions is not None:
             _data['preloaded_spark_versions'] = preloaded_spark_versions
-        return self.client.perform_query('POST', '/instance-pools/edit', data=_data, headers=headers)
+        return self.client.perform_query('POST', '/instance-pools/edit', data=_data,
+                                         headers=headers)
 
     def get_instance_pool(self, instance_pool_id=None, headers=None):
         _data = {}
@@ -799,6 +832,27 @@ class InstancePoolService(object):
 class DeltaPipelinesService(object):
     def __init__(self, client):
         self.client = client
+
+    def create(self, id=None, name=None, storage=None, configuration=None, clusters=None,
+               libraries=None, filters=None, headers=None):
+        _data = {}
+        if id is not None:
+            _data['id'] = id
+        if name is not None:
+            _data['name'] = name
+        if storage is not None:
+            _data['storage'] = storage
+        if configuration is not None:
+            _data['configuration'] = configuration
+        if clusters is not None:
+            _data['clusters'] = clusters
+        if libraries is not None:
+            _data['libraries'] = libraries
+        if filters is not None:
+            _data['filters'] = filters
+            if not isinstance(filters, dict):
+                raise TypeError('Expected databricks.Filters() or dict for field filters')
+        return self.client.perform_query('POST', '/pipelines', data=_data, headers=headers)
 
     def deploy(self, pipeline_id=None, id=None, name=None, storage=None, configuration=None,
                clusters=None, libraries=None, filters=None, headers=None):
@@ -819,20 +873,26 @@ class DeltaPipelinesService(object):
             _data['filters'] = filters
             if not isinstance(filters, dict):
                 raise TypeError('Expected databricks.Filters() or dict for field filters')
-        return self.client.perform_query('PUT', '/pipelines/{pipeline_id}'.format(pipeline_id=pipeline_id), data=_data, headers=headers)
+        return self.client.perform_query('PUT',
+                                         '/pipelines/{pipeline_id}'.format(pipeline_id=pipeline_id),
+                                         data=_data, headers=headers)
 
     def delete(self, pipeline_id=None, headers=None):
         _data = {}
 
-        return self.client.perform_query('DELETE', '/pipelines/{pipeline_id}'.format(pipeline_id=pipeline_id), data=_data, headers=headers)
+        return self.client.perform_query('DELETE',
+                                         '/pipelines/{pipeline_id}'.format(pipeline_id=pipeline_id),
+                                         data=_data, headers=headers)
 
     def get(self, pipeline_id=None, headers=None):
         _data = {}
 
-        return self.client.perform_query('GET', '/pipelines/{pipeline_id}'.format(pipeline_id=pipeline_id), data=_data, headers=headers)
+        return self.client.perform_query('GET',
+                                         '/pipelines/{pipeline_id}'.format(pipeline_id=pipeline_id),
+                                         data=_data, headers=headers)
 
     def reset(self, pipeline_id=None, headers=None):
         _data = {}
 
-        return self.client.perform_query('POST', '/pipelines/{pipeline_id}/reset'.format(pipeline_id=pipeline_id), data=_data, headers=headers)
-
+        return self.client.perform_query('POST', '/pipelines/{pipeline_id}/reset'.format(
+            pipeline_id=pipeline_id), data=_data, headers=headers)

--- a/tests/pipelines/test_api.py
+++ b/tests/pipelines/test_api.py
@@ -161,13 +161,13 @@ def test_create(pipelines_api):
     spec = copy.deepcopy(SPEC_WITHOUT_ID)
     spec['libraries'] = []
 
-    pipelines_api.create(spec, False)
+    pipelines_api.create(spec, allow_duplicate_names=False)
     data = copy.deepcopy(spec)
     data['allow_duplicate_names'] = False
     client_mock.assert_called_with("POST", "/pipelines", data=data, headers=None)
     assert client_mock.call_count == 1
 
-    pipelines_api.create(spec, True, HEADERS)
+    pipelines_api.create(spec, allow_duplicate_names=True, headers=HEADERS)
     data = copy.deepcopy(spec)
     data['allow_duplicate_names'] = True
     client_mock.assert_called_with("POST", "/pipelines", data=data, headers=HEADERS)
@@ -180,13 +180,13 @@ def test_deploy(pipelines_api):
     spec = copy.deepcopy(SPEC)
     spec['libraries'] = []
 
-    pipelines_api.deploy(spec, False)
+    pipelines_api.deploy(spec, allow_duplicate_names=False)
     data = copy.deepcopy(spec)
     data['allow_duplicate_names'] = False
     client_mock.assert_called_with("PUT", "/pipelines/" + PIPELINE_ID, data=data, headers=None)
     assert client_mock.call_count == 1
 
-    pipelines_api.deploy(spec, True, HEADERS)
+    pipelines_api.deploy(spec, allow_duplicate_names=True, headers=HEADERS)
     data = copy.deepcopy(spec)
     data['allow_duplicate_names'] = True
     client_mock.assert_called_with("PUT", "/pipelines/" + PIPELINE_ID, data=data, headers=HEADERS)

--- a/tests/pipelines/test_api.py
+++ b/tests/pipelines/test_api.py
@@ -40,6 +40,7 @@ SPEC = {
     'name': 'test_pipeline',
     'storage': 'dbfs:/path'
 }
+SPEC_WITHOUT_ID = {k: v for k, v in SPEC.items() if k != "id"}
 HEADERS = {'dummy_header': 'dummy_value'}
 
 
@@ -69,7 +70,24 @@ def file_exists_stub(_, dbfs_path):
 @mock.patch('databricks_cli.dbfs.api.DbfsApi.file_exists', file_exists_stub)
 @mock.patch('databricks_cli.dbfs.dbfs_path.DbfsPath.validate')
 @mock.patch('databricks_cli.dbfs.api.DbfsApi.put_file')
-def test_deploy(put_file_mock, dbfs_path_validate, pipelines_api, tmpdir):
+def test_create_pipeline_and_upload_libraries(put_file_mock, dbfs_path_validate, pipelines_api,
+                                              tmpdir):
+    _test_library_uploads(pipelines_api, pipelines_api.create, SPEC_WITHOUT_ID, put_file_mock,
+                          dbfs_path_validate,
+                          tmpdir)
+
+
+@mock.patch('databricks_cli.dbfs.api.DbfsApi.file_exists', file_exists_stub)
+@mock.patch('databricks_cli.dbfs.dbfs_path.DbfsPath.validate')
+@mock.patch('databricks_cli.dbfs.api.DbfsApi.put_file')
+def test_deploy_pipeline_and_upload_libraries(put_file_mock, dbfs_path_validate, pipelines_api,
+                                              tmpdir):
+    _test_library_uploads(pipelines_api, pipelines_api.deploy, SPEC, put_file_mock,
+                          dbfs_path_validate, tmpdir)
+
+
+def _test_library_uploads(pipelines_api, api_method, spec, put_file_mock, dbfs_path_validate,
+                          tmpdir):
     """
     Scenarios Tested:
     1. All three types of local file paths (absolute, relative, file: scheme)
@@ -80,6 +98,8 @@ def test_deploy(put_file_mock, dbfs_path_validate, pipelines_api, tmpdir):
     A test local file which has '456' written to it is not present in Dbfs and therefore must be.
     uploaded to dbfs.
     """
+    spec = copy.deepcopy(spec)
+
     # set-up the test
     jar1 = tmpdir.join('jar1.jar').strpath
     jar2 = tmpdir.join('jar2.jar').strpath
@@ -88,6 +108,8 @@ def test_deploy(put_file_mock, dbfs_path_validate, pipelines_api, tmpdir):
     wheel1 = tmpdir.join('wheel-name-conv.whl').strpath
     jar3_relpath = os.path.relpath(jar3, os.getcwd())
     jar4_file_prefix = 'file:{}'.format(jar4)
+    remote_path_456 = 'dbfs:/pipelines/code/51eac6b471a284d3341d8c0c63d0f1a286262a18.jar'
+
     with open(jar1, 'w') as f:
         f.write('123')
     with open(jar2, 'w') as f:
@@ -105,9 +127,10 @@ def test_deploy(put_file_mock, dbfs_path_validate, pipelines_api, tmpdir):
                  {'jar': jar3_relpath},
                  {'jar': jar4_file_prefix},
                  {'whl': wheel1}]
-    spec = copy.deepcopy(SPEC)
+
+    expected_spec = copy.deepcopy(spec)
+
     spec['libraries'] = libraries
-    expected_spec = copy.deepcopy(SPEC)
     expected_spec['libraries'] = [
         {'jar': 'dbfs:/pipelines/code/file.jar'},
         {'maven': {'coordinates': 'com.org.name:package:0.1.0'}},
@@ -115,26 +138,49 @@ def test_deploy(put_file_mock, dbfs_path_validate, pipelines_api, tmpdir):
         {'jar': 'dbfs:/pipelines/code/51eac6b471a284d3341d8c0c63d0f1a286262a18.jar'},
         {'jar': 'dbfs:/pipelines/code/51eac6b471a284d3341d8c0c63d0f1a286262a18.jar'},
         {'jar': 'dbfs:/pipelines/code/51eac6b471a284d3341d8c0c63d0f1a286262a18.jar'},
-        {'whl':
-         'dbfs:/pipelines/code/51eac6b471a284d3341d8c0c63d0f1a286262a18/wheel-name-conv.whl'}
+        {'whl': 'dbfs:/pipelines/code/51eac6b471a284d3341d8c0c63d0f1a286262a18/wheel-name-conv.whl'}
     ]
 
-    pipelines_api.deploy(spec)
+    api_method(spec)
     assert dbfs_path_validate.call_count == 5
     assert put_file_mock.call_count == 4
     assert put_file_mock.call_args_list[0][0][0] == jar2
-    assert put_file_mock.call_args_list[0][0][1].absolute_path == \
-        'dbfs:/pipelines/code/51eac6b471a284d3341d8c0c63d0f1a286262a18.jar'
+    assert put_file_mock.call_args_list[0][0][1].absolute_path == remote_path_456
     assert put_file_mock.call_args_list[1][0][0] == jar3_relpath
     assert put_file_mock.call_args_list[2][0][0] == jar4
     assert put_file_mock.call_args_list[3][0][0] == wheel1
     client_mock = pipelines_api.client.client.perform_query
-    client_mock.assert_called_with('PUT', '/pipelines/' + PIPELINE_ID,
-                                   data=expected_spec, headers=None)
+    assert client_mock.call_count == 1
+    assert client_mock.call_args_list[0][1]['data'] == expected_spec
+
+
+def test_create(pipelines_api):
+    client_mock = pipelines_api.client.client.perform_query
+
+    spec = copy.deepcopy(SPEC_WITHOUT_ID)
+    spec['libraries'] = []
+
+    pipelines_api.create(spec)
+    client_mock.assert_called_with("POST", "/pipelines/", data=spec, headers=None)
+    assert client_mock.call_count == 1
+
+    pipelines_api.create(spec, HEADERS)
+    client_mock.assert_called_with("POST", "/pipelines/", data=spec, headers=HEADERS)
+    assert client_mock.call_count == 2
+
+
+def test_deploy(pipelines_api):
+    client_mock = pipelines_api.client.client.perform_query
+
+    spec = copy.deepcopy(SPEC)
+    spec['libraries'] = []
+
+    pipelines_api.deploy(spec)
+    client_mock.assert_called_with("PUT", "/pipelines/" + PIPELINE_ID, data=spec, headers=None)
+    assert client_mock.call_count == 1
 
     pipelines_api.deploy(spec, HEADERS)
-    client_mock.assert_called_with('PUT', '/pipelines/' + PIPELINE_ID,
-                                   data=expected_spec, headers=HEADERS)
+    client_mock.assert_called_with("PUT", "/pipelines/" + PIPELINE_ID, data=spec, headers=HEADERS)
     assert client_mock.call_count == 2
 
 

--- a/tests/pipelines/test_api.py
+++ b/tests/pipelines/test_api.py
@@ -130,6 +130,7 @@ def _test_library_uploads(pipelines_api, api_method, spec, put_file_mock, dbfs_p
     expected_spec = copy.deepcopy(spec)
 
     spec['libraries'] = libraries
+
     expected_spec['libraries'] = [
         {'jar': 'dbfs:/pipelines/code/file.jar'},
         {'maven': {'coordinates': 'com.org.name:package:0.1.0'}},

--- a/tests/pipelines/test_api.py
+++ b/tests/pipelines/test_api.py
@@ -288,3 +288,15 @@ def test_library_object_serialization_deserialization():
 
     libs = LibraryObject.to_json(library_objects)
     assert libs == libraries
+
+
+def test_list(pipelines_api):
+    client_mock = pipelines_api.client.client.perform_query
+
+    pipelines_api.list()
+    assert client_mock.call_count == 1
+    client_mock.assert_called_with('GET', '/pipelines', headers=None)
+
+    pipelines_api.list(headers=HEADERS)
+    assert client_mock.call_count == 2
+    client_mock.assert_called_with('GET', '/pipelines', headers=HEADERS)

--- a/tests/pipelines/test_api.py
+++ b/tests/pipelines/test_api.py
@@ -73,8 +73,7 @@ def file_exists_stub(_, dbfs_path):
 def test_create_pipeline_and_upload_libraries(put_file_mock, dbfs_path_validate, pipelines_api,
                                               tmpdir):
     _test_library_uploads(pipelines_api, pipelines_api.create, SPEC_WITHOUT_ID, put_file_mock,
-                          dbfs_path_validate,
-                          tmpdir)
+                          dbfs_path_validate, tmpdir)
 
 
 @mock.patch('databricks_cli.dbfs.api.DbfsApi.file_exists', file_exists_stub)
@@ -161,11 +160,11 @@ def test_create(pipelines_api):
     spec['libraries'] = []
 
     pipelines_api.create(spec)
-    client_mock.assert_called_with("POST", "/pipelines/", data=spec, headers=None)
+    client_mock.assert_called_with("POST", "/pipelines", data=spec, headers=None)
     assert client_mock.call_count == 1
 
     pipelines_api.create(spec, HEADERS)
-    client_mock.assert_called_with("POST", "/pipelines/", data=spec, headers=HEADERS)
+    client_mock.assert_called_with("POST", "/pipelines", data=spec, headers=HEADERS)
     assert client_mock.call_count == 2
 
 

--- a/tests/pipelines/test_cli.py
+++ b/tests/pipelines/test_cli.py
@@ -115,10 +115,10 @@ def test_deploy_cli_incorrect_parameters(pipelines_api_mock, tmpdir):
     runner = CliRunner()
     result = runner.invoke(cli.deploy_cli, [path, '--spec', path])
     assert result.exit_code == 1
-    assert pipelines_api_mock.create.call_count == 0
+    assert pipelines_api_mock.deploy.call_count == 0
     result = runner.invoke(cli.deploy_cli, ['--spec', path, path])
     assert result.exit_code == 1
-    assert pipelines_api_mock.create.call_count == 0
+    assert pipelines_api_mock.deploy.call_count == 0
 
 
 @provide_conf
@@ -188,7 +188,7 @@ def test_deploy_delete_cli_incorrect_spec_extension(pipelines_api_mock, tmpdir):
     runner = CliRunner()
     result = runner.invoke(cli.deploy_cli, ['--spec', path])
     assert result.exit_code == 1
-    assert pipelines_api_mock.create.call_count == 0
+    assert pipelines_api_mock.deploy.call_count == 0
 
     result = runner.invoke(cli.delete_cli, ['--spec', path])
     assert result.exit_code == 1
@@ -199,7 +199,7 @@ def test_deploy_delete_cli_incorrect_spec_extension(pipelines_api_mock, tmpdir):
         f.write(DEPLOY_SPEC)
     result = runner.invoke(cli.deploy_cli, ['--spec', path_no_extension])
     assert result.exit_code == 1
-    assert pipelines_api_mock.create.call_count == 0
+    assert pipelines_api_mock.deploy.call_count == 0
 
     result = runner.invoke(cli.delete_cli, ['--spec', path_no_extension])
     assert result.exit_code == 1

--- a/tests/pipelines/test_cli.py
+++ b/tests/pipelines/test_cli.py
@@ -361,3 +361,22 @@ def test_duplicate_name_check_errors(pipelines_api_mock, tmpdir):
     result = runner.invoke(cli.deploy_cli, [path])
     assert result.exit_code == 1
     assert "Unable to check" in result.stdout
+
+
+@provide_conf
+def test_create_pipeline_no_update_spec(pipelines_api_mock, tmpdir):
+    pipelines_api_mock.create = mock.Mock(return_value={"pipeline_id": PIPELINE_ID})
+
+    path = tmpdir.join('/spec.json').strpath
+    with open(path, 'w') as f:
+        f.write(DEPLOY_SPEC_NO_ID)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.deploy_cli, [path, "--no-update-spec"])
+
+    assert result.exit_code == 0
+    assert pipelines_api_mock.create.call_count == 1
+
+    with open(path, 'r') as f:
+        spec = json.loads(f.read())
+    assert 'id' not in spec


### PR DESCRIPTION
Previously, we used the same API to both create and update a pipeline. The apis have been split, and this PR updates the cli to use the new create API for pipelines.

Testing:
- Manual testing
- Unit tests