### PR TITLE
[JOBS-5871] Add version option to runs

### DIFF
--- a/databricks_cli/configure/config.py
+++ b/databricks_cli/configure/config.py
@@ -29,6 +29,7 @@ from databricks_cli.click_types import ContextObject
 from databricks_cli.configure.provider import get_config, ProfileConfigProvider
 from databricks_cli.utils import InvalidConfigurationError
 from databricks_cli.sdk import ApiClient
+from databricks_cli.sdk.version import API_VERSIONS
 
 
 def provide_api_client(function):
@@ -64,7 +65,7 @@ def get_profile_from_context():
 
 
 def debug_option(f):
-    def callback(ctx, param, value): #  NOQA
+    def callback(ctx, param, value):  # NOQA
         context_object = ctx.ensure_object(ContextObject)
         context_object.set_debug(value)
     return click.option('--debug', is_flag=True, callback=callback,
@@ -72,13 +73,18 @@ def debug_option(f):
 
 
 def profile_option(f):
-    def callback(ctx, param, value): #  NOQA
+    def callback(ctx, param, value):  # NOQA
         if value is not None:
             context_object = ctx.ensure_object(ContextObject)
             context_object.set_profile(value)
     return click.option('--profile', required=False, default=None, callback=callback,
                         expose_value=False,
                         help='CLI connection profile to use. The default profile is "DEFAULT".')(f)
+
+
+def api_version_option(f):
+    return click.option('--version', required=False, default=None, type=click.Choice(API_VERSIONS),
+                        help='Override the API version used to call databricks.')(f)
 
 
 def _get_api_client(config, command_name=""):

--- a/databricks_cli/runs/api.py
+++ b/databricks_cli/runs/api.py
@@ -28,17 +28,19 @@ class RunsApi(object):
     def __init__(self, api_client):
         self.client = JobsService(api_client)
 
-    def submit_run(self, json):
-        return self.client.client.perform_query('POST', '/jobs/runs/submit', data=json)
+    def submit_run(self, json, version=None):
+        return self.client.client.perform_query('POST', '/jobs/runs/submit', data=json,
+                                                version=version)
 
-    def list_runs(self, job_id, active_only, completed_only, offset, limit):
-        return self.client.list_runs(job_id, active_only, completed_only, offset, limit)
+    def list_runs(self, job_id, active_only, completed_only, offset, limit, version=None):
+        return self.client.list_runs(job_id, active_only, completed_only, offset, limit,
+                                     version=version)
 
-    def get_run(self, run_id):
-        return self.client.get_run(run_id)
+    def get_run(self, run_id, version=None):
+        return self.client.get_run(run_id, version=version)
 
-    def cancel_run(self, run_id):
-        return self.client.cancel_run(run_id)
+    def cancel_run(self, run_id, version=None):
+        return self.client.cancel_run(run_id, version=version)
 
-    def get_run_output(self, run_id):
-        return self.client.get_run_output(run_id)
+    def get_run_output(self, run_id, version=None):
+        return self.client.get_run_output(run_id, version=version)

--- a/tests/runs/test_api.py
+++ b/tests/runs/test_api.py
@@ -1,0 +1,120 @@
+# Databricks CLI
+# Copyright 2017 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"), except
+# that the use of services to which certain application programming
+# interfaces (each, an "API") connect requires that the user first obtain
+# a license for the use of the APIs from Databricks, Inc. ("Databricks"),
+# by creating an account at www.databricks.com and agreeing to either (a)
+# the Community Edition Terms of Service, (b) the Databricks Terms of
+# Service, or (c) another written agreement between Licensee and Databricks
+# for the use of the APIs.
+#
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import pytest
+
+from databricks_cli.runs.api import RunsApi
+from tests.utils import provide_conf
+
+
+@pytest.fixture()
+def runs_api():
+    with mock.patch('databricks_cli.sdk.JobsService') as jobs_service_mock:
+        jobs_service_mock.return_value = mock.MagicMock()
+        runs_api_mock = RunsApi(None)
+        yield runs_api_mock
+
+
+@provide_conf
+def test_get_run():
+    with mock.patch('databricks_cli.sdk.ApiClient') as api_client_mock:
+        api = RunsApi(api_client_mock)
+        api.get_run('1')
+        api_client_mock.perform_query.assert_called_with(
+            'GET', '/jobs/runs/get', data={'run_id': '1'}, headers=None, version=None
+        )
+
+        api.get_run('1', version='3.0')
+        api_client_mock.perform_query.assert_called_with(
+            'GET', '/jobs/runs/get', data={'run_id': '1'}, headers=None, version='3.0'
+        )
+
+
+@provide_conf
+def test_get_run_output():
+    with mock.patch('databricks_cli.sdk.ApiClient') as api_client_mock:
+        api = RunsApi(api_client_mock)
+        api.get_run_output('1')
+        api_client_mock.perform_query.assert_called_with(
+            'GET', '/jobs/runs/get-output', data={'run_id': '1'}, headers=None, version=None
+        )
+        api.get_run_output('1', version='3.0')
+        api_client_mock.perform_query.assert_called_with(
+            'GET', '/jobs/runs/get-output', data={'run_id': '1'}, headers=None, version='3.0'
+        )
+
+
+@provide_conf
+def test_cancel_run():
+    with mock.patch('databricks_cli.sdk.ApiClient') as api_client_mock:
+        api = RunsApi(api_client_mock)
+        api.cancel_run('1')
+        api_client_mock.perform_query.assert_called_with(
+            'POST', '/jobs/runs/cancel', data={'run_id': '1'},
+            headers=None, version=None
+        )
+
+        api.cancel_run('1', version='3.0')
+        api_client_mock.perform_query.assert_called_with(
+            'POST', '/jobs/runs/cancel', data={'run_id': '1'},
+            headers=None, version='3.0'
+        )
+
+
+@provide_conf
+def test_list_runs():
+    with mock.patch('databricks_cli.sdk.ApiClient') as api_client_mock:
+        api = RunsApi(api_client_mock)
+        api.list_runs('1', True, False, 0, 20)
+        api_client_mock.perform_query.assert_called_with(
+            'GET', '/jobs/runs/list',
+            data={'job_id': '1', 'active_only': True,
+                  "completed_only": False, "offset": 0, "limit": 20},
+            headers=None, version=None
+        )
+
+        api.list_runs('1', True, False, 0, 20, version='3.0')
+        api_client_mock.perform_query.assert_called_with(
+            'GET', '/jobs/runs/list',
+            data={'job_id': '1', 'active_only': True,
+                  "completed_only": False, "offset": 0, "limit": 20},
+            headers=None, version='3.0'
+        )
+
+
+@provide_conf
+def test_submit_run():
+    with mock.patch('databricks_cli.sdk.ApiClient') as api_client_mock:
+        api = RunsApi(api_client_mock)
+        api.submit_run('{"tasks": [], "run_name": "mock"}', version=None)
+        api_client_mock.perform_query.assert_called_with(
+            'POST', '/jobs/runs/submit', data='{"tasks": [], "run_name": "mock"}',
+            version=None
+        )
+
+        api.submit_run('{"tasks": [], "run_name": "mock"}', version='3.0')
+        api_client_mock.perform_query.assert_called_with(
+            'POST', '/jobs/runs/submit', data='{"tasks": [], "run_name": "mock"}',
+            version='3.0'
+        )

--- a/tests/runs/test_cli.py
+++ b/tests/runs/test_cli.py
@@ -51,7 +51,8 @@ def test_submit_cli_json(runs_api_mock):
         runs_api_mock.submit_run.return_value = SUBMIT_RETURN
         runner = CliRunner()
         runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON])
-        assert runs_api_mock.submit_run.call_args[0][0] == json.loads(SUBMIT_JSON)
+        assert runs_api_mock.submit_run.call_args[0][0] == json.loads(
+            SUBMIT_JSON)
         assert echo_mock.call_args[0][0] == pretty_format(SUBMIT_RETURN)
 
 
@@ -73,7 +74,7 @@ def test_list_runs(runs_api_mock):
     with mock.patch('databricks_cli.runs.cli.click.echo') as echo_mock:
         runs_api_mock.list_runs.return_value = LIST_RETURN
         runner = CliRunner()
-        runner.invoke(cli.list_cli)
+        runner.invoke(cli.list_cli, ["--version", "2.1"])
         rows = [(1, 'name', 'RUNNING', 'n/a', RUN_PAGE_URL)]
         assert echo_mock.call_args[0][0] == tabulate(rows, tablefmt='plain')
 
@@ -83,7 +84,7 @@ def test_list_runs_output_json(runs_api_mock):
     with mock.patch('databricks_cli.runs.cli.click.echo') as echo_mock:
         runs_api_mock.list_runs.return_value = LIST_RETURN
         runner = CliRunner()
-        runner.invoke(cli.list_cli, ['--output', 'json'])
+        runner.invoke(cli.list_cli, ['--output', 'json', "--version", "2.1"])
         assert echo_mock.call_args[0][0] == pretty_format(LIST_RETURN)
 
 
@@ -92,7 +93,7 @@ def test_get_cli(runs_api_mock):
     with mock.patch('databricks_cli.runs.cli.click.echo') as echo_mock:
         runs_api_mock.get_run.return_value = {}
         runner = CliRunner()
-        runner.invoke(cli.get_cli, ['--run-id', 1])
+        runner.invoke(cli.get_cli, ['--run-id', 1, "--version", "2.1"])
         assert runs_api_mock.get_run.call_args[0][0] == 1
         assert echo_mock.call_args[0][0] == pretty_format({})
 
@@ -102,6 +103,6 @@ def test_cancel_cli(runs_api_mock):
     with mock.patch('databricks_cli.runs.cli.click.echo') as echo_mock:
         runs_api_mock.cancel_run.return_value = {}
         runner = CliRunner()
-        runner.invoke(cli.cancel_cli, ['--run-id', 1])
+        runner.invoke(cli.cancel_cli, ['--run-id', 1, "--version", "2.1"])
         assert runs_api_mock.cancel_run.call_args[0][0] == 1
         assert echo_mock.call_args[0][0] == pretty_format({})


### PR DESCRIPTION
As reported in #405 and #415, the `--version` option to override the configured `JOBS_API_VERSION` is not available in the `databricks runs` command group.

This PR ensures the same `@api_version_option` is used on the `databricks jobs` and `databricks runs` commands.