### PR TITLE
[ES-190688] make jobs_api_version optional in DatabricksConfig

### DIFF
--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -267,7 +267,7 @@ class ProfileConfigProvider(DatabricksConfigProvider):
 
 
 class DatabricksConfig(object):
-    def __init__(self, host, username, password, token, insecure, jobs_api_version):  # noqa
+    def __init__(self, host, username, password, token, insecure, jobs_api_version=None):  # noqa
         self.host = host
         self.username = username
         self.password = password

--- a/databricks_cli/jobs/cli.py
+++ b/databricks_cli/jobs/cli.py
@@ -230,7 +230,8 @@ def run_now_cli(api_client, job_id, jar_params, notebook_params, python_params,
     python_params = json_loads(python_params) if python_params else None
     spark_submit_params = json_loads(spark_submit_params) if spark_submit_params else None
     res = JobsApi(api_client).run_now(
-        job_id, jar_params_json, notebook_params_json, python_params, spark_submit_params, version=version)
+        job_id, jar_params_json, notebook_params_json, python_params, spark_submit_params,
+        version=version)
     click.echo(pretty_format(res))
 
 

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -233,3 +233,16 @@ def test_get_config_override_custom():
 def test_get_config_bad_override():
     with pytest.raises(Exception):
         set_config_provider("NotAConfigProvider")
+
+
+def test_mlflow_config_constructor():
+    """
+    Verifies the public constructor of DatabricksConfig. No variables should be added here.
+    All new properties should be optional.
+    """
+    conf = DatabricksConfig(TEST_HOST, TEST_USER, TEST_PASSWORD, TEST_TOKEN, False)
+    assert conf.host == TEST_HOST
+    assert conf.username == TEST_USER
+    assert conf.password == TEST_PASSWORD
+    assert conf.token == TEST_TOKEN
+    assert conf.insecure == False

--- a/tests/configure/test_provider.py
+++ b/tests/configure/test_provider.py
@@ -245,4 +245,4 @@ def test_mlflow_config_constructor():
     assert conf.username == TEST_USER
     assert conf.password == TEST_PASSWORD
     assert conf.token == TEST_TOKEN
-    assert conf.insecure == False
+    assert conf.insecure is False


### PR DESCRIPTION
make `jobs_api_version` optional in the constructor of `DatabricksConfig`. This was breaking MLFlow which directly uses `DatabricksConfig`.