### PR TITLE
[PLAT-23593] Fix bug with creating databricks backed secret scope

### DIFF
--- a/databricks_cli/secrets/cli.py
+++ b/databricks_cli/secrets/cli.py
@@ -73,10 +73,13 @@ def create_scope(api_client, scope, initial_manage_principal,
     """
     Creates a new secret scope with given name.
     """
-    backend_azure_keyvault = {
-        'resource_id': resource_id,
-        'dns_name': dns_name
-    }
+    backend_azure_keyvault = None
+
+    if resource_id is not None and dns_name is not None:
+        backend_azure_keyvault = {
+            'resource_id': resource_id,
+            'dns_name': dns_name
+        }
     SecretApi(api_client).create_scope(scope, initial_manage_principal,
                                        scope_backend_type, backend_azure_keyvault)
 


### PR DESCRIPTION
This was the problem:

Looks like the default secret scope setup is broken with 0.12.1 version.

($ databricks secrets create-scope --scope test23 --scope-backend-type DATABRICKS
Error: b'{"error_code":"INVALID_PARAMETER_VALUE","message":"Missing required fields: backend_azure_keyvault.resource_id, backend_azure_keyvault.dns_name"}'
$

$ databricks secrets create-scope --scope test23
Error: b'{"error_code":"INVALID_PARAMETER_VALUE","message":"Missing required fields: backend_azure_keyvault.resource_id, backend_azure_keyvault.dns_name"}'
n$

Turns out when DB scope was being made, since akv metadata wasn't initialized to none, but an empty dict, it was being sent as part of the request.