### PR TITLE
Pin pylint-django to avoid py2 issue

### DIFF
--- a/tox-requirements-2.txt
+++ b/tox-requirements-2.txt
@@ -1,6 +1,8 @@
 # Test reqs
 prospector[with_pyroma]==0.12.7
 pylint==1.8.2
+# Pin pylint-django for py2 compatibility 
+pylint-django<2.5.0
 pep8-naming==0.5.0
 pytest==3.8.1
 mock==2.0.0


### PR DESCRIPTION
**Motivation**

This PR address the build failure for py27 happening in https://app.travis-ci.com/github/databricks/databricks-cli/jobs/556278785

The issue can be repro'd by  `pip install -r tox-requirements-2.txt`


**Testing Done**

Verified  `pip install -r tox-requirements-2.txt` succeeds after this change but fails before