### PR TITLE
Use correct string method in create_repo function

### DIFF
--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -1134,7 +1134,7 @@ class ReposService(object):
         _data = {}
         if url is not None:
             _data['url'] = url
-        if provider is None or provider.trim() == "":
+        if provider is None or provider.strip() == "":
             provider = self.detect_repo_provider(url)
         if provider is not None:
             _data['provider'] = provider


### PR DESCRIPTION
Use correct string method `strip()` as python doesn't have `trim()` method for a string.
Bug Introduced in https://github.com/databricks/databricks-cli/pull/385