### PR TITLE
Add flag for UC get-effective-permissions

### DIFF
--- a/databricks_cli/unity_catalog/api.py
+++ b/databricks_cli/unity_catalog/api.py
@@ -235,6 +235,9 @@ class UnityCatalogApi(object):
     def get_permissions(self, sec_type, sec_name):
         return self.client.get_permissions(sec_type, sec_name)
 
+    def get_effective_permissions(self, sec_type, sec_name):
+        return self.client.get_effective_permissions(sec_type, sec_name)
+
     def update_permissions(self, sec_type, sec_name, diff_spec):
         return self.client.update_permissions(sec_type, sec_name, diff_spec)
 

--- a/databricks_cli/unity_catalog/perms_cli.py
+++ b/databricks_cli/unity_catalog/perms_cli.py
@@ -67,7 +67,8 @@ def _get_perm_securable_name_and_type(catalog_name, schema_full_name, table_full
 @click.option('--external-location', cls=OneOfOption, default=None,
               one_of=PERMISSIONS_OBJ_TYPES,
               help='Name of the external location of interest')
-@click.option('--effective', '-e', is_flag=True, default=False)
+@click.option('--effective', is_flag=True, default=False,
+              help='Get effective permissions (including inherited privileges)')
 @debug_option
 @profile_option
 @eat_exceptions

--- a/databricks_cli/unity_catalog/perms_cli.py
+++ b/databricks_cli/unity_catalog/perms_cli.py
@@ -67,19 +67,23 @@ def _get_perm_securable_name_and_type(catalog_name, schema_full_name, table_full
 @click.option('--external-location', cls=OneOfOption, default=None,
               one_of=PERMISSIONS_OBJ_TYPES,
               help='Name of the external location of interest')
+@click.option('--effective', '-e', is_flag=True, default=False)
 @debug_option
 @profile_option
 @eat_exceptions
 @provide_api_client
 def get_permissions_cli(api_client, catalog, schema, table, storage_credential,
-                        external_location):
+                        external_location, effective):
     """
     Get permissions on a securable.
     """
     sec_type, sec_name = _get_perm_securable_name_and_type(catalog, schema, table,
                                                            storage_credential, external_location)
 
-    perm_json = UnityCatalogApi(api_client).get_permissions(sec_type, sec_name)
+    if effective:
+        perm_json = UnityCatalogApi(api_client).get_effective_permissions(sec_type, sec_name)
+    else:
+        perm_json = UnityCatalogApi(api_client).get_permissions(sec_type, sec_name)
     click.echo(mc_pretty_format(perm_json))
 
 

--- a/databricks_cli/unity_catalog/uc_service.py
+++ b/databricks_cli/unity_catalog/uc_service.py
@@ -474,12 +474,21 @@ class UnityCatalogService(object):
 
     # Permissions Operations
 
-    def _permissions_url(self, sec_type, sec_name):
-        return '/unity-catalog/permissions/%s/%s' % (sec_type, sec_name)
+    def _permissions_url(self, sec_type, sec_name, effective=False):
+        if effective:
+            return '/unity-catalog/effective-permissions/%s/%s' % (sec_type, sec_name)
+        else:
+            return '/unity-catalog/permissions/%s/%s' % (sec_type, sec_name)
 
     def get_permissions(self, sec_type, sec_name, headers=None):
         _data = {}
         return self.client.perform_query('GET', self._permissions_url(sec_type, sec_name),
+                                         data=_data, headers=headers)
+
+    def get_effective_permissions(self, sec_type, sec_name, headers=None):
+        _data = {}
+        return self.client.perform_query('GET', self._permissions_url(sec_type, sec_name,
+                                                                      effective=True),
                                          data=_data, headers=headers)
 
     def update_permissions(self, sec_type, sec_name, perm_diff_spec, headers=None):


### PR DESCRIPTION
* Add --effective / -e flag to unity-catalog `get-permissions` CLI which causes it to use UC's `getEffectivePermissions` endpoint.
