### PR TITLE
Add --wait option to databricks runs submit CLI command

### DIFF
--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -52,7 +52,7 @@ from databricks_cli.version import print_version_callback, version as cli_versio
 @provide_api_client
 def submit_cli(api_client, json_file, json, wait, version):
     """
-    Submits a one-time run.
+    Submits a one-time run and optionally waits for its completion.
 
     The specification for the request json can be found
     https://docs.databricks.com/api/latest/jobs.html#runs-submit
@@ -74,9 +74,9 @@ def submit_cli(api_client, json_file, json, wait, version):
                 if run_state['result_state'] == 'SUCCESS':
                     sys.exit(0)
                 else:
-                    error_and_quit('job failed with state ' + run_state['result_state'] +
+                    error_and_quit('Run failed with state ' + run_state['result_state'] +
                                    ' and state message ' + run_state['state_message'])
-            click.echo('Job still running with lifecycle state ' + run_state['life_cycle_state'] +
+            click.echo('Run is still active, with lifecycle state ' + run_state['life_cycle_state'] +
                         '. URL: ' + run['run_page_url'], err=True)
             time.sleep(5)
 

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -44,7 +44,7 @@ from databricks_cli.version import print_version_callback, version as cli_versio
 @click.option('--json', default=None, type=JsonClickType(),
               help=JsonClickType.help('/api/2.*/jobs/runs/submit'))
 @click.option('--wait', is_flag=True, default=False,
-              help='If specified, wait for the submitted run to complete.')
+              help='If specified, waits for the submitted run to complete.')
 @api_version_option
 @debug_option
 @profile_option

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -21,6 +21,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import time
 from json import loads as json_loads
 
@@ -29,7 +30,8 @@ from tabulate import tabulate
 
 from databricks_cli.click_types import OutputClickType, JsonClickType, RunIdClickType
 from databricks_cli.jobs.cli import check_version
-from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS, pretty_format, truncate_string
+from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS, pretty_format, truncate_string, \
+    error_and_quit
 from databricks_cli.configure.config import provide_api_client, profile_option, debug_option, \
     api_version_option
 from databricks_cli.runs.api import RunsApi
@@ -71,14 +73,12 @@ def submit_cli(api_client, json_file, json, wait, version):
             run_state = run['state']
             if run_state['life_cycle_state'] in completed_states:
                 if run_state['result_state'] == 'SUCCESS':
-                    click.echo('Job completed successfully.')
+                    sys.exit(0)
                 else:
-                    click.echo(click.style('ERROR', fg='red') + ': job failed with state ' +
-                                run_state['result_state'] + ' and state message ' +
-                                run_state['state_message'], err=True)
-                return
+                    error_and_quit('job failed with state ' + run_state['result_state'] +
+                                   ' and state message ' + run_state['state_message'])
             click.echo('Job still running with lifecycle state ' + run_state['life_cycle_state'] +
-                        '. URL: ' + run['run_page_url'])
+                        '. URL: ' + run['run_page_url'], err=True)
             time.sleep(5)
 
 

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -57,12 +57,6 @@ def submit_cli(api_client, json_file, json, wait, version):
     https://docs.databricks.com/api/latest/jobs.html#runs-submit
     """
     check_version(api_client, version)
-    api_version = version or api_client.jobs_api_version
-    if api_version != '2.1' and wait:
-        click.echo(click.style('ERROR', fg='red') + ': the option --wait is only available ' +
-                   'in API 2.1', err=True)
-        return
-
     if json_file:
         with open(json_file, 'r') as f:
             json = f.read()

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -44,8 +44,7 @@ from databricks_cli.version import print_version_callback, version as cli_versio
 @click.option('--json', default=None, type=JsonClickType(),
               help=JsonClickType.help('/api/2.*/jobs/runs/submit'))
 @click.option('--wait', is_flag=True,
-              help='If specified, the CLI will wait for the submitted run to complete ' +
-                   '(only available in API 2.1).')
+              help='If specified, the CLI will wait for the submitted run to complete.')
 @api_version_option
 @debug_option
 @profile_option

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -22,15 +22,14 @@
 # limitations under the License.
 
 import time
-from json import dumps as json_dumps, loads as json_loads
+from json import loads as json_loads
 
 import click
 from tabulate import tabulate
 
 from databricks_cli.click_types import OutputClickType, JsonClickType, RunIdClickType
 from databricks_cli.jobs.cli import check_version
-from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS, pretty_format, json_cli_base, \
-    truncate_string
+from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS, pretty_format, truncate_string
 from databricks_cli.configure.config import provide_api_client, profile_option, debug_option, \
     api_version_option
 from databricks_cli.runs.api import RunsApi

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -72,17 +72,17 @@ def submit_cli(api_client, json_file, json, wait, version):
         while True:
             run = RunsApi(api_client).get_run(run_id, version=version)
             run_state = run['state']
-            if run_state['life_cycle_state'] in completed_states:
+            life_cycle_state = run_state['life_cycle_state']
+            if life_cycle_state in completed_states:
                 if run_state['result_state'] == 'SUCCESS':
                     sys.exit(0)
                 else:
                     error_and_quit('Run failed with state ' + run_state['result_state'] +
                                    ' and state message ' + run_state['state_message'])
-            if prev_life_cycle_state != run_state['life_cycle_state']:
-                prev_life_cycle_state = run_state['life_cycle_state']
-                click.echo('Waiting on run to complete. Current state: ' +
-                           run_state['life_cycle_state'] + '. URL: ' +
-                           run['run_page_url'], err=True)
+            if prev_life_cycle_state != life_cycle_state:
+                click.echo('Waiting on run to complete. Current state: ' + life_cycle_state +
+                           '. URL: ' + run['run_page_url'], err=True)
+                prev_life_cycle_state = life_cycle_state
             time.sleep(backoff_with_jitter(attempt))
             attempt += 1
 

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -43,8 +43,8 @@ from databricks_cli.version import print_version_callback, version as cli_versio
               help='File containing JSON request to POST to /api/2.*/jobs/runs/submit.')
 @click.option('--json', default=None, type=JsonClickType(),
               help=JsonClickType.help('/api/2.*/jobs/runs/submit'))
-@click.option('--wait', is_flag=True,
-              help='If specified, the CLI will wait for the submitted run to complete.')
+@click.option('--wait', is_flag=True, default=False,
+              help='If specified, wait for the submitted run to complete.')
 @api_version_option
 @debug_option
 @profile_option

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -76,8 +76,8 @@ def submit_cli(api_client, json_file, json, wait, version):
                 else:
                     error_and_quit('Run failed with state ' + run_state['result_state'] +
                                    ' and state message ' + run_state['state_message'])
-            click.echo('Run is still active, with lifecycle state ' + run_state['life_cycle_state'] +
-                        '. URL: ' + run['run_page_url'], err=True)
+            click.echo('Run is still active, with lifecycle state ' +
+                       run_state['life_cycle_state'] + '. URL: ' + run['run_page_url'], err=True)
             time.sleep(5)
 
 

--- a/databricks_cli/runs/cli.py
+++ b/databricks_cli/runs/cli.py
@@ -44,7 +44,7 @@ from databricks_cli.version import print_version_callback, version as cli_versio
 @click.option('--json', default=None, type=JsonClickType(),
               help=JsonClickType.help('/api/2.*/jobs/runs/submit'))
 @click.option('--wait', is_flag=True, default=False,
-              help='If specified, waits for the submitted run to complete.')
+              help='Waits for the submitted run to complete.')
 @api_version_option
 @debug_option
 @profile_option

--- a/databricks_cli/utils.py
+++ b/databricks_cli/utils.py
@@ -21,6 +21,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+import random
 import sys
 import traceback
 from json import dumps as json_dumps, loads as json_loads
@@ -96,6 +98,19 @@ def error_and_quit(message):
         traceback.print_exc()
     click.echo(u'Error: {}'.format(message))
     sys.exit(1)
+
+
+INTERVAL_MAX = 30
+INTERVAL_BASE = 5
+MAX_EXPONENT = 10
+
+def backoff_with_jitter(attempt):
+    """
+    Creates a growing but randomized wait time based on the number of attempts already made.
+    """
+    exponent = min(attempt, MAX_EXPONENT)
+    sleep_time = min(INTERVAL_MAX, INTERVAL_BASE * 2 ** exponent)
+    return random.randrange(math.floor(sleep_time * 0.5), sleep_time)
 
 
 def pretty_format(json):

--- a/tests/runs/test_cli.py
+++ b/tests/runs/test_cli.py
@@ -80,7 +80,7 @@ def test_submit_wait_success(runs_api_mock):
         runs_api_mock.submit_run.return_value = SUBMIT_RETURN
         runs_api_mock.get_run.return_value = RUNS_GET_RETURN_SUCCESS
         runner = CliRunner()
-        runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--wait'])
+        runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--version=2.1', '--wait'])
         runs_api_mock.get_run.assert_called_once()
         assert echo_mock.call_args_list[1][0][0] == 'Job completed successfully.'
 
@@ -90,7 +90,7 @@ def test_submit_wait_failure(runs_api_mock):
         runs_api_mock.submit_run.return_value = SUBMIT_RETURN
         runs_api_mock.get_run.return_value = RUNS_GET_RETURN_FAILURE
         runner = CliRunner()
-        runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--wait'])
+        runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--version=2.1', '--wait'])
         assert 'job failed with state FAILED and state message OH NO!' in \
                echo_mock.call_args_list[1][0][0]
 
@@ -101,7 +101,7 @@ def test_submit_wait_eventually_succeeds(runs_api_mock):
         runs_api_mock.submit_run.return_value = SUBMIT_RETURN
         runs_api_mock.get_run.side_effect = [RUNS_GET_RETURN_RUNNING, RUNS_GET_RETURN_SUCCESS]
         runner = CliRunner()
-        runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--wait'])
+        runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--version=2.1', '--wait'])
         assert echo_mock.call_args_list[1][0][0] == 'Job still running with lifecycle state ' + \
                                                     'RUNNING. URL: https://www.google.com'
         sleep_mock.assert_called_once()

--- a/tests/runs/test_cli.py
+++ b/tests/runs/test_cli.py
@@ -41,11 +41,18 @@ RUNS_GET_RETURN_SUCCESS = {
         "result_state": "SUCCESS",
     },
 }
+RUNS_GET_RETURN_PENDING = {
+    "state": {
+        "life_cycle_state": "PENDING",
+        "state_message": "Waiting for cluster",
+    },
+    "run_page_url": "https://www.google.com",
+}
 RUNS_GET_RETURN_RUNNING = {
     "state": {
         "life_cycle_state": "RUNNING",
     },
-    "run_page_url": "https://www.google.com"
+    "run_page_url": "https://www.google.com",
 }
 
 
@@ -67,44 +74,43 @@ def test_submit_cli_json(runs_api_mock):
             SUBMIT_JSON)
         assert echo_mock.call_args[0][0] == pretty_format(SUBMIT_RETURN)
 
+
 @provide_conf
 def test_submit_wait_success(runs_api_mock):
-    runs_api_mock.submit_run.return_value = SUBMIT_RETURN
-    runs_api_mock.get_run.return_value = RUNS_GET_RETURN_SUCCESS
-    runner = CliRunner()
-    result = runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--wait'])
-    runs_api_mock.get_run.assert_called_once()
-    assert result.exit_code == 0
+    with mock.patch('databricks_cli.runs.cli.click.echo') as echo_mock, \
+         mock.patch('time.sleep') as sleep_mock:
+        runs_api_mock.submit_run.return_value = SUBMIT_RETURN
+        runs_api_mock.get_run.side_effect = [RUNS_GET_RETURN_PENDING, RUNS_GET_RETURN_PENDING, \
+                                             RUNS_GET_RETURN_RUNNING, RUNS_GET_RETURN_SUCCESS]
+        runner = CliRunner()
+        result = runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--wait'])
+        assert runs_api_mock.get_run.call_count == 4
+        assert sleep_mock.call_count == 3
+        assert echo_mock.call_args[0][0] == 'Run is still active, with lifecycle state ' + \
+                                                    'RUNNING. URL: https://www.google.com'
+        assert result.exit_code == 0
+
 
 @pytest.mark.parametrize('bad_life_cycle_state', ['TERMINATED', 'SKIPPED', 'INTERNAL_ERROR'])
 @provide_conf
 def test_submit_wait_failure(runs_api_mock, bad_life_cycle_state):
-    with mock.patch('click.echo') as echo_mock:
+    with mock.patch('click.echo') as echo_mock, mock.patch('time.sleep') as sleep_mock:
         runs_api_mock.submit_run.return_value = SUBMIT_RETURN
-        runs_api_mock.get_run.return_value = {
+        runs_get_failed = {
             "state": {
                 "life_cycle_state": bad_life_cycle_state,
                 "result_state": "FAILED",
                 "state_message": "OH NO!",
             },
         }
+        runs_api_mock.get_run.side_effect = [RUNS_GET_RETURN_PENDING, RUNS_GET_RETURN_PENDING, \
+                                             RUNS_GET_RETURN_RUNNING, runs_get_failed]
         runner = CliRunner()
         result = runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--wait'])
+        assert runs_api_mock.get_run.call_count == 4
+        assert sleep_mock.call_count == 3
         assert 'Run failed with state FAILED and state message OH NO!' in echo_mock.call_args[0][0]
         assert result.exit_code == 1
-
-@provide_conf
-def test_submit_wait_eventually_succeeds(runs_api_mock):
-    with mock.patch('databricks_cli.runs.cli.click.echo') as echo_mock, \
-         mock.patch('time.sleep') as sleep_mock:
-        runs_api_mock.submit_run.return_value = SUBMIT_RETURN
-        runs_api_mock.get_run.side_effect = [RUNS_GET_RETURN_RUNNING, RUNS_GET_RETURN_SUCCESS]
-        runner = CliRunner()
-        result = runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--wait'])
-        assert echo_mock.call_args[0][0] == 'Run is still active, with lifecycle state ' + \
-                                                    'RUNNING. URL: https://www.google.com'
-        sleep_mock.assert_called_once()
-        assert result.exit_code == 0
 
 
 RUN_PAGE_URL = 'https://databricks.com/#job/1/run/1'

--- a/tests/runs/test_cli.py
+++ b/tests/runs/test_cli.py
@@ -76,13 +76,12 @@ def test_submit_cli_json(runs_api_mock):
 
 @provide_conf
 def test_submit_wait_success(runs_api_mock):
-    with mock.patch('databricks_cli.runs.cli.click.echo') as echo_mock:
-        runs_api_mock.submit_run.return_value = SUBMIT_RETURN
-        runs_api_mock.get_run.return_value = RUNS_GET_RETURN_SUCCESS
-        runner = CliRunner()
-        result = runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--wait'])
-        runs_api_mock.get_run.assert_called_once()
-        assert result.exit_code == 0
+    runs_api_mock.submit_run.return_value = SUBMIT_RETURN
+    runs_api_mock.get_run.return_value = RUNS_GET_RETURN_SUCCESS
+    runner = CliRunner()
+    result = runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--wait'])
+    runs_api_mock.get_run.assert_called_once()
+    assert result.exit_code == 0
 
 @provide_conf
 def test_submit_wait_failure(runs_api_mock):

--- a/tests/runs/test_cli.py
+++ b/tests/runs/test_cli.py
@@ -90,7 +90,7 @@ def test_submit_wait_failure(runs_api_mock):
         runs_api_mock.get_run.return_value = RUNS_GET_RETURN_FAILURE
         runner = CliRunner()
         result = runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--wait'])
-        assert 'job failed with state FAILED and state message OH NO!' in echo_mock.call_args[0][0]
+        assert 'Run failed with state FAILED and state message OH NO!' in echo_mock.call_args[0][0]
         assert result.exit_code == 1
 
 @provide_conf
@@ -101,7 +101,7 @@ def test_submit_wait_eventually_succeeds(runs_api_mock):
         runs_api_mock.get_run.side_effect = [RUNS_GET_RETURN_RUNNING, RUNS_GET_RETURN_SUCCESS]
         runner = CliRunner()
         result = runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--wait'])
-        assert echo_mock.call_args[0][0] == 'Job still running with lifecycle state ' + \
+        assert echo_mock.call_args[0][0] == 'Run is still active, with lifecycle state ' + \
                                                     'RUNNING. URL: https://www.google.com'
         sleep_mock.assert_called_once()
         assert result.exit_code == 0

--- a/tests/runs/test_cli.py
+++ b/tests/runs/test_cli.py
@@ -90,9 +90,8 @@ def test_submit_wait_failure(runs_api_mock):
         runs_api_mock.submit_run.return_value = SUBMIT_RETURN
         runs_api_mock.get_run.return_value = RUNS_GET_RETURN_FAILURE
         runner = CliRunner()
-        result = runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--version=2.1', '--wait'])
-        assert 'job failed with state FAILED and state message OH NO!' in \
-               echo_mock.call_args_list[1][0][0]
+        result = runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--wait'])
+        assert 'job failed with state FAILED and state message OH NO!' in echo_mock.call_args[0][0]
         assert result.exit_code == 1
 
 @provide_conf
@@ -102,8 +101,8 @@ def test_submit_wait_eventually_succeeds(runs_api_mock):
         runs_api_mock.submit_run.return_value = SUBMIT_RETURN
         runs_api_mock.get_run.side_effect = [RUNS_GET_RETURN_RUNNING, RUNS_GET_RETURN_SUCCESS]
         runner = CliRunner()
-        result = runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--version=2.1', '--wait'])
-        assert echo_mock.call_args_list[1][0][0] == 'Job still running with lifecycle state ' + \
+        result = runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--wait'])
+        assert echo_mock.call_args[0][0] == 'Job still running with lifecycle state ' + \
                                                     'RUNNING. URL: https://www.google.com'
         sleep_mock.assert_called_once()
         assert result.exit_code == 0

--- a/tests/runs/test_cli.py
+++ b/tests/runs/test_cli.py
@@ -91,16 +91,19 @@ def test_submit_wait_failure(runs_api_mock):
         runs_api_mock.get_run.return_value = RUNS_GET_RETURN_FAILURE
         runner = CliRunner()
         runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--version', '2.1', '--wait'])
-        assert 'job failed with state FAILED and state message OH NO!' in echo_mock.call_args_list[1][0][0]
+        assert 'job failed with state FAILED and state message OH NO!' in \
+               echo_mock.call_args_list[1][0][0]
 
 @provide_conf
 def test_submit_wait_eventually_succeeds(runs_api_mock):
-    with mock.patch('databricks_cli.runs.cli.click.echo') as echo_mock, mock.patch('time.sleep') as sleep_mock:
+    with mock.patch('databricks_cli.runs.cli.click.echo') as echo_mock, \
+         mock.patch('time.sleep') as sleep_mock:
         runs_api_mock.submit_run.return_value = SUBMIT_RETURN
         runs_api_mock.get_run.side_effect = [RUNS_GET_RETURN_RUNNING, RUNS_GET_RETURN_SUCCESS]
         runner = CliRunner()
         runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--version', '2.1', '--wait'])
-        assert echo_mock.call_args_list[1][0][0] == 'Job still running with lifecycle state RUNNING. URL: https://www.google.com'
+        assert echo_mock.call_args_list[1][0][0] == 'Job still running with lifecycle state ' + \
+                                                    'RUNNING. URL: https://www.google.com'
         sleep_mock.assert_called_once()
         assert echo_mock.call_args_list[2][0][0] == 'Job completed successfully.'
 

--- a/tests/runs/test_cli.py
+++ b/tests/runs/test_cli.py
@@ -80,7 +80,7 @@ def test_submit_wait_success(runs_api_mock):
         runs_api_mock.submit_run.return_value = SUBMIT_RETURN
         runs_api_mock.get_run.return_value = RUNS_GET_RETURN_SUCCESS
         runner = CliRunner()
-        runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--version=2.1', '--wait'])
+        runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--wait'])
         runs_api_mock.get_run.assert_called_once()
         assert echo_mock.call_args_list[1][0][0] == 'Job completed successfully.'
 
@@ -90,7 +90,7 @@ def test_submit_wait_failure(runs_api_mock):
         runs_api_mock.submit_run.return_value = SUBMIT_RETURN
         runs_api_mock.get_run.return_value = RUNS_GET_RETURN_FAILURE
         runner = CliRunner()
-        runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--version', '2.1', '--wait'])
+        runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--wait'])
         assert 'job failed with state FAILED and state message OH NO!' in \
                echo_mock.call_args_list[1][0][0]
 
@@ -101,7 +101,7 @@ def test_submit_wait_eventually_succeeds(runs_api_mock):
         runs_api_mock.submit_run.return_value = SUBMIT_RETURN
         runs_api_mock.get_run.side_effect = [RUNS_GET_RETURN_RUNNING, RUNS_GET_RETURN_SUCCESS]
         runner = CliRunner()
-        runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--version', '2.1', '--wait'])
+        runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--wait'])
         assert echo_mock.call_args_list[1][0][0] == 'Job still running with lifecycle state ' + \
                                                     'RUNNING. URL: https://www.google.com'
         sleep_mock.assert_called_once()

--- a/tests/runs/test_cli.py
+++ b/tests/runs/test_cli.py
@@ -86,8 +86,8 @@ def test_submit_wait_success(runs_api_mock):
         result = runner.invoke(cli.submit_cli, ['--json', SUBMIT_JSON, '--wait'])
         assert runs_api_mock.get_run.call_count == 4
         assert sleep_mock.call_count == 3
-        assert echo_mock.call_args[0][0] == 'Run is still active, with lifecycle state ' + \
-                                                    'RUNNING. URL: https://www.google.com'
+        assert echo_mock.call_args[0][0] == 'Waiting on run to complete. Current state: ' + \
+                                            'RUNNING. URL: https://www.google.com'
         assert result.exit_code == 0
 
 


### PR DESCRIPTION
## Description

This PR follows https://github.com/databricks/databricks-cli/issues/475 to implement a --wait option for the runs submit CLI. When this option is enabled, the CLI submits a one-time job run and continues to poll for the job run state until the job run completes.

## Testing

* I added unit tests to cover different branches in the added code.
* I manually tested submitting and waiting for a job run (for both API version 2.0 and 2.1). See screenshot:
<img width="1342" alt="Screen Shot 2022-06-15 at 11 11 03 AM" src="https://user-images.githubusercontent.com/66143562/173895988-db014912-852b-44d3-95f2-cf6a6c785cb6.png">
Finally, the job run successfully completes and the terminal output looks like below:
<img width="1343" alt="Screen Shot 2022-06-15 at 11 12 57 AM" src="https://user-images.githubusercontent.com/66143562/173896362-454bf874-a423-4589-97f2-df428773ae23.png">