### PR TITLE
[PLAT-24515] - Remove Case sensitive option for create-scope in secrets

### DIFF
--- a/databricks_cli/secrets/cli.py
+++ b/databricks_cli/secrets/cli.py
@@ -51,7 +51,7 @@ DASH_MARKER = '# ' + '-' * 70 + '\n'
               ' workspace. If not specified, the initial ACL with MANAGE permission applied to the'
               ' scope is assigned to the request issuer\'s user identity.')
 @click.option('--scope-backend-type',
-              type=click.Choice(['AZURE_KEYVAULT', 'DATABRICKS'], case_sensitive=True),
+              type=click.Choice(['AZURE_KEYVAULT', 'DATABRICKS']),
               default='DATABRICKS', help='The backend that will be used for this secret scope. '
                                          'Options are (case-sensitive): 1) \'AZURE_KEYVAULT\' and '
                                          '2) \'DATABRICKS\' (default option)'


### PR DESCRIPTION
The case sensitive option is not supported by the version of click that databricks_cli uses, so removing this option. After testing the commands with this change, since options  for scope backend type are uppercase (DATBRICKS, AZURE_KEYVAULT), the arguments are still case sensitive. But the explicit case sensitive option is being removed to conform with current click version.