### PR TITLE
Allow 'new_clusters' key in 'jobs reset' option to mimic JSON API pay…

### DIFF
--- a/databricks_cli/jobs/cli.py
+++ b/databricks_cli/jobs/cli.py
@@ -87,10 +87,14 @@ def reset_cli(api_client, json_file, json, job_id, version):
         with open(json_file, 'r') as f:
             json = f.read()
     deser_json = json_loads(json)
-    request_body = {
-        'job_id': job_id,
-        'new_settings': deser_json
-    }
+    if 'new_settings' in deser_json:
+        request_body = deser_json
+        request_body['job_id'] = job_id
+    else:
+        request_body = {
+            'job_id': job_id,
+            'new_settings': deser_json
+        }
     JobsApi(api_client).reset_job(request_body, version=version)
 
 

--- a/tests/jobs/test_cli.py
+++ b/tests/jobs/test_cli.py
@@ -74,15 +74,24 @@ def test_create_cli_json_file(jobs_api_mock, tmpdir):
 
 RESET_JSON = '{"job_name": "test_job"}'
 
+CORRECT_RESPONSE = {'job_id': 1,
+                    'new_settings': json.loads(RESET_JSON)}
 
 @provide_conf
 def test_reset_cli_json(jobs_api_mock):
     runner = CliRunner()
     runner.invoke(cli.reset_cli, ['--json', RESET_JSON, '--job-id', 1])
-    assert jobs_api_mock.reset_job.call_args[0][0] == {
-        'job_id': 1,
-        'new_settings': json.loads(RESET_JSON)
-    }
+    assert jobs_api_mock.reset_job.call_args[0][0] == CORRECT_RESPONSE
+
+
+RESET_JSON_NEW_SETTINGS = '{"new_settings": {"job_name": "test_job"}}'
+
+
+@provide_conf
+def test_reset_cli_json_new_settings(jobs_api_mock):
+    runner = CliRunner()
+    runner.invoke(cli.reset_cli, ['--json', RESET_JSON_NEW_SETTINGS, '--job-id', 1])
+    assert jobs_api_mock.reset_job.call_args[0][0] == CORRECT_RESPONSE
 
 
 LIST_RETURN = {


### PR DESCRIPTION
Added check for 'new_clusters' key so that the regular JSON payload for the reset endpoint is also accepted