### PR TITLE
[SC-71155] Fix TypeError in Pipelines CLI

### DIFF
--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -106,7 +106,7 @@ def deploy_cli(api_client, spec_arg, spec, allow_duplicate_names, pipeline_id):
         if (pipeline_id and 'id' in spec_obj) and pipeline_id != spec_obj["id"]:
             raise ValueError(
                 "The ID provided in --pipeline_id '{}' is different from the id provided "
-                "the spec '{}'. Please resolve the conflict and try the command again. "
+                "in the spec '{}'. Please resolve the conflict and try the command again. "
                 "Because pipeline IDs are no longer persisted after being deleted, we "
                 "recommend removing the ID field from your spec."
                 .format(pipeline_id, spec_obj["id"])

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -109,7 +109,7 @@ def deploy_cli(api_client, spec_arg, spec, allow_duplicate_names, pipeline_id):
                 "the spec '{}'. Please resolve the conflict and try the command again. "
                 "Because pipeline IDs are no longer persisted after being deleted, we "
                 "recommend removing the ID field from your spec."
-                .format(pipeline_id, spec["id"])
+                .format(pipeline_id, spec_obj["id"])
             )
 
         spec_obj['id'] = pipeline_id or spec_obj.get('id', None)

--- a/tests/pipelines/test_cli.py
+++ b/tests/pipelines/test_cli.py
@@ -307,5 +307,6 @@ def test_deploy_pipeline_conflicting_ids(pipelines_api_mock, tmpdir):
 
     result = CliRunner().invoke(cli.deploy_cli, ['--spec', path, '--pipeline-id', "fake"])
     assert result.exit_code == 1
-    assert "ValueError" in result.stdout
+    assert "ValueError: The ID provided in --pipeline_id 'fake' is different from the id " \
+           "provided in the spec '123'." in result.stdout
     assert pipelines_api_mock.deploy.call_count == 0

--- a/tests/pipelines/test_cli.py
+++ b/tests/pipelines/test_cli.py
@@ -307,4 +307,5 @@ def test_deploy_pipeline_conflicting_ids(pipelines_api_mock, tmpdir):
 
     result = CliRunner().invoke(cli.deploy_cli, ['--spec', path, '--pipeline-id', "fake"])
     assert result.exit_code == 1
+    assert "ValueError" in result.stdout
     assert pipelines_api_mock.deploy.call_count == 0


### PR DESCRIPTION
We were indexing by key into a string instead of a dict