### PR TITLE
[ES-244938] Fix pipelines list pagination

### DIFF
--- a/databricks_cli/pipelines/api.py
+++ b/databricks_cli/pipelines/api.py
@@ -63,11 +63,11 @@ class PipelinesApi(object):
         def call(page_token=None, max_results=None, order_by=None):
             _data = {}
             if page_token:
-                _data["pagination.page_token"] = page_token
+                _data["page_token"] = page_token
             if max_results:
-                _data["pagination.max_results"] = max_results
+                _data["max_results"] = max_results
             if order_by:
-                _data["pagination.order_by"] = order_by
+                _data["order_by"] = order_by
 
             return self.client.client.perform_query(
                 'GET', '/pipelines', data=_data, headers=headers)
@@ -75,8 +75,8 @@ class PipelinesApi(object):
         response = call()
         pipelines = response.get("statuses", [])
 
-        while "next_page_token" in response.get("pagination", {}):
-            response = call(page_token=response["pagination"]["next_page_token"])
+        while "next_page_token" in response:
+            response = call(page_token=response["next_page_token"])
             pipelines.extend(response.get("statuses", []))
         return pipelines
 

--- a/tests/pipelines/test_api.py
+++ b/tests/pipelines/test_api.py
@@ -330,7 +330,7 @@ def test_library_object_serialization_deserialization():
 
 def test_list(pipelines_api):
     client_mock = pipelines_api.client.client.perform_query
-    client_mock.side_effect = [{"statuses": [], "pagination": {}}]
+    client_mock.side_effect = [{"statuses": []}]
 
     pipelines_api.list()
     assert client_mock.call_count == 1
@@ -341,13 +341,13 @@ def test_list(pipelines_api):
 
 def test_list_with_page_token(pipelines_api):
     client_mock = pipelines_api.client.client.perform_query
-    client_mock.side_effect = [{"statuses": [], "pagination": {"next_page_token": "a"}},
-                               {"statuses": [], "pagination": {}}]
+    client_mock.side_effect = [{"statuses": [], "next_page_token": "a"},
+                               {"statuses": []}]
 
     pipelines_api.list()
     assert client_mock.call_count == 2
     client_mock.assert_called_with('GET', '/pipelines',
-                                   data={"pagination.page_token": "a"}, headers=None)
+                                   data={"page_token": "a"}, headers=None)
 
 
 def test_list_with_paginated_responses(pipelines_api):
@@ -363,7 +363,7 @@ def test_list_with_paginated_responses(pipelines_api):
                        'cluster_id': '1024-160918-tees475',
                        'name': 'Wiki Pipeline',
                        'health': 'HEALTHY'}],
-         'pagination': {'next_page_token': 'page2'}
+         'next_page_token': 'page2'
          },
         {'statuses': [{'pipeline_id': '3',
                        'state': 'RUNNING',
@@ -375,9 +375,8 @@ def test_list_with_paginated_responses(pipelines_api):
                        'cluster_id': '1023-093505-corm4',
                        'name': 'Jira Automation Staging',
                        'health': 'HEALTHY'}],
-         'pagination': {
-             'next_page_token': 'page3',
-             'prev_page_token': 'page2'}
+         'next_page_token': 'page3',
+         'prev_page_token': 'page2'
          },
         {'statuses': [{'pipeline_id': '5',
                        'state': 'FAILED',
@@ -389,9 +388,8 @@ def test_list_with_paginated_responses(pipelines_api):
                        'cluster_id': '1027-061023-clasp844',
                        'name': 'Pipeline Demo NYCTaxi',
                        'health': 'HEALTHY'}],
-         'pagination': {
-             'prev_page_token': 'page3'}
-         }
+         'prev_page_token': 'page3'
+        }
     ]
 
     pipelines = pipelines_api.list()
@@ -403,10 +401,10 @@ def test_list_with_paginated_responses(pipelines_api):
                       data={},
                       headers=None),
             mock.call('GET', '/pipelines',
-                      data={"pagination.page_token": "page2"},
+                      data={"page_token": "page2"},
                       headers=None),
             mock.call('GET', '/pipelines',
-                      data={"pagination.page_token": "page3"},
+                      data={"page_token": "page3"},
                       headers=None)
         ], any_order=False)
 
@@ -426,7 +424,7 @@ def test_list_with_no_returned_pipelines(pipelines_api):
                        'cluster_id': '1024-160918-tees475',
                        'name': 'Wiki Pipeline',
                        'health': 'HEALTHY'}],
-         'pagination': {'next_page_token': 'page2'}
+          'next_page_token': 'page2'
          },
         {}
     ]
@@ -440,7 +438,7 @@ def test_list_with_no_returned_pipelines(pipelines_api):
                       data={},
                       headers=None),
             mock.call('GET', '/pipelines',
-                      data={"pagination.page_token": "page2"},
+                      data={"page_token": "page2"},
                       headers=None)
         ], any_order=False)
 

--- a/tests/pipelines/test_api.py
+++ b/tests/pipelines/test_api.py
@@ -389,7 +389,7 @@ def test_list_with_paginated_responses(pipelines_api):
                        'name': 'Pipeline Demo NYCTaxi',
                        'health': 'HEALTHY'}],
          'prev_page_token': 'page3'
-        }
+         }
     ]
 
     pipelines = pipelines_api.list()
@@ -424,7 +424,7 @@ def test_list_with_no_returned_pipelines(pipelines_api):
                        'cluster_id': '1024-160918-tees475',
                        'name': 'Wiki Pipeline',
                        'health': 'HEALTHY'}],
-          'next_page_token': 'page2'
+         'next_page_token': 'page2'
          },
         {}
     ]


### PR DESCRIPTION
The `pagination` request and response property is now deprecated. Instead, the nested properties from inside `pagination` have been elevated to the top level (where `pagination` used to reside). This PR fixes the pagination-related property access so that more than one page of pipelines are returned.

### Before

```bash
$ databricks pipelines list | jq '. | length'              
25
```

### After

```bash
$ databricks pipelines list | jq '. | length'              
311
```