### PR TITLE
Interpret pipeline libraries relative to spec

### DIFF
--- a/databricks_cli/pipelines/api.py
+++ b/databricks_cli/pipelines/api.py
@@ -94,8 +94,8 @@ class PipelinesApi(object):
         lib_objects = LibraryObject.from_json(spec.get('libraries', []))
         local_lib_objects, external_lib_objects = self._identify_local_libraries(lib_objects)
 
-        spec['libraries'] = LibraryObject.to_json(external_lib_objects +
-                                                  self._upload_local_libraries(spec_dir, local_lib_objects))
+        spec['libraries'] = LibraryObject.to_json(
+            external_lib_objects + self._upload_local_libraries(spec_dir, local_lib_objects))
         return spec
 
     @staticmethod

--- a/databricks_cli/pipelines/api.py
+++ b/databricks_cli/pipelines/api.py
@@ -40,14 +40,14 @@ class PipelinesApi(object):
         self.client = DeltaPipelinesService(api_client)
         self.dbfs_client = DbfsApi(api_client)
 
-    def create(self, spec, allow_duplicate_names, headers=None):
-        data = self._upload_libraries_and_update_spec(spec)
+    def create(self, spec, spec_dir, allow_duplicate_names, headers=None):
+        data = self._upload_libraries_and_update_spec(spec, spec_dir)
         data['allow_duplicate_names'] = allow_duplicate_names
         return self.client.client.perform_query('POST', '/pipelines', data=data,
                                                 headers=headers)
 
-    def deploy(self, spec, allow_duplicate_names, headers=None):
-        data = self._upload_libraries_and_update_spec(spec)
+    def deploy(self, spec, spec_dir, allow_duplicate_names, headers=None):
+        data = self._upload_libraries_and_update_spec(spec, spec_dir)
         data['allow_duplicate_names'] = allow_duplicate_names
         pipeline_id = data['id']
         self.client.client.perform_query('PUT', '/pipelines/{}'.format(pipeline_id), data=data,
@@ -89,13 +89,13 @@ class PipelinesApi(object):
     def stop(self, pipeline_id, headers=None):
         self.client.stop(pipeline_id, headers)
 
-    def _upload_libraries_and_update_spec(self, spec):
+    def _upload_libraries_and_update_spec(self, spec, spec_dir):
         spec = copy.deepcopy(spec)
         lib_objects = LibraryObject.from_json(spec.get('libraries', []))
         local_lib_objects, external_lib_objects = self._identify_local_libraries(lib_objects)
 
         spec['libraries'] = LibraryObject.to_json(external_lib_objects +
-                                                  self._upload_local_libraries(local_lib_objects))
+                                                  self._upload_local_libraries(spec_dir, local_lib_objects))
         return spec
 
     @staticmethod
@@ -127,14 +127,15 @@ class PipelinesApi(object):
                 external_lib_objects.append(lib_object)
         return local_lib_objects, external_lib_objects
 
-    def _upload_local_libraries(self, local_lib_objects):
-        remote_lib_objects = [LibraryObject(llo.lib_type, self._get_hashed_path(llo.path))
-                              for llo in local_lib_objects]
-
+    def _upload_local_libraries(self, spec_dir, local_lib_objects):
+        relative_local_lib_objects = [LibraryObject(llo.lib_type, os.path.join(spec_dir, llo.path))
+                                      for llo in local_lib_objects]
+        remote_lib_objects = [LibraryObject(rllo.lib_type, self._get_hashed_path(rllo.path))
+                              for rllo in relative_local_lib_objects]
         transformed_remote_lib_objects = [LibraryObject(rlo.lib_type, DbfsPath(rlo.path))
                                           for rlo in remote_lib_objects]
         upload_files = [llo_tuple for llo_tuple in
-                        zip(local_lib_objects, transformed_remote_lib_objects)
+                        zip(relative_local_lib_objects, transformed_remote_lib_objects)
                         if not self.dbfs_client.file_exists(llo_tuple[1].path)]
 
         for llo, rlo in upload_files:

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -91,9 +91,10 @@ def deploy_cli(api_client, spec_arg, spec, allow_duplicate_names, pipeline_id):
         raise ValueError('The spec should be provided either by an option or argument')
     src = spec_arg if bool(spec_arg) else spec
     spec_obj = _read_spec(src)
+    spec_dir = os.path.dirname(src)
     if not pipeline_id and 'id' not in spec_obj:
         try:
-            response = PipelinesApi(api_client).create(spec_obj, allow_duplicate_names)
+            response = PipelinesApi(api_client).create(spec_obj, spec_dir, allow_duplicate_names)
         except requests.exceptions.HTTPError as e:
             _handle_duplicate_name_exception(spec_obj, e)
 
@@ -116,7 +117,7 @@ def deploy_cli(api_client, spec_arg, spec, allow_duplicate_names, pipeline_id):
         _validate_pipeline_id(spec_obj['id'])
 
         try:
-            PipelinesApi(api_client).deploy(spec_obj, allow_duplicate_names)
+            PipelinesApi(api_client).deploy(spec_obj, spec_dir, allow_duplicate_names)
         except requests.exceptions.HTTPError as e:
             _handle_duplicate_name_exception(spec_obj, e)
         click.echo("Successfully deployed pipeline: {}".format(

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -293,7 +293,9 @@ def _handle_duplicate_name_exception(spec, exception):
 
     if error_code == 'RESOURCE_CONFLICT':
         raise ValueError("Pipeline with name '{}' already exists. ".format(spec['name']) +
-                         "You can use the --allow-duplicate-names option to skip this check.")
+                         "If you are updating an existing pipeline, provide the pipeline " +
+                         "id using --pipeline-id. Otherwise, " +
+                         "you can use the --allow-duplicate-names option to skip this check. ")
     raise exception
 
 

--- a/tests/pipelines/test_cli.py
+++ b/tests/pipelines/test_cli.py
@@ -273,19 +273,19 @@ def test_allow_duplicate_names_flag(pipelines_api_mock, tmpdir):
         f.write(DEPLOY_SPEC_NO_ID)
     runner = CliRunner()
     runner.invoke(cli.deploy_cli, [path])
-    assert pipelines_api_mock.create.call_args_list[0][0][1] is False
+    assert pipelines_api_mock.create.call_args_list[0][0][2] is False
 
     runner.invoke(cli.deploy_cli, [path, "--allow-duplicate-names"])
-    assert pipelines_api_mock.create.call_args_list[1][0][1] is True
+    assert pipelines_api_mock.create.call_args_list[1][0][2] is True
 
     with open(path, 'w') as f:
         f.write(DEPLOY_SPEC)
 
     runner.invoke(cli.deploy_cli, [path])
-    assert pipelines_api_mock.deploy.call_args_list[0][0][1] is False
+    assert pipelines_api_mock.deploy.call_args_list[0][0][2] is False
 
     runner.invoke(cli.deploy_cli, [path, "--allow-duplicate-names"])
-    assert pipelines_api_mock.deploy.call_args_list[1][0][1] is True
+    assert pipelines_api_mock.deploy.call_args_list[1][0][2] is True
 
 
 @provide_conf


### PR DESCRIPTION
The library paths in a pipeline spec should be interpreted as relative to the spec's location, and not relative to the current working directory. 