### PR TITLE
Restrict package to include only databricks_cli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ version = imp.load_source(
 setup(
     name='databricks-cli',
     version=version,
-    packages=find_packages(exclude=['tests', 'tests.*']),
+    packages=find_packages(include=['databricks_cli*']),
     install_requires=[
         # Note: please keep this in sync with `requirements.txt`.
         'click>=6.7',


### PR DESCRIPTION
Because `setup.py` uses an exclude pattern rather than an include pattern we inadvertently include the `integration` directory as a top level package. This change modifies that to ensure we only package `databricks_cli`.