### PR TITLE
Reimplement retry mechanism on 429 at the http request level and for all databricks-cli operations

### DIFF
--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -28,7 +28,6 @@ import shutil
 import tempfile
 
 import re
-import functools
 import click
 
 from tenacity import retry, wait_random_exponential, retry_if_exception_type, stop_after_attempt
@@ -40,6 +39,10 @@ from databricks_cli.dbfs.dbfs_path import DbfsPath
 from databricks_cli.dbfs.exceptions import LocalFileExistsException, RateLimitException
 
 BUFFER_SIZE_BYTES = 2**20
+EXPONENTIAL_BACKOFF_MULTIPLIER = 1
+MAX_SECONDS_WAIT = 60
+MAX_RETRY_ATTEMPTS = 8
+time_for_last_retry = 0
 
 
 class ParseException(Exception):
@@ -80,75 +83,46 @@ class DbfsErrorCodes(object):
     TOO_MANY_REQUESTS = 'TOO_MANY_REQUESTS'
 
 
-class CustomRetryState(object):
-    def __init__(self):
-        self.time_for_last_retry = 0
-
-    def reset(self):
-        self.time_for_last_retry = 0
-
-
-class Retry429(object):
-    EXPONENTIAL_BACKOFF_MULTIPLIER = 1
-    MAX_SECONDS_WAIT = 60
-    MAX_RETRY_ATTEMPTS = 8
-
-    def __init__(self, func):
-        """
-        If there are no decorator arguments, the function to be decorated is passed to
-        the constructor. It is called only once for each function decorated with it.
-        """
-        self.retry_state_429 = CustomRetryState()
-
-        @retry(wait=wait_random_exponential(multiplier=self.EXPONENTIAL_BACKOFF_MULTIPLIER,
-               max=self.MAX_SECONDS_WAIT), retry=retry_if_exception_type(RateLimitException),
-               stop=stop_after_attempt(self.MAX_RETRY_ATTEMPTS), reraise=True,
-               before_sleep=lambda retry_state: self.before_sleep_on_429(retry_state, 
-                                                                         self.retry_state_429))
-        def wrapped_function(*args, **kwargs):
-            try:
-                return func(*args, **kwargs)
-            except HTTPError as e:
-                if e.response.status_code == 429:
-                    raise RateLimitException("429 Too Many Requests")
-                raise e
-
-        self.func = wrapped_function
-
-    def __call__(self, *args, **kwargs):
-        """
-        The __call__ method is called every time a decorated function is called.
-        """
-        self.retry_state_429.reset()
-
-        return self.func(*args, **kwargs)
-
-    def __get__(self, obj, objtype):
-        """
-        Making this decorator a descriptor such that we can use it on class methods.
-        See https://stackoverflow.com/a/3296318/12359607
-        """
-        return functools.partial(self.__call__, obj)
-
-    @staticmethod
-    def before_sleep_on_429(retry_state, retry_state_429):
-        """
-        Note: Here idle_for represents the total time spent sleeping in all retries so far +
-        the time that we will sleep until the next retry. We determined this empirically,
-        as it is not clearly stated in the Tenacity docs.
-        """
-        time_until_next_retry = retry_state.idle_for - retry_state_429.time_for_last_retry
+def before_sleep_on_429(retry_state):
+    global time_for_last_retry
+    if retry_state.attempt_number < 1:
+        click.echo("Warning: Unexpected retry_state.attempt_number={}.".format(
+            retry_state.attempt_number))
+        click.echo("Received 429 REQUEST_LIMIT_EXCEEDED. Retrying with exponential backoff.")
+    else:
+        # Initialize time_for_last_retry on the first attempt.
+        if retry_state.attempt_number == 1:
+            time_for_last_retry = 0
+        # Note: Here idle_for represents the total time spent sleeping in all retries so far +
+        # the time that we will sleep until the next retry. We determined this empirically,
+        # as it is not clearly stated in the Tenacity docs.
+        time_until_next_retry = retry_state.idle_for - time_for_last_retry
         click.echo(("Received 429 REQUEST_LIMIT_EXCEEDED for attempt {}. "
                     "Retrying in {:.2f} seconds.").format(retry_state.attempt_number,
                                                           time_until_next_retry))
-        retry_state_429.time_for_last_retry = retry_state.idle_for
+        time_for_last_retry = retry_state.idle_for
+
+
+def retry_429(func):
+    @retry(wait=wait_random_exponential(multiplier=EXPONENTIAL_BACKOFF_MULTIPLIER, 
+           max=MAX_SECONDS_WAIT), retry=retry_if_exception_type(RateLimitException), 
+           stop=stop_after_attempt(MAX_RETRY_ATTEMPTS), reraise=True, 
+           before_sleep=before_sleep_on_429)
+    def wrapped_function(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except HTTPError as e:
+            if e.response.status_code == 429:
+                raise RateLimitException("429 Too Many Requests")
+            raise e
+    return wrapped_function
 
 
 class DbfsApi(object):
     def __init__(self, api_client):
         self.client = DbfsService(api_client)
 
-    @Retry429
+    @retry_429
     def list_files(self, dbfs_path, headers=None):
         list_response = self.client.list(dbfs_path.absolute_path, headers=headers)
         if 'files' in list_response:
@@ -169,20 +143,20 @@ class DbfsApi(object):
             raise e
         return True
 
-    @Retry429
+    @retry_429
     def get_status(self, dbfs_path, headers=None):
         json = self.client.get_status(dbfs_path.absolute_path, headers=headers)
         return FileInfo.from_json(json)
 
-    @Retry429
+    @retry_429
     def create(self, dbfs_path, overwrite, headers):
         return self.client.create(dbfs_path.absolute_path, overwrite, headers=headers)
 
-    @Retry429
+    @retry_429
     def add_block(self, handle, contents, headers):
         self.client.add_block(handle, contents, headers=headers)
 
-    @Retry429
+    @retry_429
     def close(self, handle, headers):
         self.client.close(handle, headers=headers)
 
@@ -197,7 +171,7 @@ class DbfsApi(object):
                 self.add_block(handle, b64encode(contents).decode(), headers=headers)
             self.close(handle, headers=headers)
 
-    @Retry429
+    @retry_429
     def read(self, dbfs_path, offset, headers):
         return self.client.read(dbfs_path.absolute_path, offset, BUFFER_SIZE_BYTES, headers=headers)       
 
@@ -230,7 +204,7 @@ class DbfsApi(object):
                     message))
         return int(m.group(1))
 
-    @Retry429
+    @retry_429
     def delete(self, dbfs_path, recursive, headers=None):
         num_files_deleted = 0
         while True:
@@ -258,11 +232,11 @@ class DbfsApi(object):
             break
         click.echo("\rDelete finished successfully.\033[K")
 
-    @Retry429
+    @retry_429
     def mkdirs(self, dbfs_path, headers=None):
         self.client.mkdirs(dbfs_path.absolute_path, headers=headers)
 
-    @Retry429
+    @retry_429
     def move(self, dbfs_src, dbfs_dst, headers=None):
         self.client.move(dbfs_src.absolute_path, dbfs_dst.absolute_path, headers=headers)
 

--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -28,29 +28,16 @@ import shutil
 import tempfile
 
 import re
-import logging
-import sys
 import click
-
-
-from tenacity import retry, wait_random_exponential, retry_if_exception_type, stop_after_attempt
 
 from requests.exceptions import HTTPError
 
 from databricks_cli.sdk import DbfsService
 from databricks_cli.utils import error_and_quit
 from databricks_cli.dbfs.dbfs_path import DbfsPath
-from databricks_cli.dbfs.exceptions import LocalFileExistsException, RateLimitException
+from databricks_cli.dbfs.exceptions import LocalFileExistsException
 
 BUFFER_SIZE_BYTES = 2**20
-EXPONENTIAL_BACKOFF_MULTIPLIER = 1
-MAX_SECONDS_WAIT = 60
-MAX_RETRY_ATTEMPTS = 7
-time_for_last_retry = 0
-
-logging.basicConfig(stream=sys.stderr, level=logging.WARNING)
-
-logger = logging.getLogger(__name__)
 
 
 class ParseException(Exception):
@@ -88,42 +75,12 @@ class DbfsErrorCodes(object):
     RESOURCE_DOES_NOT_EXIST = 'RESOURCE_DOES_NOT_EXIST'
     RESOURCE_ALREADY_EXISTS = 'RESOURCE_ALREADY_EXISTS'
     PARTIAL_DELETE = 'PARTIAL_DELETE'
-    TOO_MANY_REQUESTS = 'TOO_MANY_REQUESTS'
-
-
-def before_sleep_on_429(retry_state):
-    global time_for_last_retry
-    if retry_state.attempt_number < 1:
-        loglevel = logging.INFO
-    else:
-        loglevel = logging.WARNING   
-    logger.log(
-        loglevel, ' Received 429 REQUEST_LIMIT_EXCEEDED for attempt %s. Retrying in %s seconds.',
-        retry_state.attempt_number, retry_state.idle_for - time_for_last_retry)
-    time_for_last_retry = retry_state.idle_for
-
-
-def retry_429(func):
-    @retry(wait=wait_random_exponential(multiplier=EXPONENTIAL_BACKOFF_MULTIPLIER, 
-           max=MAX_SECONDS_WAIT), retry=retry_if_exception_type(RateLimitException), 
-           stop=stop_after_attempt(MAX_RETRY_ATTEMPTS), reraise=True, 
-           before_sleep=before_sleep_on_429)
-    def wrapped_function(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except HTTPError as e:
-            if e.response.status_code == 429:
-                click.echo("Rate limit exceeded. Retrying with exponential backoff.")
-                raise RateLimitException("429 Too Many Requests")
-            raise e
-    return wrapped_function
 
 
 class DbfsApi(object):
     def __init__(self, api_client):
         self.client = DbfsService(api_client)
 
-    @retry_429
     def list_files(self, dbfs_path, headers=None):
         list_response = self.client.list(dbfs_path.absolute_path, headers=headers)
         if 'files' in list_response:
@@ -144,37 +101,20 @@ class DbfsApi(object):
             raise e
         return True
 
-    @retry_429
     def get_status(self, dbfs_path, headers=None):
         json = self.client.get_status(dbfs_path.absolute_path, headers=headers)
         return FileInfo.from_json(json)
 
-    @retry_429
-    def create(self, dbfs_path, overwrite, headers):
-        return self.client.create(dbfs_path.absolute_path, overwrite, headers=headers)
-
-    @retry_429
-    def add_block(self, handle, contents, headers):
-        self.client.add_block(handle, contents, headers=headers)
-
-    @retry_429
-    def close(self, handle, headers):
-        self.client.close(handle, headers=headers)
-
     def put_file(self, src_path, dbfs_path, overwrite, headers=None):
-        handle = self.create(dbfs_path, overwrite, headers=headers)['handle']
+        handle = self.client.create(dbfs_path.absolute_path, overwrite, headers=headers)['handle']
         with open(src_path, 'rb') as local_file:
             while True:
                 contents = local_file.read(BUFFER_SIZE_BYTES)
                 if len(contents) == 0:
                     break
                 # add_block should not take a bytes object.
-                self.add_block(handle, b64encode(contents).decode(), headers=headers)
-            self.close(handle, headers=headers)
-
-    @retry_429
-    def read(self, dbfs_path, offset, headers):
-        return self.client.read(dbfs_path.absolute_path, offset, BUFFER_SIZE_BYTES, headers=headers)       
+                self.client.add_block(handle, b64encode(contents).decode(), headers=headers)
+            self.client.close(handle, headers=headers)
 
     def get_file(self, dbfs_path, dst_path, overwrite, headers=None):
         if os.path.exists(dst_path) and not overwrite:
@@ -186,7 +126,8 @@ class DbfsApi(object):
         offset = 0
         with open(dst_path, 'wb') as local_file:
             while offset < length:
-                response = self.read(dbfs_path, offset, headers=headers)
+                response = self.client.read(dbfs_path.absolute_path, offset, BUFFER_SIZE_BYTES,
+                                            headers=headers)
                 bytes_read = response['bytes_read']
                 data = response['data']
                 offset += bytes_read
@@ -205,13 +146,11 @@ class DbfsApi(object):
                     message))
         return int(m.group(1))
 
-    @retry_429
     def delete(self, dbfs_path, recursive, headers=None):
         num_files_deleted = 0
         while True:
             try:
-                self.client.delete(dbfs_path.absolute_path, 
-                                   recursive=recursive, headers=headers)
+                self.client.delete(dbfs_path.absolute_path, recursive=recursive, headers=headers)
             except HTTPError as e:
                 if e.response.status_code == 503:
                     try:
@@ -233,11 +172,9 @@ class DbfsApi(object):
             break
         click.echo("\rDelete finished successfully.\033[K")
 
-    @retry_429
     def mkdirs(self, dbfs_path, headers=None):
         self.client.mkdirs(dbfs_path.absolute_path, headers=headers)
 
-    @retry_429
     def move(self, dbfs_src, dbfs_dst, headers=None):
         self.client.move(dbfs_src.absolute_path, dbfs_dst.absolute_path, headers=headers)
 

--- a/databricks_cli/dbfs/api.py
+++ b/databricks_cli/dbfs/api.py
@@ -28,9 +28,13 @@ import shutil
 import tempfile
 
 import re
+import logging
+import sys
 import click
 
+
 from tenacity import retry, wait_random_exponential, retry_if_exception_type, stop_after_attempt
+
 from requests.exceptions import HTTPError
 
 from databricks_cli.sdk import DbfsService
@@ -41,8 +45,12 @@ from databricks_cli.dbfs.exceptions import LocalFileExistsException, RateLimitEx
 BUFFER_SIZE_BYTES = 2**20
 EXPONENTIAL_BACKOFF_MULTIPLIER = 1
 MAX_SECONDS_WAIT = 60
-MAX_RETRY_ATTEMPTS = 8
+MAX_RETRY_ATTEMPTS = 7
 time_for_last_retry = 0
+
+logging.basicConfig(stream=sys.stderr, level=logging.WARNING)
+
+logger = logging.getLogger(__name__)
 
 
 class ParseException(Exception):
@@ -86,21 +94,13 @@ class DbfsErrorCodes(object):
 def before_sleep_on_429(retry_state):
     global time_for_last_retry
     if retry_state.attempt_number < 1:
-        click.echo("Warning: Unexpected retry_state.attempt_number={}.".format(
-            retry_state.attempt_number))
-        click.echo("Received 429 REQUEST_LIMIT_EXCEEDED. Retrying with exponential backoff.")
+        loglevel = logging.INFO
     else:
-        # Initialize time_for_last_retry on the first attempt.
-        if retry_state.attempt_number == 1:
-            time_for_last_retry = 0
-        # Note: Here idle_for represents the total time spent sleeping in all retries so far +
-        # the time that we will sleep until the next retry. We determined this empirically,
-        # as it is not clearly stated in the Tenacity docs.
-        time_until_next_retry = retry_state.idle_for - time_for_last_retry
-        click.echo(("Received 429 REQUEST_LIMIT_EXCEEDED for attempt {}. "
-                    "Retrying in {:.2f} seconds.").format(retry_state.attempt_number,
-                                                          time_until_next_retry))
-        time_for_last_retry = retry_state.idle_for
+        loglevel = logging.WARNING   
+    logger.log(
+        loglevel, ' Received 429 REQUEST_LIMIT_EXCEEDED for attempt %s. Retrying in %s seconds.',
+        retry_state.attempt_number, retry_state.idle_for - time_for_last_retry)
+    time_for_last_retry = retry_state.idle_for
 
 
 def retry_429(func):
@@ -113,6 +113,7 @@ def retry_429(func):
             return func(*args, **kwargs)
         except HTTPError as e:
             if e.response.status_code == 429:
+                click.echo("Rate limit exceeded. Retrying with exponential backoff.")
                 raise RateLimitException("429 Too Many Requests")
             raise e
     return wrapped_function

--- a/databricks_cli/dbfs/exceptions.py
+++ b/databricks_cli/dbfs/exceptions.py
@@ -24,7 +24,3 @@
 
 class LocalFileExistsException(Exception):
     pass
-
-
-class RateLimitException(Exception):
-    pass

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -44,9 +44,11 @@ from six.moves.urllib.parse import urlparse
 try:
     from requests.packages.urllib3.poolmanager import PoolManager
     from requests.packages.urllib3 import exceptions
+    from requests.packages.urllib3.util.retry import Retry
 except ImportError:
     from urllib3.poolmanager import PoolManager
     from urllib3 import exceptions
+    from urllib3.util.retry import Retry
 
 from databricks_cli.version import version as databricks_cli_version
 
@@ -70,8 +72,16 @@ class ApiClient(object):
         if host[-1] == "/":
             host = host[:-1]
 
+        retries = max_retries=Retry(
+            total=6,
+            backoff_factor=1,
+            status_forcelist=[429],
+            method_whitelist=set({'POST'}) | set(Retry.DEFAULT_METHOD_WHITELIST),
+            respect_retry_after_header=True,
+            raise_on_status=False # return original response when retries have been exhausted
+        )
         self.session = requests.Session()
-        self.session.mount('https://', TlsV1HttpAdapter())
+        self.session.mount('https://', TlsV1HttpAdapter(max_retries=retries))
 
         parsed_url = urlparse(host)
         scheme = parsed_url.scheme

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -72,7 +72,7 @@ class ApiClient(object):
         if host[-1] == "/":
             host = host[:-1]
 
-        retries = max_retries=Retry(
+        retries = Retry(
             total=6,
             backoff_factor=1,
             status_forcelist=[429],

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'tabulate>=0.7.7',
         'six>=1.10.0',
         'configparser>=0.3.5;python_version < "3.6"',
-        'tenacity>=6.2.0'
     ],
     entry_points='''
         [console_scripts]

--- a/tests/dbfs/test_api.py
+++ b/tests/dbfs/test_api.py
@@ -40,7 +40,6 @@ TEST_FILE_JSON = {
     'file_size': 1
 }
 TEST_FILE_INFO = api.FileInfo(TEST_DBFS_PATH, False, 1)
-MAX_RETRY_ATTEMPTS = 8
 
 
 def get_resource_does_not_exist_exception():
@@ -141,7 +140,7 @@ class TestDbfsApi(object):
         dbfs_api.client.mkdirs = mock.Mock(side_effect=exception_sequence)
         with pytest.raises(RateLimitException):
             dbfs_api.mkdirs(DbfsPath('dbfs:/test/mkdir'))
-        assert dbfs_api.client.mkdirs.call_count == MAX_RETRY_ATTEMPTS
+        assert dbfs_api.client.mkdirs.call_count == 7
 
     def test_file_exists_true(self, dbfs_api):
         dbfs_api.client.get_status.return_value = TEST_FILE_JSON

--- a/tests/dbfs/test_api.py
+++ b/tests/dbfs/test_api.py
@@ -31,7 +31,7 @@ import pytest
 
 import databricks_cli.dbfs.api as api
 from databricks_cli.dbfs.dbfs_path import DbfsPath
-from databricks_cli.dbfs.exceptions import LocalFileExistsException, RateLimitException
+from databricks_cli.dbfs.exceptions import LocalFileExistsException
 
 TEST_DBFS_PATH = DbfsPath('dbfs:/test')
 TEST_FILE_JSON = {
@@ -52,13 +52,6 @@ def get_partial_delete_exception(message="[...] operation has deleted 10 files [
     response = requests.Response()
     response.status_code = 503
     response._content = ('{{"error_code": "{}","message": "{}"}}'.format(api.DbfsErrorCodes.PARTIAL_DELETE, message)).encode() #  NOQA
-    return requests.exceptions.HTTPError(response=response)
-
-
-def get_rate_limit_exception():
-    response = requests.Response()
-    response.status_code = 429
-    response._content = ('{{"error_code": "{}"}}'.format(api.DbfsErrorCodes.TOO_MANY_REQUESTS)).encode() #  NOQA
     return requests.exceptions.HTTPError(response=response)
 
 
@@ -110,38 +103,6 @@ class TestDbfsApi(object):
 
         assert len(files) == 0
 
-    def test_list_files_rate_limited(self, dbfs_api):
-        rate_limit_exception = get_rate_limit_exception()
-        # Simulate 2 rate limit exceptions followed by a full successful operation
-        exception_sequence = [rate_limit_exception, rate_limit_exception, None]
-        dbfs_api.client.list_files = mock.Mock(side_effect=exception_sequence)
-        # Should succeed
-        files = dbfs_api.list_files(TEST_DBFS_PATH)
-
-        assert len(files) == 0
-
-    def test_mkdirs_rate_limited(self, dbfs_api):
-        rate_limit_exception = get_rate_limit_exception()
-        # Simulate 2 rate limit exceptions followed by a full successful operation
-        exception_sequence = [rate_limit_exception, rate_limit_exception, None]
-        dbfs_api.client.mkdirs = mock.Mock(side_effect=exception_sequence)
-        # Should succeed
-        dbfs_api.mkdirs(DbfsPath('dbfs:/test/mkdir'))
-        files = dbfs_api.client.list(DbfsPath('dbfs:/test/mkdir'))
-
-        assert len(files) == 0
-
-    def test_mkdirs_stop_retrying(self, dbfs_api):
-        rate_limit_exception = get_rate_limit_exception()
-        # Simulate 9 rate limit exceptions which will fail eventually
-        exception_sequence = [rate_limit_exception, rate_limit_exception, rate_limit_exception, 
-                              rate_limit_exception, rate_limit_exception, rate_limit_exception, 
-                              rate_limit_exception, rate_limit_exception, rate_limit_exception]
-        dbfs_api.client.mkdirs = mock.Mock(side_effect=exception_sequence)
-        with pytest.raises(RateLimitException):
-            dbfs_api.mkdirs(DbfsPath('dbfs:/test/mkdir'))
-        assert dbfs_api.client.mkdirs.call_count == 7
-
     def test_file_exists_true(self, dbfs_api):
         dbfs_api.client.get_status.return_value = TEST_FILE_JSON
         assert dbfs_api.file_exists(TEST_DBFS_PATH)
@@ -161,16 +122,6 @@ class TestDbfsApi(object):
         with pytest.raises(exception.__class__):
             dbfs_api.get_status(TEST_DBFS_PATH)
 
-    def test_get_status_rate_limited(self, dbfs_api):
-        exception = get_rate_limit_exception()
-        dbfs_api.client.get_status = mock.Mock(side_effect=[exception, {
-            'path': '/test',
-            'is_dir': False,
-            'file_size': 1
-        }])
-        # Should succeed
-        assert dbfs_api.get_status(TEST_DBFS_PATH) is not None
-
     def test_put_file(self, dbfs_api, tmpdir):
         test_file_path = os.path.join(tmpdir.strpath, 'test')
         with open(test_file_path, 'wt') as f:
@@ -185,26 +136,6 @@ class TestDbfsApi(object):
         assert test_handle == api_mock.add_block.call_args[0][0]
         assert b64encode(b'test').decode() == api_mock.add_block.call_args[0][1]
         assert api_mock.close.call_count == 1
-        assert test_handle == api_mock.close.call_args[0][0]
-
-    def test_put_file_rate_limited(self, dbfs_api, tmpdir):
-        test_file_path = os.path.join(tmpdir.strpath, 'test')
-        with open(test_file_path, 'wt') as f:
-            f.write('test')
-
-        exception = get_rate_limit_exception()
-        api_mock = dbfs_api.client
-        test_handle = 0
-        api_mock.create = mock.Mock(side_effect=[exception, {'handle': test_handle}])
-        api_mock.add_block = mock.Mock(side_effect=[exception, None])
-        api_mock.close = mock.Mock(side_effect=[exception, None])
-        dbfs_api.put_file(test_file_path, TEST_DBFS_PATH, True)
-
-        assert api_mock.create.call_count == 2
-        assert api_mock.add_block.call_count == 2
-        assert test_handle == api_mock.add_block.call_args[0][0]
-        assert b64encode(b'test').decode() == api_mock.add_block.call_args[0][1]
-        assert api_mock.close.call_count == 2
         assert test_handle == api_mock.close.call_args[0][0]
 
     def test_get_file_check_overwrite(self, dbfs_api, tmpdir):
@@ -228,22 +159,6 @@ class TestDbfsApi(object):
         with open(test_file_path, 'r') as f:
             assert f.read() == 'x'
 
-    def test_get_file_rate_limited(self, dbfs_api, tmpdir):
-        api_mock = dbfs_api.client
-        api_mock.get_status.return_value = TEST_FILE_JSON
-        rate_limit_exception = get_rate_limit_exception()
-
-        api_mock.read = mock.Mock(side_effect=[rate_limit_exception, {
-            'bytes_read': 1,
-            'data': b64encode(b'x'),
-        }])
-
-        test_file_path = os.path.join(tmpdir.strpath, 'test')
-        dbfs_api.get_file(TEST_DBFS_PATH, test_file_path, True)
-
-        with open(test_file_path, 'r') as f:
-            assert f.read() == 'x'
-
     def test_cat(self, dbfs_api):
         dbfs_api.client.get_status.return_value = {
             'path': '/test',
@@ -258,53 +173,10 @@ class TestDbfsApi(object):
             dbfs_api.cat('dbfs:/whatever-doesnt-matter')
             click_mock.echo.assert_called_with('a', nl=False)
 
-    def test_cat_rate_limited(self, dbfs_api):
-        rate_limit_exception = get_rate_limit_exception()
-        # Simulate 2 rate limit exceptions followed by a full successful operation
-        get_status_exception_sequence = [rate_limit_exception, rate_limit_exception, {
-            'path': '/test',
-            'is_dir': False,
-            'file_size': 1
-        }]
-        read_exception_sequence = [rate_limit_exception, rate_limit_exception, {
-            'bytes_read': 1,
-            'data': b64encode(b'a'),
-        }]
-
-        dbfs_api.client.get_status = mock.Mock(side_effect=get_status_exception_sequence)
-        dbfs_api.client.read = mock.Mock(side_effect=read_exception_sequence)
-
-        with mock.patch('databricks_cli.dbfs.api.click') as click_mock:
-            dbfs_api.cat('dbfs:/whatever-doesnt-matter')
-            click_mock.echo.assert_called_with('a', nl=False)
-
     def test_partial_delete(self, dbfs_api):
         e_partial_delete = get_partial_delete_exception()
-        # Simulate 3 partial deletes followed by a full successful operation
+        # Simulate 3 partial deletes followed by a full successful delete
         exception_sequence = [e_partial_delete, e_partial_delete, e_partial_delete, None]
-        dbfs_api.client.delete = mock.Mock(side_effect=exception_sequence)
-        dbfs_api.delete_retry_delay_millis = 1
-        # Should succeed
-        dbfs_api.delete(DbfsPath('dbfs:/whatever-doesnt-matter'), recursive=True)
-
-    def test_partial_delete_with_rate_limit(self, dbfs_api):
-        rate_limit_exception = get_rate_limit_exception()
-        e_partial_delete = get_partial_delete_exception()
-        # Simulate 3 partial deletes interspersed with rate limiting exceptions 
-        # followed by a full successful delete
-        exception_sequence = [e_partial_delete, rate_limit_exception, 
-                              e_partial_delete, rate_limit_exception,
-                              e_partial_delete, None]
-
-        dbfs_api.client.delete = mock.Mock(side_effect=exception_sequence)
-        dbfs_api.delete_retry_delay_millis = 1
-        # Should succeed
-        dbfs_api.delete(DbfsPath('dbfs:/whatever-doesnt-matter'), recursive=True)
-
-    def test_delete_with_rate_limit(self, dbfs_api):
-        rate_limit_exception = get_rate_limit_exception()
-        # Simulate a rate limit exception followed by a full successful delete
-        exception_sequence = [rate_limit_exception, None]
         dbfs_api.client.delete = mock.Mock(side_effect=exception_sequence)
         dbfs_api.delete_retry_delay_millis = 1
         # Should succeed

--- a/tests/dbfs/test_api.py
+++ b/tests/dbfs/test_api.py
@@ -40,6 +40,7 @@ TEST_FILE_JSON = {
     'file_size': 1
 }
 TEST_FILE_INFO = api.FileInfo(TEST_DBFS_PATH, False, 1)
+MAX_RETRY_ATTEMPTS = 8
 
 
 def get_resource_does_not_exist_exception():
@@ -140,7 +141,7 @@ class TestDbfsApi(object):
         dbfs_api.client.mkdirs = mock.Mock(side_effect=exception_sequence)
         with pytest.raises(RateLimitException):
             dbfs_api.mkdirs(DbfsPath('dbfs:/test/mkdir'))
-        assert dbfs_api.client.mkdirs.call_count == api.Retry429.MAX_RETRY_ATTEMPTS
+        assert dbfs_api.client.mkdirs.call_count == MAX_RETRY_ATTEMPTS
 
     def test_file_exists_true(self, dbfs_api):
         dbfs_api.client.get_status.return_value = TEST_FILE_JSON


### PR DESCRIPTION
Revert retry logic on 429 responses for DBFS API requests (https://github.com/databricks/databricks-cli/pull/319, https://github.com/databricks/databricks-cli/pull/326, https://github.com/databricks/databricks-cli/pull/327) and reimplement it using [urllib3.util.Retry](https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html), for all the requests made by `databricks-cli`.

* We perform a maximum number of 6 retries with exponential backoff, resulting in the following delays between them: 0.5, 1, 2, 4, 8, 16 (seconds). The `Retry-After` header is respected if present.
* There is no message logged for each retry (I could not find a way to do it using `urllib3.util.Retry`).
* If all retry attempts fail, the original 429 http response is forwarded by the retry utility.

I tested manually by enabling debug logging and validating that retries are performed. I don't see an easy way of adding automated tests and I don't think it's worth the effort to do it given that we are only using standard functionality.
```
DEBUG:urllib3.connectionpool:https://adb-1805849421037944.4.dev.azuredatabricks.net:443 "GET /api/2.0/dbfs/list?path=dbfs%3A%2F HTTP/1.1" 429 None
DEBUG:urllib3.util.retry:Incremented Retry for (url='/api/2.0/dbfs/list?path=dbfs%3A%2F'): Retry(total=2, connect=None, read=None, redirect=None, status=None)
DEBUG:urllib3.connectionpool:Retry: /api/2.0/dbfs/list?path=dbfs%3A%2F
DEBUG:urllib3.connectionpool:https://adb-1805849421037944.4.dev.azuredatabricks.net:443 "GET /api/2.0/dbfs/list?path=dbfs%3A%2F HTTP/1.1" 429 None
DEBUG:urllib3.util.retry:Incremented Retry for (url='/api/2.0/dbfs/list?path=dbfs%3A%2F'): Retry(total=1, connect=None, read=None, redirect=None, status=None)
DEBUG:urllib3.connectionpool:Retry: /api/2.0/dbfs/list?path=dbfs%3A%2F
DEBUG:urllib3.connectionpool:https://adb-1805849421037944.4.dev.azuredatabricks.net:443 "GET /api/2.0/dbfs/list?path=dbfs%3A%2F HTTP/1.1" 429 None
DEBUG:urllib3.util.retry:Incremented Retry for (url='/api/2.0/dbfs/list?path=dbfs%3A%2F'): Retry(total=0, connect=None, read=None, redirect=None, status=None)
DEBUG:urllib3.connectionpool:Retry: /api/2.0/dbfs/list?path=dbfs%3A%2F
DEBUG:urllib3.connectionpool:https://adb-1805849421037944.4.dev.azuredatabricks.net:443 "GET /api/2.0/dbfs/list?path=dbfs%3A%2F HTTP/1.1" 429 None
Error: {"error_code":"REQUEST_LIMIT_EXCEEDED","message":"Workspace 1805849421037944 exceeded the concurrent limit of 30 requests."}
```