### PR TITLE
[Jobs] Make python_named_parameters optional in jobs.api.run_now

### DIFF
--- a/databricks_cli/jobs/api.py
+++ b/databricks_cli/jobs/api.py
@@ -49,10 +49,10 @@ class JobsApi(object):
         return self.client.client.perform_query('POST', '/jobs/reset', data=json, headers=headers,
                                                 version=version)
 
-    def run_now(self, job_id, jar_params, notebook_params, python_params, python_named_params,
-                spark_submit_params, headers=None, version=None):
+    def run_now(self, job_id, jar_params, notebook_params, python_params, spark_submit_params,
+                python_named_params=None, headers=None, version=None):
         return self.client.run_now(job_id, jar_params, notebook_params, python_params,
-                                   python_named_params, spark_submit_params, headers=headers,
+                                   spark_submit_params, python_named_params, headers=headers,
                                    version=version)
 
     def _list_jobs_by_name(self, name, headers=None):

--- a/databricks_cli/jobs/cli.py
+++ b/databricks_cli/jobs/cli.py
@@ -235,7 +235,7 @@ def run_now_cli(api_client, job_id, jar_params, notebook_params, python_params,
     spark_submit_params = json_loads(spark_submit_params) if spark_submit_params else None
     res = JobsApi(api_client).run_now(
         job_id, jar_params_json, notebook_params_json, python_params,
-        python_named_params, spark_submit_params, version=version)
+        spark_submit_params, python_named_params, version=version)
     click.echo(pretty_format(res))
 
 

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -156,8 +156,8 @@ class JobsService(object):
 
         return self.client.perform_query('GET', '/jobs/list', data=_data, headers=headers, version=version)
 
-    def run_now(self, job_id=None, jar_params=None, notebook_params=None, python_params=None, python_named_params=None,
-                spark_submit_params=None, headers=None, version=None):
+    def run_now(self, job_id=None, jar_params=None, notebook_params=None, python_params=None, spark_submit_params=None,
+                python_named_params=None, headers=None, version=None):
         _data = {}
         if job_id is not None:
             _data['job_id'] = job_id

--- a/tests/jobs/test_cli.py
+++ b/tests/jobs/test_cli.py
@@ -227,9 +227,9 @@ def test_run_now_with_params(jobs_api_mock):
         assert jobs_api_mock.run_now.call_args[0][3] == json.loads(
             PYTHON_PARAMS)
         assert jobs_api_mock.run_now.call_args[0][4] == json.loads(
-            PYTHON_NAMED_PARAMS)
-        assert jobs_api_mock.run_now.call_args[0][5] == json.loads(
             SPARK_SUBMIT_PARAMS)
+        assert jobs_api_mock.run_now.call_args[0][5] == json.loads(
+            PYTHON_NAMED_PARAMS)
         assert echo_mock.call_args[0][0] == pretty_format(RUN_NOW_RETURN)
 
 


### PR DESCRIPTION
As [reported](https://github.com/databricks/databricks-cli/pull/425#issuecomment-1029497331) by @skyxie, #425 broke the run-now api by making `python_named_parameters` optional. This PR mitigates this by making the new parameter optional.