### PR TITLE
Better support for authentication with AAD tokens

### DIFF
--- a/databricks_cli/cli.py
+++ b/databricks_cli/cli.py
@@ -23,7 +23,7 @@
 
 import click
 
-from databricks_cli.configure.config import profile_option, debug_option
+from databricks_cli.configure.config import profile_option, debug_option, azure_cli_auth_option
 from databricks_cli.libraries.cli import libraries_group
 from databricks_cli.version import print_version_callback, version
 from databricks_cli.utils import CONTEXT_SETTINGS
@@ -48,6 +48,7 @@ from databricks_cli.repos.cli import repos_group
               expose_value=False, is_eager=True, help=version)
 @debug_option
 @profile_option
+@azure_cli_auth_option
 def cli():
     pass
 

--- a/databricks_cli/cli.py
+++ b/databricks_cli/cli.py
@@ -23,7 +23,7 @@
 
 import click
 
-from databricks_cli.configure.config import profile_option, debug_option, azure_cli_auth_option, azure_msi_auth_option
+from databricks_cli.configure.config import profile_option, debug_option
 from databricks_cli.libraries.cli import libraries_group
 from databricks_cli.version import print_version_callback, version
 from databricks_cli.utils import CONTEXT_SETTINGS
@@ -48,8 +48,6 @@ from databricks_cli.repos.cli import repos_group
               expose_value=False, is_eager=True, help=version)
 @debug_option
 @profile_option
-@azure_cli_auth_option
-@azure_msi_auth_option
 def cli():
     pass
 

--- a/databricks_cli/cli.py
+++ b/databricks_cli/cli.py
@@ -23,7 +23,7 @@
 
 import click
 
-from databricks_cli.configure.config import profile_option, debug_option, azure_cli_auth_option
+from databricks_cli.configure.config import profile_option, debug_option, azure_cli_auth_option, azure_msi_auth_option
 from databricks_cli.libraries.cli import libraries_group
 from databricks_cli.version import print_version_callback, version
 from databricks_cli.utils import CONTEXT_SETTINGS
@@ -49,6 +49,7 @@ from databricks_cli.repos.cli import repos_group
 @debug_option
 @profile_option
 @azure_cli_auth_option
+@azure_msi_auth_option
 def cli():
     pass
 

--- a/databricks_cli/click_types.py
+++ b/databricks_cli/click_types.py
@@ -171,19 +171,6 @@ class ContextObject(object):
     def get_profile(self):
         return self._profile
 
-    @property
-    def use_azure_cli_auth(self):
-        return self._azure_cli_auth
-
-    def set_azure_cli_auth(self, use_azure_cli = False):
-        self._azure_cli_auth = use_azure_cli
-
-    @property
-    def use_azure_msi_auth(self):
-        return self._azure_msi_auth
-
-    def set_azure_msi_auth(self, use_azure_msi = False):
-        self._azure_msi_auth = use_azure_msi
 
 class RequiredOptions(Option):
     def __init__(self, *args, **kwargs):

--- a/databricks_cli/click_types.py
+++ b/databricks_cli/click_types.py
@@ -136,6 +136,7 @@ class ContextObject(object):
     def __init__(self):
         self._profile = None
         self._debug = False
+        self._azure_cli_auth = False
 
     def set_debug(self, debug=False):
         self._debug = debug
@@ -168,6 +169,13 @@ class ContextObject(object):
 
     def get_profile(self):
         return self._profile
+
+    @property
+    def use_azure_cli_auth(self):
+        return self._azure_cli_auth
+
+    def set_azure_cli_auth(self, use_azure_cli = False):
+        self._azure_cli_auth = use_azure_cli
 
 
 class RequiredOptions(Option):

--- a/databricks_cli/click_types.py
+++ b/databricks_cli/click_types.py
@@ -137,6 +137,7 @@ class ContextObject(object):
         self._profile = None
         self._debug = False
         self._azure_cli_auth = False
+        self._azure_msi_auth = False
 
     def set_debug(self, debug=False):
         self._debug = debug
@@ -177,6 +178,12 @@ class ContextObject(object):
     def set_azure_cli_auth(self, use_azure_cli = False):
         self._azure_cli_auth = use_azure_cli
 
+    @property
+    def use_azure_msi_auth(self):
+        return self._azure_msi_auth
+
+    def set_azure_msi_auth(self, use_azure_msi = False):
+        self._azure_msi_auth = use_azure_msi
 
 class RequiredOptions(Option):
     def __init__(self, *args, **kwargs):

--- a/databricks_cli/configure/cli.py
+++ b/databricks_cli/configure/cli.py
@@ -30,7 +30,7 @@ from click import ParamType
 
 from databricks_cli.configure.config import profile_option, get_profile_from_context, debug_option
 from databricks_cli.configure.provider import DatabricksConfig, update_and_persist_config, \
-    ProfileConfigProvider
+    ProfileConfigProvider, AZURE_ENVIRONMENTS
 from databricks_cli.sdk.version import API_VERSION, API_VERSIONS
 from databricks_cli.utils import CONTEXT_SETTINGS
 
@@ -38,6 +38,11 @@ PROMPT_HOST = 'Databricks Host (should begin with https://)'
 PROMPT_USERNAME = 'Username'
 PROMPT_PASSWORD = 'Password'  # NOQA
 PROMPT_TOKEN = 'Token'  # NOQA
+PROMPT_CLIENT_ID = 'Client ID'
+PROMPT_CLIENT_SECRET = 'Client secret'
+PROMPT_TENANT_ID = 'Tenant ID'
+PROMPT_AZURE_RESOURCE_ID = 'Azure Resource ID (optional)'
+PROMPT_AZURE_ENVIRONMENT = 'Azure Environment name'
 ENV_AAD_TOKEN = 'DATABRICKS_AAD_TOKEN'
 
 
@@ -88,6 +93,60 @@ def _configure_cli_aad_token(profile, insecure, host, jobs_api_version):
     update_and_persist_config(profile, new_config)
 
 
+def _configure_cli_azure_cli_auth(profile, insecure, host, jobs_api_version):
+    config = ProfileConfigProvider(profile).get_config() or DatabricksConfig.empty()
+
+    if not host:
+        host = click.prompt(PROMPT_HOST, default=config.host, type=_DbfsHost())
+
+    new_config = DatabricksConfig.using_azure_cli_auth(host, insecure, jobs_api_version)
+    update_and_persist_config(profile, new_config)
+
+
+def _configure_cli_azure_msi_auth(profile, insecure, host, jobs_api_version):
+    config = ProfileConfigProvider(profile).get_config() or DatabricksConfig.empty()
+
+    if not host:
+        host = click.prompt(PROMPT_HOST, default=config.host, type=_DbfsHost())
+
+    if 'DATABRICKS_AZURE_RESOURCE_ID' in os.environ:
+        azure_resource_id = os.environ['DATABRICKS_AZURE_RESOURCE_ID']
+    else:
+        azure_resource_id = click.prompt(PROMPT_AZURE_RESOURCE_ID, default=(config.azure_resource_id or ""))
+    if azure_resource_id == "":
+        azure_resource_id = None
+
+    new_config = DatabricksConfig.using_azure_msi_auth(host, azure_resource_id, insecure, jobs_api_version)
+    update_and_persist_config(profile, new_config)
+
+
+def _configure_cli_azure_spn_auth(profile, insecure, host, jobs_api_version):
+    config = ProfileConfigProvider(profile).get_config() or DatabricksConfig.empty()
+    if config.azure_client_secret:
+        default_password = '*' * len(config.azure_client_secret)
+    else:
+        default_password = None
+
+    if not host:
+        host = click.prompt(PROMPT_HOST, default=config.host, type=_DbfsHost())
+
+    azure_client_id = click.prompt(PROMPT_CLIENT_ID, default=config.azure_client_id)
+    azure_client_secret = click.prompt(PROMPT_CLIENT_SECRET, default=default_password, hide_input=True,
+                                       confirmation_prompt=True)
+    azure_tenant_id = click.prompt(PROMPT_TENANT_ID, default=config.azure_tenant_id)
+    azure_resource_id = click.prompt(PROMPT_AZURE_RESOURCE_ID, default=(config.azure_resource_id or ""))
+    azure_env = click.prompt(PROMPT_AZURE_ENVIRONMENT, default=(config.azure_environment or 'public'),
+                             type=click.Choice(AZURE_ENVIRONMENTS.keys()))
+    if azure_resource_id == "":
+        azure_resource_id = None
+    if azure_client_secret == default_password:
+        azure_client_secret = config.azure_client_secret
+    new_config = DatabricksConfig.for_azure_spn(host, azure_client_id, azure_client_secret, azure_tenant_id,
+                                                azure_resource_id, azure_env,
+                                                insecure=insecure, jobs_api_version=jobs_api_version)
+    update_and_persist_config(profile, new_config)
+
+
 def _configure_cli_password(profile, insecure, host, jobs_api_version):
     config = ProfileConfigProvider(profile).get_config() or DatabricksConfig.empty()
     if config.password:
@@ -117,13 +176,20 @@ def _configure_cli_password(profile, insecure, host, jobs_api_version):
 @click.option('--host', show_default=True, default=None,
               help='Host to connect to.')
 @click.option('--aad-token', show_default=True, is_flag=True, default=False)
+@click.option('--azure-cli-auth', show_default=True, is_flag=True, default=False,
+              help='Obtain AAD tokens via Azure CLI')
+@click.option('--azure-msi-auth', show_default=True, is_flag=True, default=False,
+              help='Obtain AAD tokens from Azure Managed Identity')
+@click.option('--azure-spn-auth', show_default=True, is_flag=True, default=False,
+              help='Obtain AAD tokens for Azure Service Principal')
 @click.option('--insecure', show_default=True, is_flag=True, default=None,
               help='DO NOT verify SSL Certificates')
 @click.option('--jobs-api-version', show_default=True, default=API_VERSION,
               type=click.Choice(API_VERSIONS), help='API version to use for jobs.')
 @debug_option
 @profile_option
-def configure_cli(token, aad_token, azure_cli, insecure, host, token_file, jobs_api_version):
+def configure_cli(token, aad_token, azure_cli_auth, azure_msi_auth, azure_spn_auth,
+                  insecure, host, token_file, jobs_api_version):
     """
     Configures host, authentication, and jobs-api version for the CLI.
     """
@@ -139,6 +205,15 @@ def configure_cli(token, aad_token, azure_cli, insecure, host, token_file, jobs_
     elif aad_token:
         _configure_cli_aad_token(profile=profile, insecure=insecure_str, host=host,
                                  jobs_api_version=jobs_api_version)
+    elif azure_cli_auth:
+        _configure_cli_azure_cli_auth(profile=profile, insecure=insecure_str, host=host,
+                                      jobs_api_version=jobs_api_version)
+    elif azure_msi_auth:
+        _configure_cli_azure_msi_auth(profile=profile, insecure=insecure_str, host=host,
+                                      jobs_api_version=jobs_api_version)
+    elif azure_spn_auth:
+        _configure_cli_azure_spn_auth(profile=profile, insecure=insecure_str, host=host,
+                                      jobs_api_version=jobs_api_version)
     else:
         _configure_cli_password(profile=profile, insecure=insecure_str, host=host,
                                 jobs_api_version=jobs_api_version)

--- a/databricks_cli/configure/cli.py
+++ b/databricks_cli/configure/cli.py
@@ -22,6 +22,7 @@
 # limitations under the License.
 import io
 import os
+import subprocess
 from os import path
 
 import click
@@ -74,9 +75,8 @@ def _configure_cli_aad_token(profile, insecure, host, jobs_api_version):
                    'AAD Token and run again.\n' % ENV_AAD_TOKEN)
         click.echo('Commands to run to get your AAD token:\n'
                    '\t az login\n'
-                   '\t token_response=$(az account get-access-token '
-                   '--resource 2ff814a6-3304-4ab8-85cb-cd0e6f879c1d)\n'
-                   '\t export %s=$(jq .accessToken -r <<< "$token_response")\n' % ENV_AAD_TOKEN
+                   '\t export %s=$(az account get-access-token -o tsv --query accessToken'
+                   '--resource 2ff814a6-3304-4ab8-85cb-cd0e6f879c1d)\n' % ENV_AAD_TOKEN
                    )
         return
 
@@ -123,7 +123,7 @@ def _configure_cli_password(profile, insecure, host, jobs_api_version):
               type=click.Choice(API_VERSIONS), help='API version to use for jobs.')
 @debug_option
 @profile_option
-def configure_cli(token, aad_token, insecure, host, token_file, jobs_api_version):
+def configure_cli(token, aad_token, azure_cli, insecure, host, token_file, jobs_api_version):
     """
     Configures host, authentication, and jobs-api version for the CLI.
     """

--- a/databricks_cli/configure/cli.py
+++ b/databricks_cli/configure/cli.py
@@ -22,7 +22,6 @@
 # limitations under the License.
 import io
 import os
-import subprocess
 from os import path
 
 import click
@@ -38,12 +37,12 @@ PROMPT_HOST = 'Databricks Host (should begin with https://)'
 PROMPT_USERNAME = 'Username'
 PROMPT_PASSWORD = 'Password'  # NOQA
 PROMPT_TOKEN = 'Token'  # NOQA
-PROMPT_CLIENT_ID = 'Client ID'
-PROMPT_CLIENT_SECRET = 'Client secret'
-PROMPT_TENANT_ID = 'Tenant ID'
+PROMPT_CLIENT_ID = 'Azure Client ID'
+PROMPT_CLIENT_SECRET = 'Azure Client secret'  # NOQA
+PROMPT_TENANT_ID = 'Azure Tenant ID'
 PROMPT_AZURE_RESOURCE_ID = 'Azure Resource ID (optional)'
 PROMPT_AZURE_ENVIRONMENT = 'Azure Environment name'
-ENV_AAD_TOKEN = 'DATABRICKS_AAD_TOKEN'
+ENV_AAD_TOKEN = 'DATABRICKS_AAD_TOKEN'  # NOQA
 
 
 def _configure_cli_token_file(profile, token_file, host, insecure, jobs_api_version):
@@ -112,11 +111,13 @@ def _configure_cli_azure_msi_auth(profile, insecure, host, jobs_api_version):
     if 'DATABRICKS_AZURE_RESOURCE_ID' in os.environ:
         azure_resource_id = os.environ['DATABRICKS_AZURE_RESOURCE_ID']
     else:
-        azure_resource_id = click.prompt(PROMPT_AZURE_RESOURCE_ID, default=(config.azure_resource_id or ""))
+        azure_resource_id = click.prompt(PROMPT_AZURE_RESOURCE_ID,
+                                         default=(config.azure_resource_id or ""))
     if azure_resource_id == "":
         azure_resource_id = None
 
-    new_config = DatabricksConfig.using_azure_msi_auth(host, azure_resource_id, insecure, jobs_api_version)
+    new_config = DatabricksConfig.using_azure_msi_auth(host, azure_resource_id,
+                                                       insecure, jobs_api_version)
     update_and_persist_config(profile, new_config)
 
 
@@ -131,19 +132,22 @@ def _configure_cli_azure_spn_auth(profile, insecure, host, jobs_api_version):
         host = click.prompt(PROMPT_HOST, default=config.host, type=_DbfsHost())
 
     azure_client_id = click.prompt(PROMPT_CLIENT_ID, default=config.azure_client_id)
-    azure_client_secret = click.prompt(PROMPT_CLIENT_SECRET, default=default_password, hide_input=True,
-                                       confirmation_prompt=True)
+    azure_client_secret = click.prompt(PROMPT_CLIENT_SECRET, default=default_password,
+                                       hide_input=True, confirmation_prompt=True)
     azure_tenant_id = click.prompt(PROMPT_TENANT_ID, default=config.azure_tenant_id)
-    azure_resource_id = click.prompt(PROMPT_AZURE_RESOURCE_ID, default=(config.azure_resource_id or ""))
-    azure_env = click.prompt(PROMPT_AZURE_ENVIRONMENT, default=(config.azure_environment or 'public'),
+    azure_resource_id = click.prompt(PROMPT_AZURE_RESOURCE_ID,
+                                     default=(config.azure_resource_id or ""))
+    azure_env = click.prompt(PROMPT_AZURE_ENVIRONMENT,
+                             default=(config.azure_environment or 'public'),
                              type=click.Choice(AZURE_ENVIRONMENTS.keys()))
     if azure_resource_id == "":
         azure_resource_id = None
     if azure_client_secret == default_password:
         azure_client_secret = config.azure_client_secret
-    new_config = DatabricksConfig.for_azure_spn(host, azure_client_id, azure_client_secret, azure_tenant_id,
-                                                azure_resource_id, azure_env,
-                                                insecure=insecure, jobs_api_version=jobs_api_version)
+    new_config = DatabricksConfig.for_azure_spn(host, azure_client_id, azure_client_secret,
+                                                azure_tenant_id, azure_resource_id, azure_env,
+                                                insecure=insecure,
+                                                jobs_api_version=jobs_api_version)
     update_and_persist_config(profile, new_config)
 
 

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -42,7 +42,7 @@ USE_AZURE_MSI_AUTH = 'azure-msi-auth'
 AZURE_ENVIRONMENT = 'azure-environment'
 AZURE_TENANT_ID = 'azure-tenant-id'
 AZURE_CLIENT_ID = 'azure-client-id'
-AZURE_CLIENT_SECRET = 'azure-client-secret'
+AZURE_CLIENT_SECRET = 'azure-client-secret'  # NOQA
 AZURE_DATABRICKS_RESOURCE_ID = 'azure-resource-id'
 AZURE_DEFAULT_AD_ENDPOINT = "https://login.microsoftonline.com"
 DEFAULT_SECTION = 'DEFAULT'
@@ -118,14 +118,16 @@ def update_and_persist_config(profile, databricks_config):
     if databricks_config.use_azure_msi_auth:
         _set_option(raw_config, profile, USE_AZURE_MSI_AUTH, "true")
         if databricks_config.azure_resource_id:
-            _set_option(raw_config, profile, AZURE_DATABRICKS_RESOURCE_ID, databricks_config.azure_resource_id)
+            _set_option(raw_config, profile, AZURE_DATABRICKS_RESOURCE_ID,
+                        databricks_config.azure_resource_id)
     if databricks_config.azure_client_id and databricks_config.azure_client_secret \
             and databricks_config.azure_tenant_id:
         _set_option(raw_config, profile, AZURE_CLIENT_ID, databricks_config.azure_client_id)
         _set_option(raw_config, profile, AZURE_CLIENT_SECRET, databricks_config.azure_client_secret)
         _set_option(raw_config, profile, AZURE_TENANT_ID, databricks_config.azure_tenant_id)
         if databricks_config.azure_resource_id:
-            _set_option(raw_config, profile, AZURE_DATABRICKS_RESOURCE_ID, databricks_config.azure_resource_id)
+            _set_option(raw_config, profile, AZURE_DATABRICKS_RESOURCE_ID,
+                        databricks_config.azure_resource_id)
         if databricks_config.azure_environment:
             _set_option(raw_config, profile, AZURE_ENVIRONMENT, databricks_config.azure_environment)
 
@@ -278,9 +280,10 @@ class EnvironmentVariableConfigProvider(DatabricksConfigProvider):
         azure_tenant_id = os.environ.get('ARM_TENANT_ID')
         azure_environment = os.environ.get('ARM_ENVIRONMENT')
         azure_resource_id = os.environ.get('DATABRICKS_AZURE_RESOURCE_ID')
-        config = DatabricksConfig(host, username, password, token, insecure, jobs_api_version, use_azure_cli_auth,
-                                  use_azure_msi_auth, azure_environment, azure_tenant_id, azure_client_id,
-                                  azure_client_secret, azure_resource_id)
+        config = DatabricksConfig(host, username, password, token, insecure, jobs_api_version,
+                                  use_azure_cli_auth, use_azure_msi_auth, azure_environment,
+                                  azure_tenant_id, azure_client_id, azure_client_secret,
+                                  azure_resource_id)
         if config.is_valid:
             return config
         return None
@@ -299,16 +302,19 @@ class ProfileConfigProvider(DatabricksConfigProvider):
         token = _get_option_if_exists(raw_config, self.profile, TOKEN)
         insecure = _get_option_if_exists(raw_config, self.profile, INSECURE)
         jobs_api_version = _get_option_if_exists(raw_config, self.profile, JOBS_API_VERSION)
-        use_azure_cli_auth = _get_option_if_exists(raw_config, self.profile, USE_AZURE_CLI_AUTH)
-        use_azure_msi_auth = _get_option_if_exists(raw_config, self.profile, USE_AZURE_MSI_AUTH)
-        azure_environment = _get_option_if_exists(raw_config, self.profile, AZURE_ENVIRONMENT)
-        azure_tenant_id = _get_option_if_exists(raw_config, self.profile, AZURE_TENANT_ID)
-        azure_client_id = _get_option_if_exists(raw_config, self.profile, AZURE_CLIENT_ID)
-        azure_client_secret = _get_option_if_exists(raw_config, self.profile, AZURE_CLIENT_SECRET)
-        azure_resource_id = _get_option_if_exists(raw_config, self.profile, AZURE_DATABRICKS_RESOURCE_ID)
-        config = DatabricksConfig(host, username, password, token, insecure, jobs_api_version, use_azure_cli_auth,
-                                  use_azure_msi_auth, azure_environment, azure_tenant_id, azure_client_id,
-                                  azure_client_secret, azure_resource_id)
+        config = DatabricksConfig(host, username, password, token, insecure, jobs_api_version,
+                                  _get_option_if_exists(raw_config, self.profile,
+                                                        USE_AZURE_CLI_AUTH),
+                                  _get_option_if_exists(raw_config, self.profile,
+                                                        USE_AZURE_MSI_AUTH),
+                                  _get_option_if_exists(raw_config, self.profile,
+                                                        AZURE_ENVIRONMENT),
+                                  _get_option_if_exists(raw_config, self.profile, AZURE_TENANT_ID),
+                                  _get_option_if_exists(raw_config, self.profile, AZURE_CLIENT_ID),
+                                  _get_option_if_exists(raw_config, self.profile,
+                                                        AZURE_CLIENT_SECRET),
+                                  _get_option_if_exists(raw_config, self.profile,
+                                                        AZURE_DATABRICKS_RESOURCE_ID))
         if config.is_valid:
             return config
         return None
@@ -339,12 +345,13 @@ class DatabricksConfig(object):
 
     @classmethod
     def using_azure_cli_auth(cls, host, insecure=None, jobs_api_version=None):
-        return DatabricksConfig(host, None, None, None, insecure, jobs_api_version, use_azure_cli_auth=True)
+        return DatabricksConfig(host, None, None, None, insecure, jobs_api_version,
+                                use_azure_cli_auth=True)
 
     @classmethod
     def using_azure_msi_auth(cls, host, resource_id=None, insecure=None, jobs_api_version=None):
-        return DatabricksConfig(host, None, None, None, insecure, jobs_api_version, use_azure_msi_auth=True,
-                                azure_resource_id=resource_id)
+        return DatabricksConfig(host, None, None, None, insecure, jobs_api_version,
+                                use_azure_msi_auth=True, azure_resource_id=resource_id)
 
     @classmethod
     def from_password(cls, host, username, password, insecure=None, jobs_api_version=None):
@@ -372,20 +379,21 @@ class DatabricksConfig(object):
 
     @property
     def is_valid_with_azure_cli_auth(self):
-        return self.host is not None and self.use_azure_cli_auth is not None and self.use_azure_cli_auth
+        return self.host is not None and self.use_azure_cli_auth is not None \
+            and self.use_azure_cli_auth
 
     @property
     def is_valid_with_azure_msi_auth(self):
-        return self.host is not None and self.use_azure_msi_auth is not None and self.use_azure_msi_auth
+        return self.host is not None and self.use_azure_msi_auth is not None \
+            and self.use_azure_msi_auth
 
     @property
     def is_valid_with_azure_client_auth(self):
         return self.host is not None and self.azure_tenant_id is not None \
-               and self.azure_client_id is not None and self.azure_client_secret is not None
+            and self.azure_client_id is not None and self.azure_client_secret is not None
 
     @property
     def is_valid(self):
         return self.is_valid_with_azure_cli_auth or self.is_valid_with_azure_msi_auth \
-               or self.is_valid_with_azure_client_auth \
-               or self.is_valid_with_token or self.is_valid_with_password
-
+            or self.is_valid_with_azure_client_auth \
+            or self.is_valid_with_token or self.is_valid_with_password

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -108,12 +108,9 @@ def update_and_persist_config(profile, databricks_config):
     raw_config = _fetch_from_fs()
     _create_section_if_absent(raw_config, profile)
     _set_option(raw_config, profile, HOST, databricks_config.host)
-    if databricks_config.username:
-        _set_option(raw_config, profile, USERNAME, databricks_config.username)
-    if databricks_config.password:
-        _set_option(raw_config, profile, PASSWORD, databricks_config.password)
-    if databricks_config.token:
-        _set_option(raw_config, profile, TOKEN, databricks_config.token)
+    _set_option(raw_config, profile, USERNAME, databricks_config.username)
+    _set_option(raw_config, profile, PASSWORD, databricks_config.password)
+    _set_option(raw_config, profile, TOKEN, databricks_config.token)
     _set_option(raw_config, profile, INSECURE, databricks_config.insecure)
     _set_option(raw_config, profile, JOBS_API_VERSION, databricks_config.jobs_api_version)
     if databricks_config.use_azure_cli_auth:

--- a/databricks_cli/configure/provider.py
+++ b/databricks_cli/configure/provider.py
@@ -38,7 +38,19 @@ TOKEN = 'token'
 INSECURE = 'insecure'
 JOBS_API_VERSION = 'jobs-api-version'
 USE_AZURE_CLI_AUTH = 'azure-cli-auth'
+USE_AZURE_MSI_AUTH = 'azure-msi-auth'
+AZURE_ENVIRONMENT = 'azure-environment'
+AZURE_TENANT_ID = 'azure-tenant-id'
+AZURE_CLIENT_ID = 'azure-client-id'
+AZURE_CLIENT_SECRET = 'azure-client-secret'
+AZURE_DATABRICKS_RESOURCE_ID = 'azure-resource-id'
+AZURE_DEFAULT_AD_ENDPOINT = "https://login.microsoftonline.com"
 DEFAULT_SECTION = 'DEFAULT'
+AZURE_ENVIRONMENTS = {
+    'china': 'https://login.chinacloudapi.cn',
+    'usgovernment': 'https://login.microsoftonline.us',
+    'german': 'https://login.microsoftonline.de',
+}
 
 # User-provided override for the DatabricksConfigProvider
 _config_provider = None
@@ -244,7 +256,15 @@ class EnvironmentVariableConfigProvider(DatabricksConfigProvider):
         insecure = os.environ.get('DATABRICKS_INSECURE')
         jobs_api_version = os.environ.get('DATABRICKS_JOBS_API_VERSION')
         use_azure_cli_auth = os.environ.get('DATABRICKS_USE_AZURE_CLI_AUTH') is not None
-        config = DatabricksConfig(host, username, password, token, insecure, jobs_api_version, use_azure_cli_auth)
+        use_azure_msi_auth = os.environ.get('ARM_USE_MSI') is not None
+        azure_client_id = os.environ.get('ARM_CLIENT_ID')
+        azure_client_secret = os.environ.get('ARM_CLIENT_SECRET')
+        azure_tenant_id = os.environ.get('ARM_TENANT_ID')
+        azure_environment = os.environ.get('ARM_ENVIRONMENT')
+        azure_resource_id = os.environ.get('DATABRICKS_AZURE_RESOURCE_ID')
+        config = DatabricksConfig(host, username, password, token, insecure, jobs_api_version, use_azure_cli_auth,
+                                  use_azure_msi_auth, azure_environment, azure_tenant_id, azure_client_id,
+                                  azure_client_secret, azure_resource_id)
         if config.is_valid:
             return config
         return None
@@ -264,7 +284,15 @@ class ProfileConfigProvider(DatabricksConfigProvider):
         insecure = _get_option_if_exists(raw_config, self.profile, INSECURE)
         jobs_api_version = _get_option_if_exists(raw_config, self.profile, JOBS_API_VERSION)
         use_azure_cli_auth = _get_option_if_exists(raw_config, self.profile, USE_AZURE_CLI_AUTH)
-        config = DatabricksConfig(host, username, password, token, insecure, jobs_api_version, use_azure_cli_auth)
+        use_azure_msi_auth = _get_option_if_exists(raw_config, self.profile, USE_AZURE_MSI_AUTH)
+        azure_environment = _get_option_if_exists(raw_config, self.profile, AZURE_ENVIRONMENT)
+        azure_tenant_id = _get_option_if_exists(raw_config, self.profile, AZURE_TENANT_ID)
+        azure_client_id = _get_option_if_exists(raw_config, self.profile, AZURE_CLIENT_ID)
+        azure_client_secret = _get_option_if_exists(raw_config, self.profile, AZURE_CLIENT_SECRET)
+        azure_resource_id = _get_option_if_exists(raw_config, self.profile, AZURE_DATABRICKS_RESOURCE_ID)
+        config = DatabricksConfig(host, username, password, token, insecure, jobs_api_version, use_azure_cli_auth,
+                                  use_azure_msi_auth, azure_environment, azure_tenant_id, azure_client_id,
+                                  azure_client_secret, azure_resource_id)
         if config.is_valid:
             return config
         return None
@@ -272,7 +300,9 @@ class ProfileConfigProvider(DatabricksConfigProvider):
 
 class DatabricksConfig(object):
     def __init__(self, host, username, password, token, insecure,
-                 jobs_api_version=None, use_azure_cli_auth=False):  # noqa
+                 jobs_api_version=None, use_azure_cli_auth=False,
+                 use_azure_msi_auth=None, azure_environment=None, azure_tenant_id=None,
+                 azure_client_id=None, azure_client_secret=None, azure_resource_id=None):  # noqa
         self.host = host
         self.username = username
         self.password = password
@@ -280,6 +310,13 @@ class DatabricksConfig(object):
         self.insecure = insecure
         self.jobs_api_version = jobs_api_version
         self.use_azure_cli_auth = use_azure_cli_auth
+        self.use_azure_msi_auth = use_azure_msi_auth
+        self.azure_environment = AZURE_ENVIRONMENTS.get((azure_environment or "").lower(),
+                                                        AZURE_DEFAULT_AD_ENDPOINT)
+        self.azure_tenant_id = azure_tenant_id
+        self.azure_client_id = azure_client_id
+        self.azure_client_secret = azure_client_secret
+        self.azure_resource_id = azure_resource_id
 
     @classmethod
     def from_token(cls, host, token, insecure=None, jobs_api_version=None):
@@ -307,9 +344,20 @@ class DatabricksConfig(object):
 
     @property
     def is_valid_with_azure_cli_auth(self):
-        return self.host is not None and self.use_azure_cli_auth is not None
+        return self.host is not None and self.use_azure_cli_auth is not None and self.use_azure_cli_auth
+
+    @property
+    def is_valid_with_azure_msi_auth(self):
+        return self.host is not None and self.use_azure_msi_auth is not None and self.use_azure_msi_auth
+
+    @property
+    def is_valid_with_azure_client_auth(self):
+        return self.host is not None and self.azure_tenant_id is not None \
+               and self.azure_client_id is not None and self.azure_client_secret is not None
 
     @property
     def is_valid(self):
-        return self.is_valid_with_token or self.is_valid_with_password or self.is_valid_with_azure_cli_auth
+        return self.is_valid_with_azure_cli_auth or self.is_valid_with_azure_msi_auth \
+               or self.is_valid_with_azure_client_auth \
+               or self.is_valid_with_token or self.is_valid_with_password
 

--- a/tox-requirements-2.txt
+++ b/tox-requirements-2.txt
@@ -11,3 +11,4 @@ pytest-cov==2.5.1
 docutils==0.14
 codecov
 requests_mock==1.5.2
+pylint-django==2.4.4


### PR DESCRIPTION
This PR adds support for authentication using AAD tokens that could be obtained by different means:

* using azure-cli's `az account get-access-token`
* Service Principal - with client ID & secret
* azure managed identity assigned to Azure VM

Support for AAD tokens enables use of databricks-cli in organizations that don't permit PATs