### PR TITLE
Fix broken test test_debug_option in tests/configure/test_config.py

### DIFF
--- a/tests/configure/test_config.py
+++ b/tests/configure/test_config.py
@@ -38,7 +38,7 @@ from tests.utils import provide_conf
 def test_debug_option():
     # Test that context object debug_mode property changes with --debug flag fed.
     @click.command()
-    @click.option('--debug-fed')
+    @click.option('--debug-fed', type=bool)
     @config.debug_option
     def test_debug(debug_fed): # noqa
         ctx = click.get_current_context()


### PR DESCRIPTION
There was a breaking change in click which caused our tests in master to break.