### PR TITLE
Updated SDK for Delta Pipelines to match API PipelineSettings definition

### DIFF
--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -977,7 +977,7 @@ class DeltaPipelinesService(object):
         self.client = client
 
     def create(self, id=None, name=None, storage=None, configuration=None, clusters=None,
-               libraries=None, trigger=None, filters=None, allow_duplicate_names=None,
+               libraries=None, continuous=None, development=None, allow_duplicate_names=None,
                headers=None):
         _data = {}
         if id is not None:
@@ -992,20 +992,16 @@ class DeltaPipelinesService(object):
             _data['clusters'] = clusters
         if libraries is not None:
             _data['libraries'] = libraries
-        if trigger is not None:
-            _data['trigger'] = trigger
-            if not isinstance(trigger, dict):
-                raise TypeError('Expected databricks.PipelineTrigger() or dict for field trigger')
-        if filters is not None:
-            _data['filters'] = filters
-            if not isinstance(filters, dict):
-                raise TypeError('Expected databricks.Filters() or dict for field filters')
+        if continuous is not None:
+            _data['continuous'] = continuous
+        if development is not None:
+            _data['development'] = development
         if allow_duplicate_names is not None:
             _data['allow_duplicate_names'] = allow_duplicate_names
         return self.client.perform_query('POST', '/pipelines', data=_data, headers=headers)
 
     def deploy(self, pipeline_id=None, id=None, name=None, storage=None, configuration=None,
-               clusters=None, libraries=None, trigger=None, filters=None,
+               clusters=None, libraries=None, continuous=None, development=None,
                allow_duplicate_names=None, headers=None):
         _data = {}
         if id is not None:
@@ -1020,14 +1016,14 @@ class DeltaPipelinesService(object):
             _data['clusters'] = clusters
         if libraries is not None:
             _data['libraries'] = libraries
-        if trigger is not None:
-            _data['trigger'] = trigger
-            if not isinstance(trigger, dict):
-                raise TypeError('Expected databricks.PipelineTrigger() or dict for field trigger')
-        if filters is not None:
-            _data['filters'] = filters
-            if not isinstance(filters, dict):
-                raise TypeError('Expected databricks.Filters() or dict for field filters')
+        if continuous is not None:
+            _data['continuous'] = continuous
+            # if not isinstance(trigger, dict):
+            #     raise TypeError('Expected databricks.PipelineTrigger() or dict for field trigger')
+        if development is not None:
+            _data['development'] = development
+            # if not isinstance(filters, dict):
+            #     raise TypeError('Expected databricks.Filters() or dict for field filters')
         if allow_duplicate_names is not None:
             _data['allow_duplicate_names'] = allow_duplicate_names
         return self.client.perform_query('PUT', '/pipelines/{pipeline_id}'.format(pipeline_id=pipeline_id), data=_data,

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -977,7 +977,7 @@ class DeltaPipelinesService(object):
         self.client = client
 
     def create(self, id=None, name=None, storage=None, configuration=None, clusters=None,
-               libraries=None, continuous=None, development=None, allow_duplicate_names=None,
+               libraries=None, target=None, continuous=None, development=None, allow_duplicate_names=None,
                headers=None):
         _data = {}
         if id is not None:
@@ -992,6 +992,8 @@ class DeltaPipelinesService(object):
             _data['clusters'] = clusters
         if libraries is not None:
             _data['libraries'] = libraries
+        if target is not None:
+            _data['target'] = target
         if continuous is not None:
             _data['continuous'] = continuous
         if development is not None:
@@ -1001,7 +1003,7 @@ class DeltaPipelinesService(object):
         return self.client.perform_query('POST', '/pipelines', data=_data, headers=headers)
 
     def deploy(self, pipeline_id=None, id=None, name=None, storage=None, configuration=None,
-               clusters=None, libraries=None, continuous=None, development=None,
+               clusters=None, libraries=None, target=None, continuous=None, development=None,
                allow_duplicate_names=None, headers=None):
         _data = {}
         if id is not None:
@@ -1016,6 +1018,8 @@ class DeltaPipelinesService(object):
             _data['clusters'] = clusters
         if libraries is not None:
             _data['libraries'] = libraries
+        if target is not None:
+            _data['target'] = target
         if continuous is not None:
             _data['continuous'] = continuous
         if development is not None:

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -1018,12 +1018,8 @@ class DeltaPipelinesService(object):
             _data['libraries'] = libraries
         if continuous is not None:
             _data['continuous'] = continuous
-            # if not isinstance(trigger, dict):
-            #     raise TypeError('Expected databricks.PipelineTrigger() or dict for field trigger')
         if development is not None:
             _data['development'] = development
-            # if not isinstance(filters, dict):
-            #     raise TypeError('Expected databricks.Filters() or dict for field filters')
         if allow_duplicate_names is not None:
             _data['allow_duplicate_names'] = allow_duplicate_names
         return self.client.perform_query('PUT', '/pipelines/{pipeline_id}'.format(pipeline_id=pipeline_id), data=_data,

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -977,7 +977,7 @@ class DeltaPipelinesService(object):
         self.client = client
 
     def create(self, id=None, name=None, storage=None, configuration=None, clusters=None,
-               libraries=None, target=None, continuous=None, development=None, allow_duplicate_names=None,
+               libraries=None, trigger=None, filters=None, target=None, continuous=None, development=None, allow_duplicate_names=None,
                headers=None):
         _data = {}
         if id is not None:
@@ -992,6 +992,14 @@ class DeltaPipelinesService(object):
             _data['clusters'] = clusters
         if libraries is not None:
             _data['libraries'] = libraries
+        if trigger is not None:
+            _data['trigger'] = trigger
+            if not isinstance(trigger, dict):
+                raise TypeError('Expected databricks.PipelineTrigger() or dict for field trigger')
+        if filters is not None:
+            _data['filters'] = filters
+            if not isinstance(filters, dict):
+                raise TypeError('Expected databricks.Filters() or dict for field filters')
         if target is not None:
             _data['target'] = target
         if continuous is not None:
@@ -1003,7 +1011,7 @@ class DeltaPipelinesService(object):
         return self.client.perform_query('POST', '/pipelines', data=_data, headers=headers)
 
     def deploy(self, pipeline_id=None, id=None, name=None, storage=None, configuration=None,
-               clusters=None, libraries=None, target=None, continuous=None, development=None,
+               clusters=None, libraries=None, trigger=None, filters=None, target=None, continuous=None, development=None,
                allow_duplicate_names=None, headers=None):
         _data = {}
         if id is not None:
@@ -1018,6 +1026,14 @@ class DeltaPipelinesService(object):
             _data['clusters'] = clusters
         if libraries is not None:
             _data['libraries'] = libraries
+        if trigger is not None:
+            _data['trigger'] = trigger
+            if not isinstance(trigger, dict):
+                raise TypeError('Expected databricks.PipelineTrigger() or dict for field trigger')
+        if filters is not None:
+            _data['filters'] = filters
+            if not isinstance(filters, dict):
+                raise TypeError('Expected databricks.Filters() or dict for field filters')
         if target is not None:
             _data['target'] = target
         if continuous is not None:


### PR DESCRIPTION
In the [Delta Live Tables API 2.0](https://docs.microsoft.com/en-us/azure/databricks/data-engineering/delta-live-tables/delta-live-tables-api-guide), the ` PipelineSettings` definition ([link](https://docs.microsoft.com/en-us/azure/databricks/data-engineering/delta-live-tables/delta-live-tables-api-guide#pipeline-spec)) used in the `create` ([link](https://docs.microsoft.com/en-us/azure/databricks/data-engineering/delta-live-tables/delta-live-tables-api-guide#--create-a-pipeline)) and `edit` ([link](https://docs.microsoft.com/en-us/azure/databricks/data-engineering/delta-live-tables/delta-live-tables-api-guide#edit-a-pipeline)) methods specify the following elements which are not present in the SDK code: `target`, `continuous`, `development`.

There are instead two elements (`trigger` and `filters`) which are not used and, if specified when using the SDK functions, make the code fail.