### PR TITLE
Remove unused constant PIPELINE_ID_PERMITTED_CHARACTERS

### DIFF
--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -46,8 +46,6 @@ try:
 except AttributeError:  # Python 2
     json_parse_exception = ValueError
 
-PIPELINE_ID_PERMITTED_CHARACTERS = set(string.ascii_letters + string.digits + '-_')
-
 
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Creates a pipeline.')

--- a/databricks_cli/pipelines/cli.py
+++ b/databricks_cli/pipelines/cli.py
@@ -23,7 +23,6 @@
 
 import os
 import json
-import string
 import requests
 
 try:


### PR DESCRIPTION
The reference to this constant was removed in #437.