### PR TITLE
Catch the JSONDecodeError in the DBFS client to ensure the more descriptive failure is shown

### DIFF
--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -92,8 +92,12 @@ class DbfsApi(object):
         try:
             self.get_status(dbfs_path, headers=headers)
         except HTTPError as e:
-            if e.response.json()['error_code'] == DbfsErrorCodes.RESOURCE_DOES_NOT_EXIST:
-                return False
+            try:
+                if e.response.json()['error_code'] == DbfsErrorCodes.RESOURCE_DOES_NOT_EXIST:
+                    return False
+            except ValueError:
+                pass
+
             raise e
         return True
 


### PR DESCRIPTION
This is a small PR that catches JSON errors in the DBFS client, arising from attempting to parse non-JSON error strings, to ensure that the more descriptive HTTP error is shown.