### PR TITLE
[HACKATHON] SQL query CLI

### DIFF
--- a/databricks_cli/cli.py
+++ b/databricks_cli/cli.py
@@ -40,6 +40,7 @@ from databricks_cli.groups.cli import groups_group
 from databricks_cli.tokens.cli import tokens_group
 from databricks_cli.instance_pools.cli import instance_pools_group
 from databricks_cli.pipelines.cli import pipelines_group
+from databricks_cli.sql.cli import sql_group
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
@@ -65,6 +66,7 @@ cli.add_command(groups_group, name='groups')
 cli.add_command(tokens_group, name='tokens')
 cli.add_command(instance_pools_group, name="instance-pools")
 cli.add_command(pipelines_group, name='pipelines')
+cli.add_command(sql_group, name='sql')
 
 if __name__ == "__main__":
     cli()

--- a/databricks_cli/click_types.py
+++ b/databricks_cli/click_types.py
@@ -105,6 +105,17 @@ class PipelineIdClickType(ParamType):
     name = 'PIPELINE_ID'
     help = 'Delta Pipeline ID'
 
+class SqlQueryClickType(ParamType):
+    name = 'SQL_QUERY'
+    help = 'Text of the SQL query to perform'
+
+class SqlQueryFileClickType(ParamType):
+    name = 'SQL_QUERY_FILE'
+    help = 'Path of file containing the the SQL query to perform'
+
+class SqlEndpointNameClickType(ParamType):
+    name = 'ENDPOINT_NAME'
+    help = 'Name of the SQL Endpoint'
 
 class OneOfOption(Option):
     def __init__(self, *args, **kwargs):

--- a/databricks_cli/sql/api.py
+++ b/databricks_cli/sql/api.py
@@ -1,0 +1,82 @@
+# Databricks CLI
+# Copyright 2020 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"), except
+# that the use of services to which certain application programming
+# interfaces (each, an "API") connect requires that the user first obtain
+# a license for the use of the APIs from Databricks, Inc. ("Databricks"),
+# by creating an account at www.databricks.com and agreeing to either (a)
+# the Community Edition Terms of Service, (b) the Databricks Terms of
+# Service, or (c) another written agreement between Licensee and Databricks
+# for the use of the APIs.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import time
+
+
+def spinning_cursor():
+    while True:
+        for cursor in '|/-\\':
+            yield cursor
+
+
+class SqlApi(object):
+    def __init__(self, api_client):
+        self.client = api_client
+
+    # Wrapper around api_client.perform_auery
+    def perform_query(self, method, path, data=None):
+        return self.client.perform_query(method, path, data=data, use_api_prefix=False)
+
+    def do_query(self, data_source_id, query):
+        _data = {
+            "apply_auto_limit": True,
+            "data_source_id": data_source_id,
+            "max_age": 0,
+            "parameters": {},
+            "query": query,
+        }
+        job_info = self.perform_query('POST', '/sql/api/query_results', data=_data)
+
+        if 'job' not in job_info or 'id' not in job_info['job']:
+            raise RuntimeError("Did not find job id in response from query_results: %s" % (job_info))
+
+        status_uri = '/sql/api/query_executions/' + job_info['job']['id']
+        # Use input timeout and/or max_attempts?
+        max_attempts = 20
+        timeout = 30  # sec
+        deadline = time.time() + timeout
+        spinner = spinning_cursor()
+        job_status = None
+        for i in range(max_attempts):
+            job_status = self.perform_query('GET', status_uri)
+            if job_status['job']['status'] == 3:
+                # Query is ready!
+                break
+            if job_status['job']['error'] != "":
+                raise RuntimeError("Error from job status: %s" % job_status['job']['error'])
+            if time.time() > deadline or i == max_attempts-1:
+                raise RuntimeError("Query timed out.")
+
+            sys.stdout.write(next(spinner))
+            sys.stdout.flush()
+            time.sleep(0.3)
+            sys.stdout.write('\b')
+
+        query_result_uri = '/sql/api/query_results/' + job_status['job']['query_result_id']
+        return self.perform_query('GET', query_result_uri)
+
+    def list_data_sources(self):
+        return self.perform_query('GET', '/sql/api/data_sources')
+

--- a/databricks_cli/sql/cli.py
+++ b/databricks_cli/sql/cli.py
@@ -1,0 +1,163 @@
+# Databricks CLI
+# Copyright 2020 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"), except
+# that the use of services to which certain application programming
+# interfaces (each, an "API") connect requires that the user first obtain
+# a license for the use of the APIs from Databricks, Inc. ("Databricks"),
+# by creating an account at www.databricks.com and agreeing to either (a)
+# the Community Edition Terms of Service, (b) the Databricks Terms of
+# Service, or (c) another written agreement between Licensee and Databricks
+# for the use of the APIs.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from json import loads as json_loads
+
+import click
+from tabulate import tabulate
+import uuid
+
+from databricks_cli.click_types import OutputClickType, JsonClickType, OneOfOption, \
+    SqlQueryClickType, SqlEndpointNameClickType, ContextObject, MissingParameter
+from databricks_cli.sql.api import SqlApi
+from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS, pretty_format, json_cli_base, \
+    truncate_string
+from databricks_cli.configure.config import provide_api_client, profile_option, debug_option
+from databricks_cli.version import print_version_callback, version
+
+def print_query_results(results, output_type):
+    if OutputClickType.is_json(output_type):
+        click.echo(pretty_format(results))
+        return
+
+    cols = results['columns']
+    col_names = [ c['friendly_name'] for c in cols ]
+    rows = []
+    for r in results['rows']:
+        newrow = [ r[c['name']] for c in cols ]
+        rows += [ newrow ]
+
+    click.echo(' ')  # blank line before table
+    click.echo(tabulate(rows, headers=col_names, tablefmt='simple', disable_numparse=True))
+
+QUERY_OPTIONS = ['query', 'query-file']
+
+@click.command(context_settings=CONTEXT_SETTINGS,
+               short_help='Perform an SQL query.')
+@click.option('--endpoint', '-e', default=None, required=True, type=SqlEndpointNameClickType(),
+              help='Name of the SQL endpoint.')
+@click.option('--query', cls=OneOfOption, one_of=QUERY_OPTIONS, type=SqlQueryClickType(),
+              help='Text of the SQL query to perform.')
+@click.option('--query-file', cls=OneOfOption, one_of=QUERY_OPTIONS, type=SqlQueryClickType(),
+              help='File containing the text of the SQL query to perform.')
+@click.option('--output', default=None, help=OutputClickType.help, type=OutputClickType())
+@debug_option
+@profile_option
+@eat_exceptions
+@provide_api_client
+def query_cli(api_client, endpoint, query, query_file, output):
+    """
+    Perform an SQL Query.
+
+    """
+    if query_file:
+        with open(query_file, 'r') as f:
+            query = f.read()
+        click.echo("query: %s" % query)
+
+    ctx = click.get_current_context()
+    context_object = ctx.ensure_object(ContextObject)
+
+    api_client.do_login()
+
+    endpoints = SqlApi(api_client).list_data_sources()
+    endpoint_list = [ e for e in endpoints if e["name"] == endpoint ]
+    if len(endpoint_list) == 0:
+        raise RuntimeError("Did not find endpoint with name: %s" % (endpoint))
+    chosen_endpoint = endpoint_list[0]
+
+    if context_object.debug_mode:
+        click.echo('Endpoint:\n' + pretty_format(chosen_endpoint))
+
+    data_source_id = chosen_endpoint['id']
+
+    query_output_json = SqlApi(api_client).do_query(data_source_id, query)
+    results_data = query_output_json['query_result']['data']
+
+    print_query_results(results_data, output)
+
+
+def print_endpoints(endpoints, all_fields, output_type):
+    if not all_fields:   # Names only
+        names = [ e['name'] for e in endpoints ]
+        if OutputClickType.is_json(output_type):
+            click.echo(pretty_format(names))
+        else:
+            table = [ [name] for name in names ]
+            click.echo(' ')  # blank line before results
+            click.echo(tabulate(table, headers=['name'], tablefmt='simple', disable_numparse=True))
+        return
+
+    if OutputClickType.is_json(output_type):
+        click.echo(pretty_format(endpoints))
+        return
+
+    col_names = sorted(endpoints[0].keys())
+    rows = []
+    for r in endpoints:
+        newrow = []
+        for c in col_names:
+            newrow.append(r.get(c, '--'))   # Some endpoints don't have all col values
+        rows += [ newrow ]
+
+    click.echo(' ')  # blank line before results
+    click.echo(tabulate(rows, headers=col_names, tablefmt='simple', disable_numparse=True))
+
+
+@click.command(context_settings=CONTEXT_SETTINGS,
+               short_help='List SQL Endpoints.')
+@click.option('--all-fields', '-a', is_flag=True, default=False,
+              help='Show all endpont fields (not just names)')
+@click.option('--output', default=None, help=OutputClickType.help, type=OutputClickType())
+@debug_option
+@profile_option
+@eat_exceptions
+@provide_api_client
+def list_endpoints_cli(api_client, all_fields, output):
+    """
+    List SQL Endpoints
+
+    """
+    api_client.do_login()
+
+    endpoints = SqlApi(api_client).list_data_sources()
+    print_endpoints(endpoints, all_fields, output)
+
+
+@click.group(context_settings=CONTEXT_SETTINGS,
+             short_help='Utility to run SQL queries.')
+@click.option('--version', '-v', is_flag=True, callback=print_version_callback,
+              expose_value=False, is_eager=True, help=version)
+@debug_option
+@profile_option
+@eat_exceptions
+def sql_group():  # pragma: no cover
+    """
+    Utility to interact with SQL Analytics.
+
+    """
+    pass
+
+
+sql_group.add_command(query_cli, name='query')
+sql_group.add_command(list_endpoints_cli, name='list-endpoints')


### PR DESCRIPTION
# Use LakeHouse /sql/api to perform SQL queries

This Hackathon project adds an `sql` command, with two sub-commands:
```
  list-endpoints  List SQL Endpoints.
  query           Perform an SQL query.
```
Simple examples of these two sql commands:
```
$ databricks sql list-endpoints

name
---------------------------------------------
akhil-test
Ali-credit
BI integration test (DO NOT DELETE)
BI load test
Clemens ML Cluster
[...]
```
```
$ databricks sql query --endpoint 'QS Endpoint' --query 'SELECT * FROM people10m LIMIT 10'

id       firstName    middleName    lastName    gender    birthDate            ssn          salary
-------  -----------  ------------  ----------  --------  -------------------  -----------  --------
3766824  Hisako       Isabella      Malitrott   F         1961-02-12T05:00:00  938-80-1874  58862
3766825  Daisy        Merissa       Fibben      F         1998-05-19T04:00:00  971-14-3755  66221
3766826  Caren        Blossom       Henner      F         1962-08-06T04:00:00  954-19-8973  54376
3766827  Darleen      Gertie        Goodinson   F         1980-03-12T05:00:00  981-65-5269  69954
3766828  Kyle         Lu            Habben      F         1974-02-15T04:00:00  936-95-3240  56681
3766829  Melia        Kristy        Bonhill     F         1970-09-13T04:00:00  960-91-9232  73995
3766830  Yevette      Faye          Bebbell     F         1972-09-07T04:00:00  987-72-3701  92888
3766831  Delpha       Kenisha       Gillison    F         1979-06-25T04:00:00  962-66-5404  51206
3766832  Mikaela      Jenifer       Hallan      F         1973-05-23T04:00:00  911-38-3114  98887
3766833  Cindi        Renita        Cousin      F         1979-03-19T05:00:00  666-50-3216  63646
```
# Limitations:
## API Tokens Not Supported
The `/sql/api` does not accept authentication via PAT Tokens (attempts yield a redirect to the `/login.html` page). That should be changed if this new functionality for databricks-cli is to be seriously considered.

As a workaround to the lack of support for PAT Tokens with the `/sql/api`, the databricks-cli profile (for the shard of interest) must have a username and password configured.

The extensions to databricks-cli use a new `ApiClient.do_login` method to POST the username+password credential to the `/j_security_check` page, in order to get back the `JSESSIONID` cookie. It then fetches the /config page in order to get the CSRF token that must be included in subsequent requests to the  `/sql/api`.  This is pretty cheesy stuff, and it should be replaced with proper use of PAT Tokens to the `/sql/api`.

## No Single Sign-on Support (Admin Auth Only)

The work-around of authenticating via username+password at the login page only works for Admin logins; the Single Sign-on flow is not supported.  


# TODO:
- Add unit tests
- Better error handling and input/output validation
- Fix any lint issues

