### PR TITLE
Add .databrickscfg to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist
 build
 databricks_cli.egg-info
 .idea
+.databrickscfg
 *.iml
 venv
 .DS_Store


### PR DESCRIPTION
To prevent developers pushing their configuration file by mistake and leaking tokens, hostnames this PR adds `.databrickscfg` to `.gitignore`. Such leak is a possible scenario if developer starts docker from the root of the project in which case .databrickscfg file will be created in the root directory of the repository. 