### PR TITLE
Re-add init_scripts to ClusterService.create_cluster

### DIFF
--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -212,12 +212,13 @@ class ClusterService(object):
 
         return self.client.perform_query('GET', '/clusters/list', data=_data, headers=headers)
 
+    # init_scripts argument was removed by autogeneration and manually added here.
     def create_cluster(self, num_workers=None, autoscale=None, cluster_name=None, spark_version=None,
                        spark_conf=None, aws_attributes=None, node_type_id=None,
                        driver_node_type_id=None, ssh_public_keys=None, custom_tags=None,
-                       cluster_log_conf=None, spark_env_vars=None, autotermination_minutes=None,
-                       enable_elastic_disk=None, cluster_source=None, instance_pool_id=None,
-                       headers=None):
+                       cluster_log_conf=None, init_scripts=None, spark_env_vars=None,
+                       autotermination_minutes=None, enable_elastic_disk=None, cluster_source=None,
+                       instance_pool_id=None, headers=None):
         _data = {}
         if num_workers is not None:
             _data['num_workers'] = num_workers
@@ -247,6 +248,9 @@ class ClusterService(object):
             _data['cluster_log_conf'] = cluster_log_conf
             if not isinstance(cluster_log_conf, dict):
                 raise TypeError('Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
+        # init_scripts handling was removed by autogeneration and manually added here.
+        if init_scripts is not None:
+            _data['init_scripts'] = init_scripts
         if spark_env_vars is not None:
             _data['spark_env_vars'] = spark_env_vars
         if autotermination_minutes is not None:


### PR DESCRIPTION
It looks like this is being bashed around by the code generation: it was removed in #200, re-added in #266, then removed again by #325.

I'm not sure how the code generation works so this could happen again in future. Perhaps it should be looked into somewhere upstream instead, for now it would be useful to get this merged if possible!

Fixes #264 and #335.