### PR TITLE
[Jobs] Add `--python-named-params` to databricks jobs run-now

### DIFF
--- a/databricks_cli/jobs/api.py
+++ b/databricks_cli/jobs/api.py
@@ -57,6 +57,5 @@ class JobsApi(object):
 
     def _list_jobs_by_name(self, name, headers=None):
         jobs = self.list_jobs(headers=headers)['jobs']
-        result = list(
-            filter(lambda job: job['settings']['name'] == name, jobs))
+        result = list(filter(lambda job: job['settings']['name'] == name, jobs))
         return result

--- a/databricks_cli/jobs/api.py
+++ b/databricks_cli/jobs/api.py
@@ -49,12 +49,14 @@ class JobsApi(object):
         return self.client.client.perform_query('POST', '/jobs/reset', data=json, headers=headers,
                                                 version=version)
 
-    def run_now(self, job_id, jar_params, notebook_params, python_params, spark_submit_params,
-                headers=None, version=None):
+    def run_now(self, job_id, jar_params, notebook_params, python_params, python_named_params,
+                spark_submit_params, headers=None, version=None):
         return self.client.run_now(job_id, jar_params, notebook_params, python_params,
-                                   spark_submit_params, headers=headers, version=version)
+                                   python_named_params, spark_submit_params, headers=headers,
+                                   version=version)
 
     def _list_jobs_by_name(self, name, headers=None):
         jobs = self.list_jobs(headers=headers)['jobs']
-        result = list(filter(lambda job: job['settings']['name'] == name, jobs))
+        result = list(
+            filter(lambda job: job['settings']['name'] == name, jobs))
         return result

--- a/databricks_cli/jobs/cli.py
+++ b/databricks_cli/jobs/cli.py
@@ -207,6 +207,9 @@ def get_cli(api_client, job_id, version):
                    'i.e. {"name": "john doe", "age": 35}')
 @click.option('--python-params', default=None, type=JsonClickType(),
               help='JSON string specifying an array of parameters. i.e. ["param1", "param2"]')
+@click.option('--python-named-params', default=None, type=JsonClickType(),
+              help='JSON string specifying a map of key-value pairs. '
+                   'i.e. {"name": "john doe", "age": 35}')
 @click.option('--spark-submit-params', default=None, type=JsonClickType(),
               help='JSON string specifying an array of parameters. i.e. '
                    '["--class", "org.apache.spark.examples.SparkPi"]')
@@ -217,7 +220,7 @@ def get_cli(api_client, job_id, version):
 @eat_exceptions
 @provide_api_client
 def run_now_cli(api_client, job_id, jar_params, notebook_params, python_params,
-                spark_submit_params, version):
+                python_named_params, spark_submit_params, version):
     """
     Runs a job with optional per-run parameters.
 
@@ -228,10 +231,11 @@ def run_now_cli(api_client, job_id, jar_params, notebook_params, python_params,
     jar_params_json = json_loads(jar_params) if jar_params else None
     notebook_params_json = json_loads(notebook_params) if notebook_params else None
     python_params = json_loads(python_params) if python_params else None
+    python_named_params = json_loads(python_named_params) if python_named_params else None
     spark_submit_params = json_loads(spark_submit_params) if spark_submit_params else None
     res = JobsApi(api_client).run_now(
-        job_id, jar_params_json, notebook_params_json, python_params, spark_submit_params,
-        version=version)
+        job_id, jar_params_json, notebook_params_json, python_params,
+        python_named_params, spark_submit_params, version=version)
     click.echo(pretty_format(res))
 
 

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -43,15 +43,13 @@ class JobsService(object):
         if new_cluster is not None:
             _data['new_cluster'] = new_cluster
             if not isinstance(new_cluster, dict):
-                raise TypeError(
-                    'Expected databricks.NewCluster() or dict for field new_cluster')
+                raise TypeError('Expected databricks.NewCluster() or dict for field new_cluster')
         if libraries is not None:
             _data['libraries'] = libraries
         if email_notifications is not None:
             _data['email_notifications'] = email_notifications
             if not isinstance(email_notifications, dict):
-                raise TypeError(
-                    'Expected databricks.JobEmailNotifications() or dict for field email_notifications')
+                raise TypeError('Expected databricks.JobEmailNotifications() or dict for field email_notifications')
         if timeout_seconds is not None:
             _data['timeout_seconds'] = timeout_seconds
         if max_retries is not None:
@@ -63,28 +61,23 @@ class JobsService(object):
         if schedule is not None:
             _data['schedule'] = schedule
             if not isinstance(schedule, dict):
-                raise TypeError(
-                    'Expected databricks.CronSchedule() or dict for field schedule')
+                raise TypeError('Expected databricks.CronSchedule() or dict for field schedule')
         if notebook_task is not None:
             _data['notebook_task'] = notebook_task
             if not isinstance(notebook_task, dict):
-                raise TypeError(
-                    'Expected databricks.NotebookTask() or dict for field notebook_task')
+                raise TypeError('Expected databricks.NotebookTask() or dict for field notebook_task')
         if spark_jar_task is not None:
             _data['spark_jar_task'] = spark_jar_task
             if not isinstance(spark_jar_task, dict):
-                raise TypeError(
-                    'Expected databricks.SparkJarTask() or dict for field spark_jar_task')
+                raise TypeError('Expected databricks.SparkJarTask() or dict for field spark_jar_task')
         if spark_python_task is not None:
             _data['spark_python_task'] = spark_python_task
             if not isinstance(spark_python_task, dict):
-                raise TypeError(
-                    'Expected databricks.SparkPythonTask() or dict for field spark_python_task')
+                raise TypeError('Expected databricks.SparkPythonTask() or dict for field spark_python_task')
         if spark_submit_task is not None:
             _data['spark_submit_task'] = spark_submit_task
             if not isinstance(spark_submit_task, dict):
-                raise TypeError(
-                    'Expected databricks.SparkSubmitTask() or dict for field spark_submit_task')
+                raise TypeError('Expected databricks.SparkSubmitTask() or dict for field spark_submit_task')
         if max_concurrent_runs is not None:
             _data['max_concurrent_runs'] = max_concurrent_runs
         if tasks is not None:
@@ -102,30 +95,25 @@ class JobsService(object):
         if new_cluster is not None:
             _data['new_cluster'] = new_cluster
             if not isinstance(new_cluster, dict):
-                raise TypeError(
-                    'Expected databricks.NewCluster() or dict for field new_cluster')
+                raise TypeError('Expected databricks.NewCluster() or dict for field new_cluster')
         if libraries is not None:
             _data['libraries'] = libraries
         if notebook_task is not None:
             _data['notebook_task'] = notebook_task
             if not isinstance(notebook_task, dict):
-                raise TypeError(
-                    'Expected databricks.NotebookTask() or dict for field notebook_task')
+                raise TypeError('Expected databricks.NotebookTask() or dict for field notebook_task')
         if spark_jar_task is not None:
             _data['spark_jar_task'] = spark_jar_task
             if not isinstance(spark_jar_task, dict):
-                raise TypeError(
-                    'Expected databricks.SparkJarTask() or dict for field spark_jar_task')
+                raise TypeError('Expected databricks.SparkJarTask() or dict for field spark_jar_task')
         if spark_python_task is not None:
             _data['spark_python_task'] = spark_python_task
             if not isinstance(spark_python_task, dict):
-                raise TypeError(
-                    'Expected databricks.SparkPythonTask() or dict for field spark_python_task')
+                raise TypeError('Expected databricks.SparkPythonTask() or dict for field spark_python_task')
         if spark_submit_task is not None:
             _data['spark_submit_task'] = spark_submit_task
             if not isinstance(spark_submit_task, dict):
-                raise TypeError(
-                    'Expected databricks.SparkSubmitTask() or dict for field spark_submit_task')
+                raise TypeError('Expected databricks.SparkSubmitTask() or dict for field spark_submit_task')
         if timeout_seconds is not None:
             _data['timeout_seconds'] = timeout_seconds
         if tasks is not None:
@@ -139,8 +127,7 @@ class JobsService(object):
         if new_settings is not None:
             _data['new_settings'] = new_settings
             if not isinstance(new_settings, dict):
-                raise TypeError(
-                    'Expected databricks.JobSettings() or dict for field new_settings')
+                raise TypeError('Expected databricks.JobSettings() or dict for field new_settings')
         return self.client.perform_query('POST', '/jobs/reset', data=_data, headers=headers, version=version)
 
     def delete_job(self, job_id, headers=None, version=None):
@@ -255,8 +242,7 @@ class ClusterService(object):
         if autoscale is not None:
             _data['autoscale'] = autoscale
             if not isinstance(autoscale, dict):
-                raise TypeError(
-                    'Expected databricks.AutoScale() or dict for field autoscale')
+                raise TypeError('Expected databricks.AutoScale() or dict for field autoscale')
         if cluster_name is not None:
             _data['cluster_name'] = cluster_name
         if spark_version is not None:
@@ -266,8 +252,7 @@ class ClusterService(object):
         if aws_attributes is not None:
             _data['aws_attributes'] = aws_attributes
             if not isinstance(aws_attributes, dict):
-                raise TypeError(
-                    'Expected databricks.AwsAttributes() or dict for field aws_attributes')
+                raise TypeError('Expected databricks.AwsAttributes() or dict for field aws_attributes')
         if node_type_id is not None:
             _data['node_type_id'] = node_type_id
         if driver_node_type_id is not None:
@@ -279,8 +264,7 @@ class ClusterService(object):
         if cluster_log_conf is not None:
             _data['cluster_log_conf'] = cluster_log_conf
             if not isinstance(cluster_log_conf, dict):
-                raise TypeError(
-                    'Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
+                raise TypeError('Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
         if spark_env_vars is not None:
             _data['spark_env_vars'] = spark_env_vars
         if autotermination_minutes is not None:
@@ -331,8 +315,7 @@ class ClusterService(object):
         if autoscale is not None:
             _data['autoscale'] = autoscale
             if not isinstance(autoscale, dict):
-                raise TypeError(
-                    'Expected databricks.AutoScale() or dict for field autoscale')
+                raise TypeError('Expected databricks.AutoScale() or dict for field autoscale')
         return self.client.perform_query('POST', '/clusters/resize', data=_data, headers=headers)
 
     def edit_cluster(self, cluster_id, num_workers=None, autoscale=None, cluster_name=None,
@@ -349,8 +332,7 @@ class ClusterService(object):
         if autoscale is not None:
             _data['autoscale'] = autoscale
             if not isinstance(autoscale, dict):
-                raise TypeError(
-                    'Expected databricks.AutoScale() or dict for field autoscale')
+                raise TypeError('Expected databricks.AutoScale() or dict for field autoscale')
         if cluster_name is not None:
             _data['cluster_name'] = cluster_name
         if spark_version is not None:
@@ -360,8 +342,7 @@ class ClusterService(object):
         if aws_attributes is not None:
             _data['aws_attributes'] = aws_attributes
             if not isinstance(aws_attributes, dict):
-                raise TypeError(
-                    'Expected databricks.AwsAttributes() or dict for field aws_attributes')
+                raise TypeError('Expected databricks.AwsAttributes() or dict for field aws_attributes')
         if node_type_id is not None:
             _data['node_type_id'] = node_type_id
         if driver_node_type_id is not None:
@@ -373,8 +354,7 @@ class ClusterService(object):
         if cluster_log_conf is not None:
             _data['cluster_log_conf'] = cluster_log_conf
             if not isinstance(cluster_log_conf, dict):
-                raise TypeError(
-                    'Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
+                raise TypeError('Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
         if spark_env_vars is not None:
             _data['spark_env_vars'] = spark_env_vars
         if autotermination_minutes is not None:
@@ -569,8 +549,7 @@ class DbfsService(object):
         if src_path is not None:
             headers = {'Content-Type': None}
             filename = os.path.basename(src_path)
-            _files = {'file': (filename, open(
-                src_path, 'rb'), 'multipart/form-data')}
+            _files = {'file': (filename, open(src_path, 'rb'), 'multipart/form-data')}
         return self.client.perform_query('POST', '/dbfs/put', data=_data, headers=headers, files=_files)
 
     def put_test(self, path, contents=None, overwrite=None, headers=None, src_path=None):
@@ -585,8 +564,7 @@ class DbfsService(object):
         if src_path is not None:
             headers = {'Content-Type': None}
             filename = os.path.basename(src_path)
-            _files = {'file': (filename, open(
-                src_path, 'rb'), 'multipart/form-data')}
+            _files = {'file': (filename, open(src_path, 'rb'), 'multipart/form-data')}
         return self.client.perform_query('POST', '/dbfs/put', data=_data, headers=headers, files=_files)
 
     def mkdirs(self, path, headers=None):
@@ -922,8 +900,7 @@ class InstancePoolService(object):
         if aws_attributes is not None:
             _data['aws_attributes'] = aws_attributes
             if not isinstance(aws_attributes, dict):
-                raise TypeError(
-                    'Expected databricks.InstancePoolAwsAttributes() or dict for field aws_attributes')
+                raise TypeError('Expected databricks.InstancePoolAwsAttributes() or dict for field aws_attributes')
         if node_type_id is not None:
             _data['node_type_id'] = node_type_id
         if custom_tags is not None:
@@ -935,8 +912,7 @@ class InstancePoolService(object):
         if disk_spec is not None:
             _data['disk_spec'] = disk_spec
             if not isinstance(disk_spec, dict):
-                raise TypeError(
-                    'Expected databricks.DiskSpec() or dict for field disk_spec')
+                raise TypeError('Expected databricks.DiskSpec() or dict for field disk_spec')
         if preloaded_spark_versions is not None:
             _data['preloaded_spark_versions'] = preloaded_spark_versions
         return self.client.perform_query('POST', '/instance-pools/create', data=_data, headers=headers)
@@ -963,8 +939,7 @@ class InstancePoolService(object):
         if aws_attributes is not None:
             _data['aws_attributes'] = aws_attributes
             if not isinstance(aws_attributes, dict):
-                raise TypeError(
-                    'Expected databricks.InstancePoolAwsAttributes() or dict for field aws_attributes')
+                raise TypeError('Expected databricks.InstancePoolAwsAttributes() or dict for field aws_attributes')
         if node_type_id is not None:
             _data['node_type_id'] = node_type_id
         if custom_tags is not None:
@@ -976,8 +951,7 @@ class InstancePoolService(object):
         if disk_spec is not None:
             _data['disk_spec'] = disk_spec
             if not isinstance(disk_spec, dict):
-                raise TypeError(
-                    'Expected databricks.DiskSpec() or dict for field disk_spec')
+                raise TypeError('Expected databricks.DiskSpec() or dict for field disk_spec')
         if preloaded_spark_versions is not None:
             _data['preloaded_spark_versions'] = preloaded_spark_versions
         return self.client.perform_query('POST', '/instance-pools/edit', data=_data, headers=headers)
@@ -1016,13 +990,11 @@ class DeltaPipelinesService(object):
         if trigger is not None:
             _data['trigger'] = trigger
             if not isinstance(trigger, dict):
-                raise TypeError(
-                    'Expected databricks.PipelineTrigger() or dict for field trigger')
+                raise TypeError('Expected databricks.PipelineTrigger() or dict for field trigger')
         if filters is not None:
             _data['filters'] = filters
             if not isinstance(filters, dict):
-                raise TypeError(
-                    'Expected databricks.Filters() or dict for field filters')
+                raise TypeError('Expected databricks.Filters() or dict for field filters')
         if allow_duplicate_names is not None:
             _data['allow_duplicate_names'] = allow_duplicate_names
         return self.client.perform_query('POST', '/pipelines', data=_data, headers=headers)
@@ -1046,13 +1018,11 @@ class DeltaPipelinesService(object):
         if trigger is not None:
             _data['trigger'] = trigger
             if not isinstance(trigger, dict):
-                raise TypeError(
-                    'Expected databricks.PipelineTrigger() or dict for field trigger')
+                raise TypeError('Expected databricks.PipelineTrigger() or dict for field trigger')
         if filters is not None:
             _data['filters'] = filters
             if not isinstance(filters, dict):
-                raise TypeError(
-                    'Expected databricks.Filters() or dict for field filters')
+                raise TypeError('Expected databricks.Filters() or dict for field filters')
         if allow_duplicate_names is not None:
             _data['allow_duplicate_names'] = allow_duplicate_names
         return self.client.perform_query('PUT', '/pipelines/{pipeline_id}'.format(pipeline_id=pipeline_id), data=_data,
@@ -1075,8 +1045,7 @@ class DeltaPipelinesService(object):
         if pagination is not None:
             _data['pagination'] = pagination
             if not isinstance(pagination, dict):
-                raise TypeError(
-                    'Expected databricks.Pagination() or dict for field pagination')
+                raise TypeError('Expected databricks.Pagination() or dict for field pagination')
         return self.client.perform_query('GET', '/pipelines', data=_data, headers=headers)
 
     def reset(self, pipeline_id=None, headers=None):
@@ -1096,8 +1065,6 @@ class DeltaPipelinesService(object):
 
         return self.client.perform_query('POST', '/pipelines/{pipeline_id}/stop'.format(pipeline_id=pipeline_id),
                                          data=_data, headers=headers)
-
-
 class ReposService(object):
     def __init__(self, client):
         self.client = client
@@ -1112,9 +1079,9 @@ class ReposService(object):
 
     def get_repo(self, id, headers=None):
         _data = {}
-
+    
         return self.client.perform_query('GET', '/repos/{id}'.format(id=id), data=_data, headers=headers)
-
+    
     def update_repo(self, id, branch=None, tag=None, headers=None):
         _data = {}
         if branch is not None:
@@ -1122,7 +1089,7 @@ class ReposService(object):
         if tag is not None:
             _data['tag'] = tag
         return self.client.perform_query('PATCH', '/repos/{id}'.format(id=id), data=_data, headers=headers)
-
+    
     def create_repo(self, url, provider, path=None, headers=None):
         _data = {}
         if url is not None:
@@ -1135,5 +1102,5 @@ class ReposService(object):
 
     def delete_repo(self, id, headers=None):
         _data = {}
-
+    
         return self.client.perform_query('DELETE', '/repos/{id}'.format(id=id), data=_data, headers=headers)

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -43,13 +43,15 @@ class JobsService(object):
         if new_cluster is not None:
             _data['new_cluster'] = new_cluster
             if not isinstance(new_cluster, dict):
-                raise TypeError('Expected databricks.NewCluster() or dict for field new_cluster')
+                raise TypeError(
+                    'Expected databricks.NewCluster() or dict for field new_cluster')
         if libraries is not None:
             _data['libraries'] = libraries
         if email_notifications is not None:
             _data['email_notifications'] = email_notifications
             if not isinstance(email_notifications, dict):
-                raise TypeError('Expected databricks.JobEmailNotifications() or dict for field email_notifications')
+                raise TypeError(
+                    'Expected databricks.JobEmailNotifications() or dict for field email_notifications')
         if timeout_seconds is not None:
             _data['timeout_seconds'] = timeout_seconds
         if max_retries is not None:
@@ -61,23 +63,28 @@ class JobsService(object):
         if schedule is not None:
             _data['schedule'] = schedule
             if not isinstance(schedule, dict):
-                raise TypeError('Expected databricks.CronSchedule() or dict for field schedule')
+                raise TypeError(
+                    'Expected databricks.CronSchedule() or dict for field schedule')
         if notebook_task is not None:
             _data['notebook_task'] = notebook_task
             if not isinstance(notebook_task, dict):
-                raise TypeError('Expected databricks.NotebookTask() or dict for field notebook_task')
+                raise TypeError(
+                    'Expected databricks.NotebookTask() or dict for field notebook_task')
         if spark_jar_task is not None:
             _data['spark_jar_task'] = spark_jar_task
             if not isinstance(spark_jar_task, dict):
-                raise TypeError('Expected databricks.SparkJarTask() or dict for field spark_jar_task')
+                raise TypeError(
+                    'Expected databricks.SparkJarTask() or dict for field spark_jar_task')
         if spark_python_task is not None:
             _data['spark_python_task'] = spark_python_task
             if not isinstance(spark_python_task, dict):
-                raise TypeError('Expected databricks.SparkPythonTask() or dict for field spark_python_task')
+                raise TypeError(
+                    'Expected databricks.SparkPythonTask() or dict for field spark_python_task')
         if spark_submit_task is not None:
             _data['spark_submit_task'] = spark_submit_task
             if not isinstance(spark_submit_task, dict):
-                raise TypeError('Expected databricks.SparkSubmitTask() or dict for field spark_submit_task')
+                raise TypeError(
+                    'Expected databricks.SparkSubmitTask() or dict for field spark_submit_task')
         if max_concurrent_runs is not None:
             _data['max_concurrent_runs'] = max_concurrent_runs
         if tasks is not None:
@@ -95,25 +102,30 @@ class JobsService(object):
         if new_cluster is not None:
             _data['new_cluster'] = new_cluster
             if not isinstance(new_cluster, dict):
-                raise TypeError('Expected databricks.NewCluster() or dict for field new_cluster')
+                raise TypeError(
+                    'Expected databricks.NewCluster() or dict for field new_cluster')
         if libraries is not None:
             _data['libraries'] = libraries
         if notebook_task is not None:
             _data['notebook_task'] = notebook_task
             if not isinstance(notebook_task, dict):
-                raise TypeError('Expected databricks.NotebookTask() or dict for field notebook_task')
+                raise TypeError(
+                    'Expected databricks.NotebookTask() or dict for field notebook_task')
         if spark_jar_task is not None:
             _data['spark_jar_task'] = spark_jar_task
             if not isinstance(spark_jar_task, dict):
-                raise TypeError('Expected databricks.SparkJarTask() or dict for field spark_jar_task')
+                raise TypeError(
+                    'Expected databricks.SparkJarTask() or dict for field spark_jar_task')
         if spark_python_task is not None:
             _data['spark_python_task'] = spark_python_task
             if not isinstance(spark_python_task, dict):
-                raise TypeError('Expected databricks.SparkPythonTask() or dict for field spark_python_task')
+                raise TypeError(
+                    'Expected databricks.SparkPythonTask() or dict for field spark_python_task')
         if spark_submit_task is not None:
             _data['spark_submit_task'] = spark_submit_task
             if not isinstance(spark_submit_task, dict):
-                raise TypeError('Expected databricks.SparkSubmitTask() or dict for field spark_submit_task')
+                raise TypeError(
+                    'Expected databricks.SparkSubmitTask() or dict for field spark_submit_task')
         if timeout_seconds is not None:
             _data['timeout_seconds'] = timeout_seconds
         if tasks is not None:
@@ -127,7 +139,8 @@ class JobsService(object):
         if new_settings is not None:
             _data['new_settings'] = new_settings
             if not isinstance(new_settings, dict):
-                raise TypeError('Expected databricks.JobSettings() or dict for field new_settings')
+                raise TypeError(
+                    'Expected databricks.JobSettings() or dict for field new_settings')
         return self.client.perform_query('POST', '/jobs/reset', data=_data, headers=headers, version=version)
 
     def delete_job(self, job_id, headers=None, version=None):
@@ -156,7 +169,7 @@ class JobsService(object):
 
         return self.client.perform_query('GET', '/jobs/list', data=_data, headers=headers, version=version)
 
-    def run_now(self, job_id=None, jar_params=None, notebook_params=None, python_params=None,
+    def run_now(self, job_id=None, jar_params=None, notebook_params=None, python_params=None, python_named_params=None,
                 spark_submit_params=None, headers=None, version=None):
         _data = {}
         if job_id is not None:
@@ -167,6 +180,8 @@ class JobsService(object):
             _data['notebook_params'] = notebook_params
         if python_params is not None:
             _data['python_params'] = python_params
+        if python_named_params is not None:
+            _data['python_named_params'] = python_named_params
         if spark_submit_params is not None:
             _data['spark_submit_params'] = spark_submit_params
         return self.client.perform_query('POST', '/jobs/run-now', data=_data, headers=headers, version=version)
@@ -240,7 +255,8 @@ class ClusterService(object):
         if autoscale is not None:
             _data['autoscale'] = autoscale
             if not isinstance(autoscale, dict):
-                raise TypeError('Expected databricks.AutoScale() or dict for field autoscale')
+                raise TypeError(
+                    'Expected databricks.AutoScale() or dict for field autoscale')
         if cluster_name is not None:
             _data['cluster_name'] = cluster_name
         if spark_version is not None:
@@ -250,7 +266,8 @@ class ClusterService(object):
         if aws_attributes is not None:
             _data['aws_attributes'] = aws_attributes
             if not isinstance(aws_attributes, dict):
-                raise TypeError('Expected databricks.AwsAttributes() or dict for field aws_attributes')
+                raise TypeError(
+                    'Expected databricks.AwsAttributes() or dict for field aws_attributes')
         if node_type_id is not None:
             _data['node_type_id'] = node_type_id
         if driver_node_type_id is not None:
@@ -262,7 +279,8 @@ class ClusterService(object):
         if cluster_log_conf is not None:
             _data['cluster_log_conf'] = cluster_log_conf
             if not isinstance(cluster_log_conf, dict):
-                raise TypeError('Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
+                raise TypeError(
+                    'Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
         if spark_env_vars is not None:
             _data['spark_env_vars'] = spark_env_vars
         if autotermination_minutes is not None:
@@ -313,7 +331,8 @@ class ClusterService(object):
         if autoscale is not None:
             _data['autoscale'] = autoscale
             if not isinstance(autoscale, dict):
-                raise TypeError('Expected databricks.AutoScale() or dict for field autoscale')
+                raise TypeError(
+                    'Expected databricks.AutoScale() or dict for field autoscale')
         return self.client.perform_query('POST', '/clusters/resize', data=_data, headers=headers)
 
     def edit_cluster(self, cluster_id, num_workers=None, autoscale=None, cluster_name=None,
@@ -330,7 +349,8 @@ class ClusterService(object):
         if autoscale is not None:
             _data['autoscale'] = autoscale
             if not isinstance(autoscale, dict):
-                raise TypeError('Expected databricks.AutoScale() or dict for field autoscale')
+                raise TypeError(
+                    'Expected databricks.AutoScale() or dict for field autoscale')
         if cluster_name is not None:
             _data['cluster_name'] = cluster_name
         if spark_version is not None:
@@ -340,7 +360,8 @@ class ClusterService(object):
         if aws_attributes is not None:
             _data['aws_attributes'] = aws_attributes
             if not isinstance(aws_attributes, dict):
-                raise TypeError('Expected databricks.AwsAttributes() or dict for field aws_attributes')
+                raise TypeError(
+                    'Expected databricks.AwsAttributes() or dict for field aws_attributes')
         if node_type_id is not None:
             _data['node_type_id'] = node_type_id
         if driver_node_type_id is not None:
@@ -352,7 +373,8 @@ class ClusterService(object):
         if cluster_log_conf is not None:
             _data['cluster_log_conf'] = cluster_log_conf
             if not isinstance(cluster_log_conf, dict):
-                raise TypeError('Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
+                raise TypeError(
+                    'Expected databricks.ClusterLogConf() or dict for field cluster_log_conf')
         if spark_env_vars is not None:
             _data['spark_env_vars'] = spark_env_vars
         if autotermination_minutes is not None:
@@ -547,7 +569,8 @@ class DbfsService(object):
         if src_path is not None:
             headers = {'Content-Type': None}
             filename = os.path.basename(src_path)
-            _files = {'file': (filename, open(src_path, 'rb'), 'multipart/form-data')}
+            _files = {'file': (filename, open(
+                src_path, 'rb'), 'multipart/form-data')}
         return self.client.perform_query('POST', '/dbfs/put', data=_data, headers=headers, files=_files)
 
     def put_test(self, path, contents=None, overwrite=None, headers=None, src_path=None):
@@ -562,7 +585,8 @@ class DbfsService(object):
         if src_path is not None:
             headers = {'Content-Type': None}
             filename = os.path.basename(src_path)
-            _files = {'file': (filename, open(src_path, 'rb'), 'multipart/form-data')}
+            _files = {'file': (filename, open(
+                src_path, 'rb'), 'multipart/form-data')}
         return self.client.perform_query('POST', '/dbfs/put', data=_data, headers=headers, files=_files)
 
     def mkdirs(self, path, headers=None):
@@ -898,7 +922,8 @@ class InstancePoolService(object):
         if aws_attributes is not None:
             _data['aws_attributes'] = aws_attributes
             if not isinstance(aws_attributes, dict):
-                raise TypeError('Expected databricks.InstancePoolAwsAttributes() or dict for field aws_attributes')
+                raise TypeError(
+                    'Expected databricks.InstancePoolAwsAttributes() or dict for field aws_attributes')
         if node_type_id is not None:
             _data['node_type_id'] = node_type_id
         if custom_tags is not None:
@@ -910,7 +935,8 @@ class InstancePoolService(object):
         if disk_spec is not None:
             _data['disk_spec'] = disk_spec
             if not isinstance(disk_spec, dict):
-                raise TypeError('Expected databricks.DiskSpec() or dict for field disk_spec')
+                raise TypeError(
+                    'Expected databricks.DiskSpec() or dict for field disk_spec')
         if preloaded_spark_versions is not None:
             _data['preloaded_spark_versions'] = preloaded_spark_versions
         return self.client.perform_query('POST', '/instance-pools/create', data=_data, headers=headers)
@@ -937,7 +963,8 @@ class InstancePoolService(object):
         if aws_attributes is not None:
             _data['aws_attributes'] = aws_attributes
             if not isinstance(aws_attributes, dict):
-                raise TypeError('Expected databricks.InstancePoolAwsAttributes() or dict for field aws_attributes')
+                raise TypeError(
+                    'Expected databricks.InstancePoolAwsAttributes() or dict for field aws_attributes')
         if node_type_id is not None:
             _data['node_type_id'] = node_type_id
         if custom_tags is not None:
@@ -949,7 +976,8 @@ class InstancePoolService(object):
         if disk_spec is not None:
             _data['disk_spec'] = disk_spec
             if not isinstance(disk_spec, dict):
-                raise TypeError('Expected databricks.DiskSpec() or dict for field disk_spec')
+                raise TypeError(
+                    'Expected databricks.DiskSpec() or dict for field disk_spec')
         if preloaded_spark_versions is not None:
             _data['preloaded_spark_versions'] = preloaded_spark_versions
         return self.client.perform_query('POST', '/instance-pools/edit', data=_data, headers=headers)
@@ -988,11 +1016,13 @@ class DeltaPipelinesService(object):
         if trigger is not None:
             _data['trigger'] = trigger
             if not isinstance(trigger, dict):
-                raise TypeError('Expected databricks.PipelineTrigger() or dict for field trigger')
+                raise TypeError(
+                    'Expected databricks.PipelineTrigger() or dict for field trigger')
         if filters is not None:
             _data['filters'] = filters
             if not isinstance(filters, dict):
-                raise TypeError('Expected databricks.Filters() or dict for field filters')
+                raise TypeError(
+                    'Expected databricks.Filters() or dict for field filters')
         if allow_duplicate_names is not None:
             _data['allow_duplicate_names'] = allow_duplicate_names
         return self.client.perform_query('POST', '/pipelines', data=_data, headers=headers)
@@ -1016,11 +1046,13 @@ class DeltaPipelinesService(object):
         if trigger is not None:
             _data['trigger'] = trigger
             if not isinstance(trigger, dict):
-                raise TypeError('Expected databricks.PipelineTrigger() or dict for field trigger')
+                raise TypeError(
+                    'Expected databricks.PipelineTrigger() or dict for field trigger')
         if filters is not None:
             _data['filters'] = filters
             if not isinstance(filters, dict):
-                raise TypeError('Expected databricks.Filters() or dict for field filters')
+                raise TypeError(
+                    'Expected databricks.Filters() or dict for field filters')
         if allow_duplicate_names is not None:
             _data['allow_duplicate_names'] = allow_duplicate_names
         return self.client.perform_query('PUT', '/pipelines/{pipeline_id}'.format(pipeline_id=pipeline_id), data=_data,
@@ -1043,7 +1075,8 @@ class DeltaPipelinesService(object):
         if pagination is not None:
             _data['pagination'] = pagination
             if not isinstance(pagination, dict):
-                raise TypeError('Expected databricks.Pagination() or dict for field pagination')
+                raise TypeError(
+                    'Expected databricks.Pagination() or dict for field pagination')
         return self.client.perform_query('GET', '/pipelines', data=_data, headers=headers)
 
     def reset(self, pipeline_id=None, headers=None):
@@ -1063,6 +1096,8 @@ class DeltaPipelinesService(object):
 
         return self.client.perform_query('POST', '/pipelines/{pipeline_id}/stop'.format(pipeline_id=pipeline_id),
                                          data=_data, headers=headers)
+
+
 class ReposService(object):
     def __init__(self, client):
         self.client = client
@@ -1077,9 +1112,9 @@ class ReposService(object):
 
     def get_repo(self, id, headers=None):
         _data = {}
-    
+
         return self.client.perform_query('GET', '/repos/{id}'.format(id=id), data=_data, headers=headers)
-    
+
     def update_repo(self, id, branch=None, tag=None, headers=None):
         _data = {}
         if branch is not None:
@@ -1087,7 +1122,7 @@ class ReposService(object):
         if tag is not None:
             _data['tag'] = tag
         return self.client.perform_query('PATCH', '/repos/{id}'.format(id=id), data=_data, headers=headers)
-    
+
     def create_repo(self, url, provider, path=None, headers=None):
         _data = {}
         if url is not None:
@@ -1100,5 +1135,5 @@ class ReposService(object):
 
     def delete_repo(self, id, headers=None):
         _data = {}
-    
+
         return self.client.perform_query('DELETE', '/repos/{id}'.format(id=id), data=_data, headers=headers)

--- a/tests/jobs/test_api.py
+++ b/tests/jobs/test_api.py
@@ -59,7 +59,8 @@ def test_list_jobs_by_name(jobs_api):
     assert len(res) == 1
     assert res[0]['settings']['name'] == test_job_name
 
-    jobs_api.list_jobs.return_value = {'jobs': [test_job, test_job_alt, test_job]}
+    jobs_api.list_jobs.return_value = {
+        'jobs': [test_job, test_job_alt, test_job]}
     res = jobs_api._list_jobs_by_name(test_job_name)
     assert len(res) == 2
     assert res[0]['settings']['name'] == test_job_name
@@ -131,13 +132,13 @@ def test_list_jobs():
 def test_run_now():
     with mock.patch('databricks_cli.sdk.ApiClient') as api_client_mock:
         api = JobsApi(api_client_mock)
-        api.run_now('1', ['bla'], None, None, None)
+        api.run_now('1', ['bla'], None, None, None, None)
         api_client_mock.perform_query.assert_called_with(
             'POST', '/jobs/run-now', data={'job_id': '1', 'jar_params': ['bla']},
             headers=None, version=None
         )
 
-        api.run_now('1', ['bla'], None, None, None, version='3.0')
+        api.run_now('1', ['bla'], None, None, None, None, version='3.0')
         api_client_mock.perform_query.assert_called_with(
             'POST', '/jobs/run-now', data={'job_id': '1', 'jar_params': ['bla']},
             headers=None, version='3.0'

--- a/tests/jobs/test_api.py
+++ b/tests/jobs/test_api.py
@@ -59,8 +59,7 @@ def test_list_jobs_by_name(jobs_api):
     assert len(res) == 1
     assert res[0]['settings']['name'] == test_job_name
 
-    jobs_api.list_jobs.return_value = {
-        'jobs': [test_job, test_job_alt, test_job]}
+    jobs_api.list_jobs.return_value = {'jobs': [test_job, test_job_alt, test_job]}
     res = jobs_api._list_jobs_by_name(test_job_name)
     assert len(res) == 2
     assert res[0]['settings']['name'] == test_job_name

--- a/tests/jobs/test_cli.py
+++ b/tests/jobs/test_cli.py
@@ -191,6 +191,7 @@ RUN_NOW_RETURN = {
 NOTEBOOK_PARAMS = '{"a": 1}'
 JAR_PARAMS = '[1, 2, 3]'
 PYTHON_PARAMS = '["python", "params"]'
+PYTHON_NAMED_PARAMS = '{"python": "named", "params": 1}'
 SPARK_SUBMIT_PARAMS = '["--class", "org.apache.spark.examples.SparkPi"]'
 
 
@@ -217,6 +218,7 @@ def test_run_now_with_params(jobs_api_mock):
                                         '--jar-params', JAR_PARAMS,
                                         '--notebook-params', NOTEBOOK_PARAMS,
                                         '--python-params', PYTHON_PARAMS,
+                                        '--python-named-params', PYTHON_NAMED_PARAMS,
                                         '--spark-submit-params', SPARK_SUBMIT_PARAMS])
         assert jobs_api_mock.run_now.call_args[0][0] == 1
         assert jobs_api_mock.run_now.call_args[0][1] == json.loads(JAR_PARAMS)
@@ -225,6 +227,8 @@ def test_run_now_with_params(jobs_api_mock):
         assert jobs_api_mock.run_now.call_args[0][3] == json.loads(
             PYTHON_PARAMS)
         assert jobs_api_mock.run_now.call_args[0][4] == json.loads(
+            PYTHON_NAMED_PARAMS)
+        assert jobs_api_mock.run_now.call_args[0][5] == json.loads(
             SPARK_SUBMIT_PARAMS)
         assert echo_mock.call_args[0][0] == pretty_format(RUN_NOW_RETURN)
 
@@ -304,7 +308,8 @@ def test_get_job_21(jobs_api_mock):
         runner = CliRunner()
         runner.invoke(cli.get_cli, ['--job-id', '1', '--version', '2.1'])
         assert jobs_api_mock.get_job.call_args == mock.call('1', version='2.1')
-        assert echo_mock.call_args[0][0] == pretty_format(LIST_21_RETURN['jobs'][0])
+        assert echo_mock.call_args[0][0] == pretty_format(
+            LIST_21_RETURN['jobs'][0])
 
 
 @provide_conf

--- a/tests/jobs/test_cli.py
+++ b/tests/jobs/test_cli.py
@@ -308,8 +308,7 @@ def test_get_job_21(jobs_api_mock):
         runner = CliRunner()
         runner.invoke(cli.get_cli, ['--job-id', '1', '--version', '2.1'])
         assert jobs_api_mock.get_job.call_args == mock.call('1', version='2.1')
-        assert echo_mock.call_args[0][0] == pretty_format(
-            LIST_21_RETURN['jobs'][0])
+        assert echo_mock.call_args[0][0] == pretty_format(LIST_21_RETURN['jobs'][0])
 
 
 @provide_conf


### PR DESCRIPTION
This allows users to override the `python_named_parameters` in the `jobs/run-now` endpoint.

Usage example:
```sh
databricks jobs run-now --job-id 12345 --python-named-params '{"parameter": "value"}'
```

Corresponding API payload to `api/2.1/jobs/run-now`:
```
{
    "job_id": 12345,
    "python_named_params": {
        "parameter": "value"
    }
}  
```