### PR TITLE
Point out invalid characters during pipeline_id vaidation

### DIFF
--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -278,8 +278,11 @@ def _validate_pipeline_id(pipeline_id):
     """
     if pipeline_id is None or len(pipeline_id) == 0:
         error_and_quit(u'Empty pipeline id provided')
-    if not set(pipeline_id) <= PIPELINE_ID_PERMITTED_CHARACTERS:
-        message = u'Pipeline id {} has invalid character(s)\n'.format(pipeline_id)
+        pipeline_id_chars = set(pipeline_id)
+    if not pipeline_id_chars <= PIPELINE_ID_PERMITTED_CHARACTERS:
+        invalid_characters = pipeline_id_chars - PIPELINE_ID_PERMITTED_CHARACTERS
+        message = u'Pipeline id {} contains the following invalid character(s) {}\n'.format(pipeline_id,
+                                                                                            invalid_characters)
         message += u'Valid characters are: _ - a-z A-Z 0-9'
         error_and_quit(message)
 


### PR DESCRIPTION
It would be useful for clients to get information not only regarding their `pipeline_id`'s being malformed, but also in what way. This PR gives the users back the actual characters that need to be removed so that the `pipeline_id` satisfies the validation requirements.