### PR TITLE
Increase base PyJWT version to 1.7.0

### DIFF
--- a/databricks_cli/version.py
+++ b/databricks_cli/version.py
@@ -21,7 +21,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = '0.16.4.dev0' #  NOQA
+version = '0.16.4' #  NOQA
 
 
 def print_version_callback(ctx, param, value): #  NOQA

--- a/databricks_cli/version.py
+++ b/databricks_cli/version.py
@@ -21,7 +21,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = '0.16.0.dev0' #  NOQA
+version = '0.16.1' #  NOQA
 
 
 def print_version_callback(ctx, param, value): #  NOQA

--- a/databricks_cli/version.py
+++ b/databricks_cli/version.py
@@ -21,7 +21,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = '0.16.2' #  NOQA
+version = '0.16.3.dev0' #  NOQA
 
 
 def print_version_callback(ctx, param, value): #  NOQA

--- a/databricks_cli/version.py
+++ b/databricks_cli/version.py
@@ -21,7 +21,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = '0.16.2.dev0' #  NOQA
+version = '0.16.2' #  NOQA
 
 
 def print_version_callback(ctx, param, value): #  NOQA

--- a/databricks_cli/version.py
+++ b/databricks_cli/version.py
@@ -21,7 +21,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = '0.15.0.dev0' #  NOQA
+version = '0.16.0' #  NOQA
 
 
 def print_version_callback(ctx, param, value): #  NOQA

--- a/databricks_cli/version.py
+++ b/databricks_cli/version.py
@@ -21,7 +21,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = '0.16.1' #  NOQA
+version = '0.16.2.dev0' #  NOQA
 
 
 def print_version_callback(ctx, param, value): #  NOQA

--- a/databricks_cli/version.py
+++ b/databricks_cli/version.py
@@ -21,7 +21,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = '0.16.0' #  NOQA
+version = '0.16.1.dev0' #  NOQA
 
 
 def print_version_callback(ctx, param, value): #  NOQA

--- a/databricks_cli/version.py
+++ b/databricks_cli/version.py
@@ -21,7 +21,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = '0.16.1.dev0' #  NOQA
+version = '0.16.0.dev0' #  NOQA
 
 
 def print_version_callback(ctx, param, value): #  NOQA

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     packages=find_packages(exclude=['tests', 'tests.*']),
     install_requires=[
         'click>=6.7',
-        'pyjwt>=1.5.0',
+        'pyjwt>=1.7.0',
         'oauthlib>=3.1.0',
         'requests>=2.17.3',
         'tabulate>=0.7.7',


### PR DESCRIPTION
We use PyJWT features introduced in version 1.7.0. However, base version required in cli is 1.5.0 causing problems. See https://github.com/databricks/databricks-cli/issues/444 for details of this fix.