### PR TITLE
[JOBS-5870] Add idempotency-token to run-now in runs cli and api

### DIFF
--- a/databricks_cli/jobs/api.py
+++ b/databricks_cli/jobs/api.py
@@ -50,10 +50,10 @@ class JobsApi(object):
                                                 version=version)
 
     def run_now(self, job_id, jar_params, notebook_params, python_params, spark_submit_params,
-                python_named_params=None, headers=None, version=None):
+                python_named_params=None, idempotency_token=None, headers=None, version=None):
         return self.client.run_now(job_id, jar_params, notebook_params, python_params,
-                                   spark_submit_params, python_named_params, headers=headers,
-                                   version=version)
+                                   spark_submit_params, python_named_params,
+                                   idempotency_token, headers=headers, version=version)
 
     def _list_jobs_by_name(self, name, headers=None):
         jobs = self.list_jobs(headers=headers)['jobs']

--- a/databricks_cli/jobs/cli.py
+++ b/databricks_cli/jobs/cli.py
@@ -215,12 +215,16 @@ def get_cli(api_client, job_id, version):
                    '["--class", "org.apache.spark.examples.SparkPi"]')
 @click.option('--version', required=False, default=None, type=click.Choice(API_VERSIONS),
               help='Override the API version used to call jobs.')
+@click.option('--idempotency-token', default=None,
+              help='If an active run with the provided token already exists, ' +
+              'the request does not create a new run, ' +
+              'but returns the ID of the existing run instead.')
 @debug_option
 @profile_option
 @eat_exceptions
 @provide_api_client
 def run_now_cli(api_client, job_id, jar_params, notebook_params, python_params,
-                python_named_params, spark_submit_params, version):
+                python_named_params, spark_submit_params, idempotency_token, version):
     """
     Runs a job with optional per-run parameters.
 
@@ -235,7 +239,7 @@ def run_now_cli(api_client, job_id, jar_params, notebook_params, python_params,
     spark_submit_params = json_loads(spark_submit_params) if spark_submit_params else None
     res = JobsApi(api_client).run_now(
         job_id, jar_params_json, notebook_params_json, python_params,
-        spark_submit_params, python_named_params, version=version)
+        spark_submit_params, python_named_params, idempotency_token, version=version)
     click.echo(pretty_format(res))
 
 

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -157,7 +157,7 @@ class JobsService(object):
         return self.client.perform_query('GET', '/jobs/list', data=_data, headers=headers, version=version)
 
     def run_now(self, job_id=None, jar_params=None, notebook_params=None, python_params=None, spark_submit_params=None,
-                python_named_params=None, headers=None, version=None):
+                python_named_params=None, idempotency_token=None, headers=None, version=None):
         _data = {}
         if job_id is not None:
             _data['job_id'] = job_id
@@ -171,6 +171,8 @@ class JobsService(object):
             _data['python_named_params'] = python_named_params
         if spark_submit_params is not None:
             _data['spark_submit_params'] = spark_submit_params
+        if idempotency_token is not None:
+            _data['idempotency_token'] = idempotency_token
         return self.client.perform_query('POST', '/jobs/run-now', data=_data, headers=headers, version=version)
 
     def list_runs(self, job_id=None, active_only=None, completed_only=None, offset=None,

--- a/tests/jobs/test_api.py
+++ b/tests/jobs/test_api.py
@@ -137,6 +137,12 @@ def test_run_now():
             headers=None, version=None
         )
 
+        api.run_now('1', None, None, None, None, None, 'idempotent-token')
+        api_client_mock.perform_query.assert_called_with(
+            'POST', '/jobs/run-now', data={'job_id': '1', 'idempotency_token': 'idempotent-token'},
+            headers=None, version=None
+        )
+
         api.run_now('1', ['bla'], None, None, None, None, version='3.0')
         api_client_mock.perform_query.assert_called_with(
             'POST', '/jobs/run-now', data={'job_id': '1', 'jar_params': ['bla']},

--- a/tests/jobs/test_cli.py
+++ b/tests/jobs/test_cli.py
@@ -193,6 +193,7 @@ JAR_PARAMS = '[1, 2, 3]'
 PYTHON_PARAMS = '["python", "params"]'
 PYTHON_NAMED_PARAMS = '{"python": "named", "params": 1}'
 SPARK_SUBMIT_PARAMS = '["--class", "org.apache.spark.examples.SparkPi"]'
+IDEMPOTENCY_TOKEN = 'idempotent-token'
 
 
 @provide_conf
@@ -206,6 +207,8 @@ def test_run_now_no_params(jobs_api_mock):
         assert jobs_api_mock.run_now.call_args[0][2] is None
         assert jobs_api_mock.run_now.call_args[0][3] is None
         assert jobs_api_mock.run_now.call_args[0][4] is None
+        assert jobs_api_mock.run_now.call_args[0][5] is None
+        assert jobs_api_mock.run_now.call_args[0][6] is None
         assert echo_mock.call_args[0][0] == pretty_format(RUN_NOW_RETURN)
 
 
@@ -219,7 +222,8 @@ def test_run_now_with_params(jobs_api_mock):
                                         '--notebook-params', NOTEBOOK_PARAMS,
                                         '--python-params', PYTHON_PARAMS,
                                         '--python-named-params', PYTHON_NAMED_PARAMS,
-                                        '--spark-submit-params', SPARK_SUBMIT_PARAMS])
+                                        '--spark-submit-params', SPARK_SUBMIT_PARAMS,
+                                        '--idempotency-token', IDEMPOTENCY_TOKEN])
         assert jobs_api_mock.run_now.call_args[0][0] == 1
         assert jobs_api_mock.run_now.call_args[0][1] == json.loads(JAR_PARAMS)
         assert jobs_api_mock.run_now.call_args[0][2] == json.loads(
@@ -230,6 +234,7 @@ def test_run_now_with_params(jobs_api_mock):
             SPARK_SUBMIT_PARAMS)
         assert jobs_api_mock.run_now.call_args[0][5] == json.loads(
             PYTHON_NAMED_PARAMS)
+        assert jobs_api_mock.run_now.call_args[0][6] == IDEMPOTENCY_TOKEN
         assert echo_mock.call_args[0][0] == pretty_format(RUN_NOW_RETURN)
 
 


### PR DESCRIPTION
As noted in the [Jobs API docs](https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsRunNow), the `jobs/run-now` endpoint now allows passing an idempotency token.

This PR adds the `--idempotency-token` cli option and the `idempotency_token` api parameter to `run-now`.
