### PR TITLE
Update Pipelines CLI to take a pipeline-id parameter + stop overwriting spec with new ID + remove the spec argument from all commands except deploy.

### DIFF
--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -100,8 +100,8 @@ def deploy_cli(api_client, spec_arg, spec, allow_duplicate_names, pipeline_id):
     else:
         if (pipeline_id and 'id' in spec_obj) and pipeline_id != spec_obj["id"]:
             raise ValueError(
-                "The ID provided from --pipeline_id '{}' is different than the id provided the spec '{}'. Please "
-                "resolve the conflict and try the command again.")
+                "The ID provided in --pipeline_id '{}' is different from the id provided the spec '{}'. Please "
+                "resolve the conflict and try the command again.".format(pipeline_id, spec["id"]))
 
         spec_obj['id'] = pipeline_id or spec_obj.get('id', None)
         _validate_pipeline_id(spec_obj['id'])

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -66,9 +66,11 @@ def deploy_cli(api_client, spec_arg, spec, allow_duplicate_names, pipeline_id):
     specification that explains how to run a Delta Pipeline on Databricks. All local libraries
     referenced in the spec are uploaded to DBFS.
 
-    If the pipeline spec contains an "id" field, attempts to update an existing pipeline with
-    that ID. If it does not, creates a new pipeline and edits the spec file to add the ID of the
-    created pipeline. The spec file will not be updated if the --no-update-spec option is added.
+    If the pipeline spec contains an "id" field, or if a pipeline id is specified directly
+    (using the  --pipeline-id argument), attempts to update an existing pipeline
+    with that ID. If it does not, creates a new pipeline and logs the id of the new pipeline
+    to STDOUT. Note that if an id is both specified in the spec and passed via --pipeline-id,
+    the two ids must be the same, or the command will fail.
 
     The deploy command will not create a new pipeline if a pipeline with the same name already
     exists. This check can be disabled by adding the --allow-duplicate-names option.
@@ -103,8 +105,11 @@ def deploy_cli(api_client, spec_arg, spec, allow_duplicate_names, pipeline_id):
     else:
         if (pipeline_id and 'id' in spec_obj) and pipeline_id != spec_obj["id"]:
             raise ValueError(
-                "Because pipeline IDs are no longer persisted after being deleted, we recommend removing the ID field "
-                "from your spec."
+                "The ID provided in --pipeline_id '{}' is different from the id provided "
+                "the spec '{}'. Please resolve the conflict and try the command again. "
+                "Because pipeline IDs are no longer persisted after being deleted, we "
+                "recommend removing the ID field from your spec."
+                .format(pipeline_id, spec["id"])
             )
 
         spec_obj['id'] = pipeline_id or spec_obj.get('id', None)

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -96,17 +96,15 @@ def deploy_cli(api_client, spec_arg, spec, allow_duplicate_names, pipeline_id):
             _handle_duplicate_name_exception(spec_obj, e)
 
         new_pipeline_id = response['pipeline_id']
+        click.echo("Pipeline has been assigned ID {}".format(new_pipeline_id))
         click.echo("Successfully created pipeline: {}".format(
             _get_pipeline_url(api_client, new_pipeline_id)))
-
-        click.echo("Pipeline has been assigned ID {}".format(new_pipeline_id))
         click.echo(new_pipeline_id, err=True)
     else:
         if (pipeline_id and 'id' in spec_obj) and pipeline_id != spec_obj["id"]:
             raise ValueError(
-                "The ID provided in --pipeline_id '{}' is different from the id provided the "
-                "spec '{}'. Please resolve the conflict and try the command again."
-                .format(pipeline_id, spec["id"])
+                "Because pipeline IDs are no longer persisted after being deleted, we recommend removing the ID field "
+                "from your spec."
             )
 
         spec_obj['id'] = pipeline_id or spec_obj.get('id', None)

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -80,6 +80,10 @@ def deploy_cli(api_client, spec_arg, spec, allow_duplicate_names, pipeline_id):
     OR
 
     databricks pipelines deploy --spec example.json
+
+    OR
+
+    databricks pipelines deploy --pipeline-id 1234 --spec example.json
     """
     if bool(spec_arg) == bool(spec):
         raise RuntimeError('The spec should be provided either by an option or argument')
@@ -118,94 +122,64 @@ def deploy_cli(api_client, spec_arg, spec, allow_duplicate_names, pipeline_id):
 
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Stops a delta pipeline and deletes its associated Databricks resources')
-@click.argument('spec_arg', default=None, required=False)
-@click.option('--spec', default=None, type=PipelineSpecClickType(), help=PipelineSpecClickType.help)
 @click.option('--pipeline-id', default=None, type=PipelineIdClickType(),
               help=PipelineIdClickType.help)
 @debug_option
 @profile_option
 @pipelines_exception_eater
 @provide_api_client
-def delete_cli(api_client, spec_arg, spec, pipeline_id):
+def delete_cli(api_client, pipeline_id):
     """
     Stops a delta pipeline and deletes its associated Databricks resources. The pipeline can be
     resumed by deploying it again.
 
     Usage:
 
-    databricks pipelines delete example.json
-
-    OR
-
-    databricks pipelines delete --spec example.json
-
-    OR
-
     databricks pipelines delete --pipeline-id 1234
     """
-    pipeline_id = _get_pipeline_id(spec_arg=spec_arg, spec=spec, pipeline_id=pipeline_id)
+    _validate_pipeline_id(pipeline_id)
     PipelinesApi(api_client).delete(pipeline_id)
     click.echo("Pipeline {} deleted".format(pipeline_id))
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Gets a delta pipeline\'s current spec and status')
-@click.argument('spec_arg', default=None, required=False)
-@click.option('--spec', default=None, type=PipelineSpecClickType(), help=PipelineSpecClickType.help)
 @click.option('--pipeline-id', default=None, type=PipelineIdClickType(),
               help=PipelineIdClickType.help)
 @debug_option
 @profile_option
 @pipelines_exception_eater
 @provide_api_client
-def get_cli(api_client, spec_arg, spec, pipeline_id):
+def get_cli(api_client, pipeline_id):
     """
     Gets a delta pipeline's current spec and status.
 
     Usage:
 
-    databricks pipelines get example.json
-
-    OR
-
-    databricks pipelines get --spec example.json
-
-    OR
-
     databricks pipelines get --pipeline-id 1234
     """
-    pipeline_id = _get_pipeline_id(spec_arg=spec_arg, spec=spec, pipeline_id=pipeline_id)
+    _validate_pipeline_id(pipeline_id)
     click.echo(pretty_format(PipelinesApi(api_client).get(pipeline_id)))
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Resets a delta pipeline so data can be reprocessed from scratch')
-@click.argument('spec_arg', default=None, required=False)
-@click.option('--spec', default=None, type=PipelineSpecClickType(), help=PipelineSpecClickType.help)
 @click.option('--pipeline-id', default=None, type=PipelineIdClickType(),
               help=PipelineIdClickType.help)
 @debug_option
 @profile_option
 @pipelines_exception_eater
 @provide_api_client
-def reset_cli(api_client, spec_arg, spec, pipeline_id):
+def reset_cli(api_client, pipeline_id):
     """
     Resets a delta pipeline by truncating tables and creating new checkpoint folders so data is
     reprocessed from scratch.
 
     Usage:
 
-    databricks pipelines reset example.json
-
-    OR
-
-    databricks pipelines reset --spec example.json
-
-    OR
-
     databricks pipelines reset --pipeline-id 1234
     """
-    pipeline_id = _get_pipeline_id(spec_arg=spec_arg, spec=spec, pipeline_id=pipeline_id)
+    _validate_pipeline_id(pipeline_id)
     PipelinesApi(api_client).reset(pipeline_id)
     click.echo("Reset triggered for pipeline {}".format(pipeline_id))
 

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -100,8 +100,10 @@ def deploy_cli(api_client, spec_arg, spec, allow_duplicate_names, pipeline_id):
     else:
         if (pipeline_id and 'id' in spec_obj) and pipeline_id != spec_obj["id"]:
             raise ValueError(
-                "The ID provided in --pipeline_id '{}' is different from the id provided the spec '{}'. Please "
-                "resolve the conflict and try the command again.".format(pipeline_id, spec["id"]))
+                "The ID provided in --pipeline_id '{}' is different from the id provided the "
+                "spec '{}'. Please resolve the conflict and try the command again."
+                .format(pipeline_id, spec["id"])
+            )
 
         spec_obj['id'] = pipeline_id or spec_obj.get('id', None)
         _validate_pipeline_id(spec_obj['id'])

--- a/tests/pipelines/test_cli.py
+++ b/tests/pipelines/test_cli.py
@@ -119,26 +119,6 @@ def test_deploy_cli_incorrect_parameters(pipelines_api_mock, tmpdir):
 
 
 @provide_conf
-def test_delete_cli_spec_arg(pipelines_api_mock, tmpdir):
-    path = tmpdir.join('/spec.json').strpath
-    with open(path, 'w') as f:
-        f.write(DEPLOY_SPEC)
-    runner = CliRunner()
-    runner.invoke(cli.delete_cli, [path])
-    assert pipelines_api_mock.delete.call_args[0][0] == PIPELINE_ID
-
-
-@provide_conf
-def test_delete_cli_spec_option(pipelines_api_mock, tmpdir):
-    path = tmpdir.join('/spec.json').strpath
-    with open(path, 'w') as f:
-        f.write(DEPLOY_SPEC)
-    runner = CliRunner()
-    runner.invoke(cli.delete_cli, ['--spec', path])
-    assert pipelines_api_mock.delete.call_args[0][0] == PIPELINE_ID
-
-
-@provide_conf
 def test_delete_cli_id(pipelines_api_mock):
     runner = CliRunner()
     runner.invoke(cli.delete_cli, ['--pipeline-id', PIPELINE_ID])
@@ -146,23 +126,11 @@ def test_delete_cli_id(pipelines_api_mock):
 
 
 @provide_conf
-def test_delete_cli_incorrect_parameters(pipelines_api_mock, tmpdir):
-    path = tmpdir.join('/spec.json').strpath
-    with open(path, 'w') as f:
-        f.write(DEPLOY_SPEC)
+def test_delete_cli_correct_parameters(pipelines_api_mock):
     runner = CliRunner()
-    result = runner.invoke(cli.delete_cli, ['--spec', path, '--pipeline-id', PIPELINE_ID])
-    assert result.exit_code == 1
-    assert pipelines_api_mock.delete.call_count == 0
-    result = runner.invoke(cli.delete_cli, ['--spec', path, path])
-    assert result.exit_code == 1
-    assert pipelines_api_mock.delete.call_count == 0
-    result = runner.invoke(cli.delete_cli, [path, '--pipeline-id', PIPELINE_ID])
-    assert result.exit_code == 1
-    assert pipelines_api_mock.delete.call_count == 0
-    result = runner.invoke(cli.delete_cli, [path, '--spec', path, '--pipeline-id', PIPELINE_ID])
-    assert result.exit_code == 1
-    assert pipelines_api_mock.delete.call_count == 0
+    result = runner.invoke(cli.delete_cli, ['--pipeline-id', PIPELINE_ID])
+    assert result.exit_code == 0
+    assert pipelines_api_mock.delete.call_count == 1
 
 
 @provide_conf
@@ -174,32 +142,6 @@ def test_deploy_spec_pipeline_id_is_not_changed_if_provided_in_spec(tmpdir):
     result = runner.invoke(cli.deploy_cli, ['--spec', path])
 
     assert '123' in result.stdout
-
-
-@provide_conf
-def test_deploy_delete_cli_incorrect_spec_extension(pipelines_api_mock, tmpdir):
-    path = tmpdir.join('/spec.wrong_ext').strpath
-    with open(path, 'w') as f:
-        f.write(DEPLOY_SPEC)
-    runner = CliRunner()
-    result = runner.invoke(cli.deploy_cli, ['--spec', path])
-    assert result.exit_code == 1
-    assert pipelines_api_mock.deploy.call_count == 0
-
-    result = runner.invoke(cli.delete_cli, ['--spec', path])
-    assert result.exit_code == 1
-    assert pipelines_api_mock.delete.call_count == 0
-
-    path_no_extension = tmpdir.join('/spec').strpath
-    with open(path_no_extension, 'w') as f:
-        f.write(DEPLOY_SPEC)
-    result = runner.invoke(cli.deploy_cli, ['--spec', path_no_extension])
-    assert result.exit_code == 1
-    assert pipelines_api_mock.deploy.call_count == 0
-
-    result = runner.invoke(cli.delete_cli, ['--spec', path_no_extension])
-    assert result.exit_code == 1
-    assert pipelines_api_mock.delete.call_count == 0
 
 
 @provide_conf
@@ -244,26 +186,6 @@ def test_deploy_update_delete_cli_correct_spec_extensions(pipelines_api_mock, tm
 
 
 @provide_conf
-def test_reset_cli_spec_arg(pipelines_api_mock, tmpdir):
-    path = tmpdir.join('/spec.json').strpath
-    with open(path, 'w') as f:
-        f.write(DEPLOY_SPEC)
-    runner = CliRunner()
-    runner.invoke(cli.reset_cli, [path])
-    assert pipelines_api_mock.reset.call_args[0][0] == PIPELINE_ID
-
-
-@provide_conf
-def test_reset_cli_spec_option(pipelines_api_mock, tmpdir):
-    path = tmpdir.join('/spec.json').strpath
-    with open(path, 'w') as f:
-        f.write(DEPLOY_SPEC)
-    runner = CliRunner()
-    runner.invoke(cli.reset_cli, ['--spec', path])
-    assert pipelines_api_mock.reset.call_args[0][0] == PIPELINE_ID
-
-
-@provide_conf
 def test_reset_cli_id(pipelines_api_mock):
     runner = CliRunner()
     runner.invoke(cli.reset_cli, ['--pipeline-id', PIPELINE_ID])
@@ -276,26 +198,6 @@ def test_reset_cli_no_id(pipelines_api_mock):
     result = runner.invoke(cli.reset_cli, [])
     assert result.exit_code == 1
     assert pipelines_api_mock.reset.call_count == 0
-
-
-@provide_conf
-def test_get_cli_spec_arg(pipelines_api_mock, tmpdir):
-    path = tmpdir.join('/spec.json').strpath
-    with open(path, 'w') as f:
-        f.write(DEPLOY_SPEC)
-    runner = CliRunner()
-    runner.invoke(cli.get_cli, [path])
-    assert pipelines_api_mock.get.call_args[0][0] == PIPELINE_ID
-
-
-@provide_conf
-def test_get_cli_spec_option(pipelines_api_mock, tmpdir):
-    path = tmpdir.join('/spec.json').strpath
-    with open(path, 'w') as f:
-        f.write(DEPLOY_SPEC)
-    runner = CliRunner()
-    runner.invoke(cli.get_cli, ['--spec', path])
-    assert pipelines_api_mock.get.call_args[0][0] == PIPELINE_ID
 
 
 @provide_conf

--- a/tests/pipelines/test_cli.py
+++ b/tests/pipelines/test_cli.py
@@ -388,6 +388,7 @@ def test_create_pipeline_no_update_spec(pipelines_api_mock, tmpdir):
         spec = json.loads(f.read())
     assert 'id' not in spec
 
+
 @provide_conf
 def test_deploy_pipeline_conflicting_ids(pipelines_api_mock, tmpdir):
     pipelines_api_mock.deploy = mock.Mock()

--- a/tests/pipelines/test_cli.py
+++ b/tests/pipelines/test_cli.py
@@ -69,6 +69,7 @@ def test_create_pipeline_spec_arg(pipelines_api_mock, tmpdir):
 
     assert PIPELINE_ID in result.stdout
 
+
 @provide_conf
 def test_create_pipeline_spec_option(pipelines_api_mock, tmpdir):
     pipelines_api_mock.create = mock.Mock(return_value={"pipeline_id": PIPELINE_ID})
@@ -229,7 +230,10 @@ def test_deploy_update_delete_cli_correct_spec_extensions(pipelines_api_mock, tm
     assert result.exit_code == 0
     assert pipelines_api_mock.create.call_count == 1
 
-    result = runner.invoke(cli.deploy_cli, ['--spec', path_case_insensitive, '--pipeline-id', PIPELINE_ID])
+    result = runner.invoke(cli.deploy_cli, [
+        '--spec', path_case_insensitive,
+        '--pipeline-id', PIPELINE_ID
+    ])
     assert result.exit_code == 0
     assert pipelines_api_mock.deploy.call_count == 1
 


### PR DESCRIPTION
This PR adds a pipeline-id parameter to the deploy command, and removes automatic rewriting of the spec when a new pipeline is created. It also removes the spec parameter from all commands except for deploy, only taking an explicitly specified --pipeline_id argument instead. This will create a more intuitive CLI experience for pipeline users, now that all id's are service-generated (rather than user-generated), as pipeline_id, not a spec, becomes the core identifying parameter across pipelines commands.

Testing
* Unit tests
* Manual testing