### PR TITLE
Avoid indexing potentially empty dictionaries in the `pipelines list` command

### DIFF
--- a/databricks_cli/pipelines/api.py
+++ b/databricks_cli/pipelines/api.py
@@ -74,11 +74,11 @@ class PipelinesApi(object):
                 'GET', '/pipelines', data=_data, headers=headers)
 
         response = call()
-        pipelines = response["statuses"]
+        pipelines = response.get("statuses", [])
 
-        while "next_page_token" in response["pagination"]:
+        while "next_page_token" in response.get("pagination", {}):
             response = call(page_token=response["pagination"]["next_page_token"])
-            pipelines.extend(response["statuses"])
+            pipelines.extend(response.get("statuses", []))
         return pipelines
 
     def reset(self, pipeline_id, headers=None):

--- a/tox-requirements-3.txt
+++ b/tox-requirements-3.txt
@@ -1,6 +1,6 @@
 # Test reqs
 prospector[with_pyroma]==1.3.0
-pylint==2.5.3
+pylint==2.5.2
 pep8-naming==0.5.0
 pytest==3.8.1
 mock==2.0.0


### PR DESCRIPTION
The CLI should gracefully handle cases where there are missing fields in the response. This PR replaces all direct dictionary indexes with `dict.get()` calls, with sane default values, to ensure we don't throw an error when the API response does not have all fields present.