### PR TITLE
Add expand tasks flag to runs list command

### DIFF
--- a/databricks_cli/jobs/cli.py
+++ b/databricks_cli/jobs/cli.py
@@ -173,7 +173,7 @@ def list_cli(api_client, output, job_type, version, expand_tasks, offset, limit,
         has_more = jobs_json.get('has_more', False) and _all
         if has_more:
             offset = offset + \
-                (len(jobs_json['jobs']) if 'jobs' in jobs_json else 20)
+                (len(jobs_json['jobs']) if 'jobs' in jobs_json else limit)
 
     out = {'jobs': jobs}
     if OutputClickType.is_json(output):

--- a/databricks_cli/runs/api.py
+++ b/databricks_cli/runs/api.py
@@ -33,6 +33,7 @@ class RunsApi(object):
                                                 version=version)
 
     def list_runs(self, job_id, active_only, completed_only, offset, limit, version=None, expand_tasks = None):
+        print(f"offset: {offset}, limit: {limit}")
         return self.client.list_runs(job_id, active_only, completed_only, offset, limit, expand_tasks, version=version)
 
     def get_run(self, run_id, version=None):

--- a/databricks_cli/runs/api.py
+++ b/databricks_cli/runs/api.py
@@ -32,9 +32,8 @@ class RunsApi(object):
         return self.client.client.perform_query('POST', '/jobs/runs/submit', data=json,
                                                 version=version)
 
-    def list_runs(self, job_id, active_only, completed_only, offset, limit, version=None):
-        return self.client.list_runs(job_id, active_only, completed_only, offset, limit,
-                                     version=version)
+    def list_runs(self, job_id, active_only, completed_only, offset, limit, version=None, expand_tasks = None):
+        return self.client.list_runs(job_id, active_only, completed_only, offset, limit, expand_tasks, version=version)
 
     def get_run(self, run_id, version=None):
         return self.client.get_run(run_id, version=version)

--- a/databricks_cli/runs/api.py
+++ b/databricks_cli/runs/api.py
@@ -32,9 +32,10 @@ class RunsApi(object):
         return self.client.client.perform_query('POST', '/jobs/runs/submit', data=json,
                                                 version=version)
 
-    def list_runs(self, job_id, active_only, completed_only, offset, limit, version=None, expand_tasks = None):
-        print(f"offset: {offset}, limit: {limit}")
-        return self.client.list_runs(job_id, active_only, completed_only, offset, limit, expand_tasks, version=version)
+    def list_runs(self, job_id, active_only, completed_only, offset, limit,
+                  version=None, expand_tasks=None):
+        return self.client.list_runs(job_id, active_only, completed_only, offset, limit,
+                                     version=version, expand_tasks=expand_tasks)
 
     def get_run(self, run_id, version=None):
         return self.client.get_run(run_id, version=version)

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -124,7 +124,8 @@ def _runs_to_table(runs_json):
 @profile_option
 @eat_exceptions  # noqa
 @provide_api_client
-def list_cli(api_client, job_id, active_only, completed_only, offset, limit, expand_tasks, output, version, _all):  # noqa
+def list_cli(api_client, job_id, active_only, completed_only, offset, limit, expand_tasks,
+             output, version, _all):  # noqa
     """
     Lists job runs.
 
@@ -156,7 +157,8 @@ def list_cli(api_client, job_id, active_only, completed_only, offset, limit, exp
         limit = 20
     while has_more:
         runs_json = runs_api.list_runs(
-            job_id, active_only, completed_only, offset, limit, version=version, expand_tasks=expand_tasks)
+            job_id, active_only, completed_only, offset, limit,
+            version=version, expand_tasks=expand_tasks)
         runs += runs_json['runs'] if 'runs' in runs_json else []
         has_more = runs_json.get('has_more', False) and _all
         if has_more:

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -162,10 +162,11 @@ def list_cli(api_client, job_id, active_only, completed_only, offset, limit, exp
         if has_more:
             offset = offset + \
                 (len(runs_json['runs']) if 'runs' in runs_json else limit)
+    runs_output = {"runs": runs}
     if OutputClickType.is_json(output):
-        click.echo(pretty_format(runs_json))
+        click.echo(pretty_format(runs_output))
     else:
-        click.echo(tabulate(_runs_to_table(runs_json), tablefmt='plain'))
+        click.echo(tabulate(_runs_to_table(runs_output), tablefmt='plain'))
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -116,7 +116,7 @@ def _runs_to_table(runs_json):
 @click.option('--expand-tasks', is_flag=True,
               help='Expands the tasks array (only available in API 2.1).')
 @click.option('--all', '_all', is_flag=True,
-              help='Lists all jobs by executing sequential calls to the API ' +
+              help='Lists all runs by executing sequential calls to the API ' +
                    '(only available in API 2.1).')
 @click.option('--output', help=OutputClickType.help, type=OutputClickType())
 @api_version_option

--- a/databricks_cli/utils.py
+++ b/databricks_cli/utils.py
@@ -172,3 +172,17 @@ def merge_dicts_shallow(*dicts):
         result.update(d)
     return result
     
+def walk_paginated_api(fetch, key, page_size, offset, limit, _all):
+    has_more = True
+    objects = []
+    if _all:
+        offset = 0
+        limit = page_size
+    while has_more:
+        objects_json = fetch(offset, limit)
+        objects += objects_json[key] if key in objects_json else []
+        has_more = objects_json.get('has_more', False) and _all
+        if has_more:
+            offset = offset + \
+                (len(objects_json[key]) if key in objects_json else limit)
+    return objects

--- a/tests/runs/test_api.py
+++ b/tests/runs/test_api.py
@@ -94,11 +94,11 @@ def test_list_runs():
             headers=None, version=None
         )
 
-        api.list_runs('1', True, False, 0, 20, version='3.0')
+        api.list_runs('1', True, False, 0, 20, version='3.0', expand_tasks=True)
         api_client_mock.perform_query.assert_called_with(
             'GET', '/jobs/runs/list',
             data={'job_id': '1', 'active_only': True,
-                  "completed_only": False, "offset": 0, "limit": 20},
+                  "completed_only": False, "offset": 0, "limit": 20, "expand_tasks": True},
             headers=None, version='3.0'
         )
 

--- a/tests/runs/test_cli.py
+++ b/tests/runs/test_cli.py
@@ -131,7 +131,7 @@ def test_list_runs(runs_api_mock):
     with mock.patch('databricks_cli.runs.cli.click.echo') as echo_mock:
         runs_api_mock.list_runs.return_value = LIST_RETURN
         runner = CliRunner()
-        runner.invoke(cli.list_cli, ["--version", "2.1"])
+        runner.invoke(cli.list_cli, ["--version", "2.1", "--expand-tasks"])
         rows = [(1, 'name', 'RUNNING', 'n/a', RUN_PAGE_URL)]
         assert echo_mock.call_args[0][0] == tabulate(rows, tablefmt='plain')
 


### PR DESCRIPTION
Adds support for `--expand-tasks` and `--all` options in the `databricks runs list` command.

From the Jobs API 2.1 [docs](https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsRunsList):

> expand_tasks: boolean (Default: false) | Whether to include task and cluster details in the response.
> -- | --


The `--all` command is available in the `databricks jobs list` command, so I thought it could be useful for the runs list too.