### PR TITLE
Initial support for Databricks Repos

### DIFF
--- a/databricks_cli/cli.py
+++ b/databricks_cli/cli.py
@@ -40,6 +40,7 @@ from databricks_cli.groups.cli import groups_group
 from databricks_cli.tokens.cli import tokens_group
 from databricks_cli.instance_pools.cli import instance_pools_group
 from databricks_cli.pipelines.cli import pipelines_group
+from databricks_cli.repos.cli import repos_group
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
@@ -65,6 +66,7 @@ cli.add_command(groups_group, name='groups')
 cli.add_command(tokens_group, name='tokens')
 cli.add_command(instance_pools_group, name="instance-pools")
 cli.add_command(pipelines_group, name='pipelines')
+cli.add_command(repos_group, name='repos')
 
 if __name__ == "__main__":
     cli()

--- a/databricks_cli/repos/__init__.py
+++ b/databricks_cli/repos/__init__.py
@@ -1,0 +1,22 @@
+# Databricks CLI
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"), except
+# that the use of services to which certain application programming
+# interfaces (each, an "API") connect requires that the user first obtain
+# a license for the use of the APIs from Databricks, Inc. ("Databricks"),
+# by creating an account at www.databricks.com and agreeing to either (a)
+# the Community Edition Terms of Service, (b) the Databricks Terms of
+# Service, or (c) another written agreement between Licensee and Databricks
+# for the use of the APIs.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/databricks_cli/repos/api.py
+++ b/databricks_cli/repos/api.py
@@ -20,12 +20,32 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from databricks_cli.sdk import ReposService
+import os.path
+import requests
+from databricks_cli.sdk import ReposService, WorkspaceService
 
 
 class ReposApi(object):
     def __init__(self, api_client):
         self.client = ReposService(api_client)
+        self.ws_client = WorkspaceService(api_client)
 
     def update(self, repo_id, branch):
         return self.client.update(repo_id, branch)
+
+    def get_repos_id(self, path):
+        if not path.startswith("/Repos/"):
+            raise ValueError("Path must start with /Repos/ !")
+
+        p = path
+        while p != "/Repos":
+            try:
+                status = self.ws_client.get_status(p)
+                if status['object_type'] == 'REPO':
+                    return status['object_id']
+            except requests.exceptions.HTTPError:
+                pass
+
+            p = os.path.dirname(p)
+
+        raise RuntimeError("Can't find Repos ID for {path}".format(path=path))

--- a/databricks_cli/repos/api.py
+++ b/databricks_cli/repos/api.py
@@ -1,0 +1,31 @@
+# Databricks CLI
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"), except
+# that the use of services to which certain application programming
+# interfaces (each, an "API") connect requires that the user first obtain
+# a license for the use of the APIs from Databricks, Inc. ("Databricks"),
+# by creating an account at www.databricks.com and agreeing to either (a)
+# the Community Edition Terms of Service, (b) the Databricks Terms of
+# Service, or (c) another written agreement between Licensee and Databricks
+# for the use of the APIs.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from databricks_cli.sdk import ReposService
+
+
+class ReposApi(object):
+    def __init__(self, api_client):
+        self.client = ReposService(api_client)
+
+    def update(self, repo_id, branch):
+        return self.client.update(repo_id, branch)

--- a/databricks_cli/repos/cli.py
+++ b/databricks_cli/repos/cli.py
@@ -31,19 +31,34 @@ from databricks_cli.version import print_version_callback, version
 
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Checkout the given branch of repository')
-@click.option('--repo-id', required=True, help="Repository ID (you can find it in UI)")
+@click.option('--repos-id', required=True, help="Repository ID (you can find it in UI)")
 @click.option('--branch', required=True, help="Branch name")
 @debug_option
 @profile_option
 @eat_exceptions  # noqa
 @provide_api_client
-def update_repo_cli(api_client, repo_id, branch):
+def update_repo_cli(api_client, repos_id, branch):
     """
     Checkout and updates given branch of the repository
     This call returns the error if branch or repository doesn't exist
     """
-    content = ReposApi(api_client).update(repo_id, branch)
+    content = ReposApi(api_client).update(repos_id, branch)
     click.echo(pretty_format(content))
+
+
+@click.command(context_settings=CONTEXT_SETTINGS,
+               short_help='Find Repos ID by path.')
+@click.argument('path')
+@debug_option
+@profile_option
+@eat_exceptions
+@provide_api_client
+def get_repos_id_cli(api_client, path): # NOQA
+    """
+    Finds Repos ID by path, like, '/Repos/user/...'
+    """
+    repo_id = ReposApi(api_client).get_repos_id(path)
+    click.echo(repo_id)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS,
@@ -59,3 +74,4 @@ def repos_group():  # pragma: no cover
 
 
 repos_group.add_command(update_repo_cli, name='update')
+repos_group.add_command(get_repos_id_cli, name='get-repos-id')

--- a/databricks_cli/repos/cli.py
+++ b/databricks_cli/repos/cli.py
@@ -1,0 +1,61 @@
+# Databricks CLI
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"), except
+# that the use of services to which certain application programming
+# interfaces (each, an "API") connect requires that the user first obtain
+# a license for the use of the APIs from Databricks, Inc. ("Databricks"),
+# by creating an account at www.databricks.com and agreeing to either (a)
+# the Community Edition Terms of Service, (b) the Databricks Terms of
+# Service, or (c) another written agreement between Licensee and Databricks
+# for the use of the APIs.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+
+from databricks_cli.configure.config import provide_api_client, profile_option, debug_option
+from databricks_cli.repos.api import ReposApi
+from databricks_cli.utils import CONTEXT_SETTINGS, eat_exceptions, pretty_format
+from databricks_cli.version import print_version_callback, version
+
+
+@click.command(context_settings=CONTEXT_SETTINGS,
+               short_help='Checkout the given branch of repository')
+@click.option('--repo-id', required=True, help="Repository ID (you can find it in UI)")
+@click.option('--branch', required=True, help="Branch name")
+@debug_option
+@profile_option
+@eat_exceptions  # noqa
+@provide_api_client
+def update_repo_cli(api_client, repo_id, branch):
+    """
+    Checkout and updates given branch of the repository
+    This call returns the error if branch or repository doesn't exist
+    """
+    content = ReposApi(api_client).update(repo_id, branch)
+    click.echo(pretty_format(content))
+
+
+@click.group(context_settings=CONTEXT_SETTINGS,
+             short_help="Utility to interact with Repos.")
+@click.option("--version", "-v", is_flag=True, callback=print_version_callback,
+              expose_value=False, is_eager=True, help=version)
+@debug_option
+@profile_option
+@eat_exceptions
+def repos_group():  # pragma: no cover
+    """Utility to interact with Repos."""
+    pass
+
+
+repos_group.add_command(update_repo_cli, name='update')

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -1052,4 +1052,3 @@ class ReposService(object):
 
         return self.client.perform_query('PATCH', '/repos/{repo_id}'.format(repo_id=repo_id),
                                          data=_data, headers=headers)
-

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -1037,3 +1037,19 @@ class DeltaPipelinesService(object):
 
         return self.client.perform_query('POST', '/pipelines/{pipeline_id}/stop'.format(pipeline_id=pipeline_id),
                                          data=_data, headers=headers)
+
+
+class ReposService(object):
+    def __init__(self, client):
+        self.client = client
+
+    def update(self, repo_id, branch, headers=None):
+        _data = {}
+        if not repo_id or not branch:
+            raise
+
+        _data['branch'] = branch
+
+        return self.client.perform_query('PATCH', '/repos/{repo_id}'.format(repo_id=repo_id),
+                                         data=_data, headers=headers)
+

--- a/tests/repos/__init__.py
+++ b/tests/repos/__init__.py
@@ -1,0 +1,22 @@
+# Databricks CLI
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"), except
+# that the use of services to which certain application programming
+# interfaces (each, an "API") connect requires that the user first obtain
+# a license for the use of the APIs from Databricks, Inc. ("Databricks"),
+# by creating an account at www.databricks.com and agreeing to either (a)
+# the Community Edition Terms of Service, (b) the Databricks Terms of
+# Service, or (c) another written agreement between Licensee and Databricks
+# for the use of the APIs.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/repos/test_cli.py
+++ b/tests/repos/test_cli.py
@@ -30,8 +30,9 @@ from click.testing import CliRunner
 import databricks_cli.repos.cli as cli
 from tests.utils import provide_conf
 
+SOME_REPO_PATH = '/Repos/SomeRepo'
 
-REPO_ID = '123456'
+REPOS_ID = '123456'
 BRANCH_NAME = 'main'
 
 
@@ -46,7 +47,13 @@ def repos_api_mock():
 @provide_conf
 def test_update_repos(repos_api_mock):
     runner = CliRunner()
-    runner.invoke(cli.update_repo_cli, ['--repo-id', REPO_ID, '--branch', BRANCH_NAME])
-    assert repos_api_mock.update.call_args[0][0] == REPO_ID
+    runner.invoke(cli.update_repo_cli, ['--repos-id', REPOS_ID, '--branch', BRANCH_NAME])
+    assert repos_api_mock.update.call_args[0][0] == REPOS_ID
     assert repos_api_mock.update.call_args[0][1] == BRANCH_NAME
 
+
+@provide_conf
+def test_get_repos_id(repos_api_mock):
+    runner = CliRunner()
+    runner.invoke(cli.get_repos_id_cli, [SOME_REPO_PATH])
+    assert repos_api_mock.get_repos_id.call_args[0][0] == SOME_REPO_PATH

--- a/tests/repos/test_cli.py
+++ b/tests/repos/test_cli.py
@@ -1,0 +1,52 @@
+# Databricks CLI
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"), except
+# that the use of services to which certain application programming
+# interfaces (each, an "API") connect requires that the user first obtain
+# a license for the use of the APIs from Databricks, Inc. ("Databricks"),
+# by creating an account at www.databricks.com and agreeing to either (a)
+# the Community Edition Terms of Service, (b) the Databricks Terms of
+# Service, or (c) another written agreement between Licensee and Databricks
+# for the use of the APIs.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# pylint:disable=redefined-outer-name
+
+import mock
+import pytest
+from click.testing import CliRunner
+
+import databricks_cli.repos.cli as cli
+from tests.utils import provide_conf
+
+
+REPO_ID = '123456'
+BRANCH_NAME = 'main'
+
+
+@pytest.fixture()
+def repos_api_mock():
+    with mock.patch('databricks_cli.repos.cli.ReposApi') as ReposApiMock:
+        _repos_api_mock = mock.MagicMock()
+        ReposApiMock.return_value = _repos_api_mock
+        yield _repos_api_mock
+
+
+@provide_conf
+def test_update_repos(repos_api_mock):
+    runner = CliRunner()
+    runner.invoke(cli.update_repo_cli, ['--repo-id', REPO_ID, '--branch', BRANCH_NAME])
+    assert repos_api_mock.update.call_args[0][0] == REPO_ID
+    assert repos_api_mock.update.call_args[0][1] == BRANCH_NAME
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py27, py36
+envlist = py27, py37
 
 [testenv]
 # https://github.com/codecov/codecov-python/blob/5b9d539a6a09bc84501b381b563956295478651a/README.md#using-tox
 passenv = TOXENV CI TRAVIS TRAVIS_*
 deps = 
   py27: -rtox-requirements.txt
-  py36: -rtox-requirements-3.txt
+  py37: -rtox-requirements-3.txt
 commands =
 	pytest tests --cov=./
 	./lint.sh

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py27, py37
+envlist = py27, py36
 
 [testenv]
 # https://github.com/codecov/codecov-python/blob/5b9d539a6a09bc84501b381b563956295478651a/README.md#using-tox
 passenv = TOXENV CI TRAVIS TRAVIS_*
 deps = 
   py27: -rtox-requirements.txt
-  py37: -rtox-requirements-3.txt
+  py36: -rtox-requirements-3.txt
 commands =
 	pytest tests --cov=./
 	./lint.sh


### PR DESCRIPTION
This PR adds an initial support for [Databricks Repos](https://docs.databricks.com/repos.html) feature using the [Repos API](https://docs.databricks.com/dev-tools/api/latest/repos.html).  

Summary of changes:
* the new top level command was added: `repos`
* the `update` subcommand is used to checkout the repository specified via `--repos-id` switch to the branch specified via `--branch` switch
* the `get-repos-id` subcommand uses Workspaces API to find the Repos ID based on the file path.  It will be used to simplify the integration with CI/CD systems, etc., so people can write something like this instead of looking for Repos ID in UI:
```sh
REPOS_ID=$(databricks repos get-repos-id /Repos/Production/some-project)
databricks repos update --repos-id $REPOS_ID --branch releases
```