### PR TITLE
Copy list of runtime dependencies to requirements.txt

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,6 +10,7 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 
 RUN /usr/local/bin/python3 -m pip install --upgrade pip
 
+COPY requirements.txt /tmp/pip-tmp/
 COPY dev-requirements*.txt /tmp/pip-tmp/
 RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/dev-requirements-py3.txt && rm -rf /tmp/pip-tmp
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -36,9 +36,6 @@ jobs:
         if: ${{ startsWith(matrix.python-version, '3.') }}
         run: pip install --upgrade -r dev-requirements-py3.txt
 
-      - name: Install package
-        run: pip install -e .
-
       - name: Run tests
         run: pytest tests --cov=./
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+-r ./requirements.txt
 pytest
 pytest-cov
 mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+click>=6.7
+pyjwt>=1.7.0
+oauthlib>=3.1.0
+requests>=2.17.3
+tabulate>=0.7.7
+six>=1.10.0
+configparser>=0.3.5; python_version < "3.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ oauthlib>=3.1.0
 requests>=2.17.3
 tabulate>=0.7.7
 six>=1.10.0
-configparser>=0.3.5; python_version < "3.6"
+configparser>=0.3.5;python_version < "3.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# Note: please keep this in sync with `setup.py`.
 click>=6.7
 pyjwt>=1.7.0
 oauthlib>=3.1.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,12 @@ def read_requirements_txt():
     all necessary dependencies in a single pip invocation.
     """
     with open('requirements.txt', 'r') as file:
-        return [line.strip() for line in file.readlines()]
+        return [
+            line.strip()
+            for line in file.readlines()
+            # Ignore empty lines and comments.
+            if line.strip() and not line.startswith('#')
+        ]
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -29,19 +29,22 @@ from setuptools import setup, find_packages
 version = imp.load_source(
     'databricks_cli.version', os.path.join('databricks_cli', 'version.py')).version
 
+
+def read_requirements_txt():
+    """
+    Read `install_requires` from `requirements.txt`.
+    They are kept in a separate file such that a developer can install
+    all necessary dependencies in a single pip invocation.
+    """
+    with open('requirements.txt', 'r') as file:
+        return [line.strip() for line in file.readlines()]
+
+
 setup(
     name='databricks-cli',
     version=version,
     packages=find_packages(exclude=['tests', 'tests.*']),
-    install_requires=[
-        'click>=6.7',
-        'pyjwt>=1.7.0',
-        'oauthlib>=3.1.0',
-        'requests>=2.17.3',
-        'tabulate>=0.7.7',
-        'six>=1.10.0',
-        'configparser>=0.3.5;python_version < "3.6"',
-    ],
+    install_requires=read_requirements_txt(),
     entry_points='''
         [console_scripts]
         databricks=databricks_cli.cli:cli

--- a/setup.py
+++ b/setup.py
@@ -29,27 +29,20 @@ from setuptools import setup, find_packages
 version = imp.load_source(
     'databricks_cli.version', os.path.join('databricks_cli', 'version.py')).version
 
-
-def read_requirements_txt():
-    """
-    Read `install_requires` from `requirements.txt`.
-    They are kept in a separate file such that a developer can install
-    all necessary dependencies in a single pip invocation.
-    """
-    with open('requirements.txt', 'r') as file:
-        return [
-            line.strip()
-            for line in file.readlines()
-            # Ignore empty lines and comments.
-            if line.strip() and not line.startswith('#')
-        ]
-
-
 setup(
     name='databricks-cli',
     version=version,
     packages=find_packages(exclude=['tests', 'tests.*']),
-    install_requires=read_requirements_txt(),
+    install_requires=[
+        # Note: please keep this in sync with `requirements.txt`.
+        'click>=6.7',
+        'pyjwt>=1.7.0',
+        'oauthlib>=3.1.0',
+        'requests>=2.17.3',
+        'tabulate>=0.7.7',
+        'six>=1.10.0',
+        'configparser>=0.3.5;python_version < "3.6"',
+    ],
     entry_points='''
         [console_scripts]
         databricks=databricks_cli.cli:cli


### PR DESCRIPTION
This allows us to install the complete set of dependencies (both development and runtime) in a single call to pip.