### PR TITLE
Remove UC banner warning, fix UC tables help

### DIFF
--- a/databricks_cli/unity_catalog/cli.py
+++ b/databricks_cli/unity_catalog/cli.py
@@ -37,11 +37,7 @@ from databricks_cli.unity_catalog.perms_cli import register_perms_commands
 from databricks_cli.unity_catalog.lineage_cli import register_lineage_commands
 
 
-@click.group(context_settings=CONTEXT_SETTINGS,
-             help='Utility to interact with Databricks Unity Catalog.\n\n' +
-             '**********************************************************************\n' +
-             'WARNING: these commands are EXPERIMENTAL and not officially supported.\n' +
-             '**********************************************************************')
+@click.group(context_settings=CONTEXT_SETTINGS)
 @click.option('--version', '-v', is_flag=True, callback=print_version_callback,
               expose_value=False, is_eager=True, help=version)
 def unity_catalog_group():  # pragma: no cover

--- a/databricks_cli/unity_catalog/table_cli.py
+++ b/databricks_cli/unity_catalog/table_cli.py
@@ -152,11 +152,9 @@ def delete_table_cli(api_client, full_name):
 
 @click.group(context_settings=CONTEXT_SETTINGS,
              short_help=' ',
-             help='\n**********************************************************************\n' +
-                  'Note:\n' +
-                  'To create or update tables, please run the relevant SQL commands on a\n' +
-                  'DBR cluster or SQL endpoint/warehouse (CREATE TABLE and ALTER TABLE).\n' +
-                  '**********************************************************************')
+             help='Note:\n' +
+                  'To create or update tables, use SQL commands\n' +
+                  '(CREATE TABLE or ALTER TABLE) on a cluster or SQL warehouse.')
 def tables_group():  # pragma: no cover
     pass
 

--- a/databricks_cli/unity_catalog/table_cli.py
+++ b/databricks_cli/unity_catalog/table_cli.py
@@ -150,12 +150,14 @@ def delete_table_cli(api_client, full_name):
     UnityCatalogApi(api_client).delete_table(full_name)
 
 
-@click.group()
+@click.group(context_settings=CONTEXT_SETTINGS,
+             short_help=' ',
+             help='\n**********************************************************************\n' +
+                  'Note:\n' +
+                  'To create or update tables, please run the relevant SQL commands on a\n' +
+                  'DBR cluster or SQL endpoint/warehouse (CREATE TABLE and ALTER TABLE).\n' +
+                  '**********************************************************************')
 def tables_group():  # pragma: no cover
-    """
-    Note: To create or update tables, please run the appropriate SQL commands
-    on a cluster or endpoint (CREATE TABLE and ALTER TABLE).
-    """
     pass
 
 


### PR DESCRIPTION
* Remove the EXPERIMENTAL warning for the `unity-catalog` group
* Tweak the warning help text for `unity-catalog tables` group so it doesn't show up (truncated) in `unity-catalog --help` output.

```
$ databricks unity-catalog --help
Usage: databricks unity-catalog [OPTIONS] COMMAND [ARGS]...

  Utility to interact with Databricks Unity Catalog.

Options:
  -v, --version  0.17.1.dev0
  -h, --help     Show this message and exit.

Commands:
  catalogs
  external-locations
  lineage
  metastores
  permissions
  providers
  recipients
  schemas
  shares
  storage-credentials
  tables
```
```
$ databricks unity-catalog tables --help
Usage: databricks unity-catalog tables [OPTIONS] COMMAND [ARGS]...

  Note: To create or update tables, use SQL commands  (CREATE TABLE or ALTER
  TABLE) on a cluster or SQL warehouse.

Options:
  -h, --help  Show this message and exit.

Commands:
  delete          Delete a table.
  get             Get a table.
  list            List tables.
  list-summaries  List table summaries.
```
