### PR TITLE
Add runs export command including model parsing

### DIFF
--- a/databricks_cli/runs/api.py
+++ b/databricks_cli/runs/api.py
@@ -42,3 +42,6 @@ class RunsApi(object):
 
     def get_run_output(self, run_id):
         return self.client.get_run_output(run_id)
+
+    def export_run(self, run_id, views_to_export=None):
+        return self.client.export_run(run_id, views_to_export)

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -26,7 +26,7 @@ import re
 from json import loads as json_loads
 
 import click
-from six.moves.urllib.parse import unquote_to_bytes  # pylint: disable=W0403
+from six.moves.urllib.parse import unquote_to_bytes  # pylint: disable=relative-import
 from tabulate import tabulate
 
 from databricks_cli.click_types import OutputClickType, JsonClickType, RunIdClickType

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -22,17 +22,18 @@
 # limitations under the License.
 
 import base64
-import click
-import json
 import re
-from tabulate import tabulate
+from json import loads as json_loads
+
+import click
 from six.moves.urllib.parse import unquote_to_bytes
+from tabulate import tabulate
 
 from databricks_cli.click_types import OutputClickType, JsonClickType, RunIdClickType
-from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS, pretty_format, json_cli_base, \
-    truncate_string
 from databricks_cli.configure.config import provide_api_client, profile_option, debug_option
 from databricks_cli.runs.api import RunsApi
+from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS, pretty_format, json_cli_base, \
+    truncate_string
 from databricks_cli.version import print_version_callback, version
 
 
@@ -144,7 +145,8 @@ def get_output_cli(api_client, run_id):
 @click.option('--views-to-export', required=False,
               type=click.Choice(['CODE', 'DASHBOARDS', 'ALL'], case_sensitive=False), default='ALL')
 @click.option('--parse-model', is_flag=True, default=None,
-              help='Parse the Notebook model JSON embedded in the HTML of each view and add it as the "model" field.')
+              help='Parse the Notebook model JSON embedded in the HTML of each view and add '
+                   'it as the "model" field.')
 @debug_option
 @profile_option
 @eat_exceptions
@@ -169,7 +171,7 @@ def export_cli(api_client, run_id, views_to_export, parse_model):
             model_base64 = match.group(1)
             model_urlencoded = base64.b64decode(model_base64)
             model_json = unquote_to_bytes(model_urlencoded)
-            model_data = json.loads(model_json)
+            model_data = json_loads(model_json)
             view['model'] = model_data
 
     click.echo(pretty_format(raw_export))

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -26,7 +26,7 @@ import re
 from json import loads as json_loads
 
 import click
-from six.moves.urllib.parse import unquote_to_bytes
+from six.moves.urllib.parse import unquote_to_bytes  # pylint: disable=W0403
 from tabulate import tabulate
 
 from databricks_cli.click_types import OutputClickType, JsonClickType, RunIdClickType

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -25,8 +25,12 @@ import base64
 import re
 from json import loads as json_loads
 
+try:
+    from urlparse import unquote_to_bytes
+except ImportError:
+    from urllib.parse import unquote_to_bytes
+
 import click
-from six.moves.urllib.parse import unquote_to_bytes  # pylint: disable=relative-import
 from tabulate import tabulate
 
 from databricks_cli.click_types import OutputClickType, JsonClickType, RunIdClickType

--- a/tests/runs/test_cli.py
+++ b/tests/runs/test_cli.py
@@ -115,7 +115,8 @@ EXPORT_RETURN = {
         },
         {
             # {"foo":"bar"} urlencoded and base64 encoded
-            'content': "<script>var __DATABRICKS_NOTEBOOK_MODEL = 'JTdCJTIyZm9vJTIyJTNBJTIyYmFyJTIyJTdE';</script>"
+            'content': "<script>var __DATABRICKS_NOTEBOOK_MODEL = "
+                       "'JTdCJTIyZm9vJTIyJTNBJTIyYmFyJTIyJTdE';</script>"
         },
     ]
 }
@@ -129,6 +130,7 @@ def test_export_no_parse_model(runs_api_mock):
         runner.invoke(cli.export_cli, ['--run-id', 1])
         assert runs_api_mock.export_run.call_args[0][0] == 1
         assert echo_mock.call_args[0][0] == pretty_format(EXPORT_RETURN)
+
 
 @provide_conf
 def test_export_parse_model(runs_api_mock):
@@ -144,7 +146,8 @@ def test_export_parse_model(runs_api_mock):
                     'content': 'invalid'
                 },
                 {
-                    'content': "<script>var __DATABRICKS_NOTEBOOK_MODEL = 'JTdCJTIyZm9vJTIyJTNBJTIyYmFyJTIyJTdE';</script>",
+                    'content': "<script>var __DATABRICKS_NOTEBOOK_MODEL = "
+                               "'JTdCJTIyZm9vJTIyJTNBJTIyYmFyJTIyJTdE';</script>",
                     'model': {
                         'foo': 'bar'
                     }

--- a/tests/runs/test_cli.py
+++ b/tests/runs/test_cli.py
@@ -105,3 +105,49 @@ def test_cancel_cli(runs_api_mock):
         runner.invoke(cli.cancel_cli, ['--run-id', 1])
         assert runs_api_mock.cancel_run.call_args[0][0] == 1
         assert echo_mock.call_args[0][0] == pretty_format({})
+
+
+EXPORT_RETURN = {
+    'views': [
+        {},
+        {
+            'content': 'invalid'
+        },
+        {
+            # {"foo":"bar"} urlencoded and base64 encoded
+            'content': "<script>var __DATABRICKS_NOTEBOOK_MODEL = 'JTdCJTIyZm9vJTIyJTNBJTIyYmFyJTIyJTdE';</script>"
+        },
+    ]
+}
+
+
+@provide_conf
+def test_export_no_parse_model(runs_api_mock):
+    with mock.patch('databricks_cli.runs.cli.click.echo') as echo_mock:
+        runs_api_mock.export_run.return_value = EXPORT_RETURN
+        runner = CliRunner()
+        runner.invoke(cli.export_cli, ['--run-id', 1])
+        assert runs_api_mock.export_run.call_args[0][0] == 1
+        assert echo_mock.call_args[0][0] == pretty_format(EXPORT_RETURN)
+
+@provide_conf
+def test_export_parse_model(runs_api_mock):
+    with mock.patch('databricks_cli.runs.cli.click.echo') as echo_mock:
+        runs_api_mock.export_run.return_value = EXPORT_RETURN
+        runner = CliRunner()
+        runner.invoke(cli.export_cli, ['--run-id', 1, '--parse-model'])
+        assert runs_api_mock.export_run.call_args[0][0] == 1
+        assert echo_mock.call_args[0][0] == pretty_format({
+            'views': [
+                {},
+                {
+                    'content': 'invalid'
+                },
+                {
+                    'content': "<script>var __DATABRICKS_NOTEBOOK_MODEL = 'JTdCJTIyZm9vJTIyJTNBJTIyYmFyJTIyJTdE';</script>",
+                    'model': {
+                        'foo': 'bar'
+                    }
+                },
+            ]
+        })

--- a/tox-requirements-3.txt
+++ b/tox-requirements-3.txt
@@ -1,6 +1,6 @@
 # Test reqs
-prospector[with_pyroma]==1.3.0
-pylint==2.5.3
+prospector[with_pyroma]==1.3.*
+pylint==2.5.*
 pep8-naming==0.5.0
 pytest==3.8.1
 mock==2.0.0

--- a/tox-requirements.txt
+++ b/tox-requirements.txt
@@ -1,6 +1,6 @@
 # Test reqs
 prospector[with_pyroma]==0.12.7
-pylint==1.8.2
+pylint==1.9.5
 pep8-naming==0.5.0
 pytest==3.8.1
 mock==2.0.0


### PR DESCRIPTION
* Add support for the [runs export API](https://docs.databricks.com/api/latest/jobs.html#runs-export).
* It returns a JSON with HTML content and the actual notebook model is embedded it in in an unreadable format, which makes it not very useful for seeing e.g. errors in the run. This also optionally parses the model to improve that.