### PR TITLE
update minimal click version to allow case_sensitive option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     version=version,
     packages=find_packages(exclude=['tests', 'tests.*']),
     install_requires=[
-        'click>=6.7',
+        'click>=7.0',
         'requests>=2.17.3',
         'tabulate>=0.7.7',
         'six>=1.10.0',


### PR DESCRIPTION
When using the CLI within specific environment (in my case an Azure DevOps agent running Ubuntu 18.06) some librairies need to be upgraded for the CLI to work properly (_click_ when running the 6.7 version triggers the stacktrace displayed here : https://github.com/databricks/databricks-cli/issues/337)