### PR TITLE
Don't let .netrc take precedence in ApiClient

### DIFF
--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -41,7 +41,6 @@ from . import version
 from requests.adapters import HTTPAdapter
 from requests.utils import get_netrc_auth
 from requests.auth import HTTPBasicAuth
-from requests import PreparedRequest
 from six.moves.urllib.parse import urlparse
 
 try:
@@ -77,7 +76,7 @@ class FallbackNetrcAuth(requests.auth.AuthBase):
         request.Session().auth=FallbackNetrcAuth()
     '''
 
-    def __call__(self, r: PreparedRequest):
+    def __call__(self, r):
         if "Authorization" in r.headers:
             return r
         

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -39,6 +39,9 @@ import pprint
 from . import version
 
 from requests.adapters import HTTPAdapter
+from requests.utils import get_netrc_auth
+from requests.auth import HTTPBasicAuth
+from requests import PreparedRequest
 from six.moves.urllib.parse import urlparse
 
 try:
@@ -63,6 +66,28 @@ class TlsV1HttpAdapter(HTTPAdapter):
     def init_poolmanager(self, connections, maxsize, block=False):
         self.poolmanager = PoolManager(num_pools=connections, maxsize=maxsize, block=block, ssl_version=ssl.PROTOCOL_TLSv1_2)
 
+# https://github.com/psf/requests/issues/2773#issuecomment-174312831
+class FallbackNetrcAuth(requests.auth.AuthBase):
+    '''Force requests to ignore the ``.netrc`` if other authentication 
+    methods have been setup. Fallback to ``.netrc`` if not. 
+
+    Use with::
+
+        requests.get(url, auth=FallbackNetrcAuth())
+        request.Session().auth=FallbackNetrcAuth()
+    '''
+
+    def __call__(self, r: PreparedRequest):
+        if "Authorization" in r.headers:
+            return r
+        
+        netrc_tuple = get_netrc_auth(r.url)
+
+        if netrc_tuple is None:
+            return r
+        
+        return HTTPBasicAuth(*netrc_tuple)(r)
+
 class ApiClient(object):
     """
     A partial Python implementation of dbc rest api
@@ -82,7 +107,7 @@ class ApiClient(object):
             raise_on_status=False # return original response when retries have been exhausted
         )
         self.session = requests.Session()
-        self.session.auth = lambda x: x
+        self.session.auth = FallbackNetrcAuth()
         self.session.mount('https://', TlsV1HttpAdapter(max_retries=retries))
 
         parsed_url = urlparse(host)

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -73,7 +73,9 @@ class FallbackNetrcAuth(requests.auth.AuthBase):
     Use with::
 
         requests.get(url, auth=FallbackNetrcAuth())
-        request.Session().auth=FallbackNetrcAuth()
+        
+        s = requests.Session()
+        s.auth = FallbackNetrcAuth()
     '''
 
     def __call__(self, r):

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -126,7 +126,6 @@ class ApiClient(object):
             warnings.simplefilter("ignore", exceptions.InsecureRequestWarning)
             if method == 'GET':
                 translated_data = {k: _translate_boolean_to_query_param(data[k]) for k in data}
-                print(headers, translated_data)
                 resp = self.session.request(method, self.get_url(path, version=version), params = translated_data,
                                             verify = self.verify, headers = headers)
             else:

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -31,6 +31,7 @@ A common class to be used by client of different APIs
 import base64
 import json
 import warnings
+from pytest import param
 import requests
 import ssl
 import copy
@@ -82,6 +83,7 @@ class ApiClient(object):
             raise_on_status=False # return original response when retries have been exhausted
         )
         self.session = requests.Session()
+        self.session.auth = lambda x: x
         self.session.mount('https://', TlsV1HttpAdapter(max_retries=retries))
 
         parsed_url = urlparse(host)
@@ -125,6 +127,7 @@ class ApiClient(object):
             warnings.simplefilter("ignore", exceptions.InsecureRequestWarning)
             if method == 'GET':
                 translated_data = {k: _translate_boolean_to_query_param(data[k]) for k in data}
+                print(headers, translated_data)
                 resp = self.session.request(method, self.get_url(path, version=version), params = translated_data,
                                             verify = self.verify, headers = headers)
             else:

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -84,7 +84,7 @@ class FallbackNetrcAuth(requests.auth.AuthBase):
         
         netrc_tuple = get_netrc_auth(r.url)
 
-        if netrc_tuple is None:
+        if netrc_tuple is None or not any(netrc_tuple):
             return r
         
         return HTTPBasicAuth(*netrc_tuple)(r)

--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -31,7 +31,6 @@ A common class to be used by client of different APIs
 import base64
 import json
 import warnings
-from pytest import param
 import requests
 import ssl
 import copy

--- a/tests/sdk/test_api_client.py
+++ b/tests/sdk/test_api_client.py
@@ -48,7 +48,7 @@ def m():
 
 @pytest.fixture(autouse=False)
 def netrc_b64(tmp_path, monkeypatch):
-    netrc_file_path = os.path.join(tmp_path, ".netrc")
+    netrc_file_path = os.path.join(str(tmp_path), ".netrc")
     with open(netrc_file_path, "w+") as netrc:
         #generates header Authorization: 'Basic bmV0cmM6cGFzc3dvcmQ='
         netrc.write("machine databricks.com login netrc password password")

--- a/tests/sdk/test_api_client.py
+++ b/tests/sdk/test_api_client.py
@@ -20,7 +20,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from asyncore import write
 import json
+import os
 
 import pytest
 import requests
@@ -43,6 +45,16 @@ requests_mock.mock.case_sensitive = True
 def m():
     with requests_mock.Mocker() as m:
         yield m
+
+@pytest.fixture(autouse=False)
+def netrc_b64(tmp_path, monkeypatch):
+    netrc_file_path = os.path.join(tmp_path, ".netrc")
+    with open(netrc_file_path, "w+") as netrc:
+        #generates header Authorization: 'Basic bmV0cmM6cGFzc3dvcmQ='
+        netrc.write("machine databricks.com login netrc password password")
+
+    monkeypatch.setenv("NETRC", netrc_file_path)
+    return "bmV0cmM6cGFzc3dvcmQ="
 
 def test_simple_request(m):
     data = {'cucumber': 'dade'}
@@ -130,3 +142,21 @@ def test_api_client_url_parsing():
     # databricks_cli.configure.cli
     client = ApiClient(host='http://databricks.com')
     assert client.get_url('') == 'http://databricks.com/api/2.0'
+
+def test_api_client_auth_netrc_and_user_password(m, netrc_b64):
+    m.get('https://databricks.com/api/2.0/endpoint', text=json.dumps({}))
+    client = ApiClient(user="apple", password="banana", host="https://databricks.com")
+    client.perform_query("GET", "/endpoint")
+    assert m.request_history[0].headers['Authorization'] == "Basic YXBwbGU6YmFuYW5h"
+
+def test_api_client_auth_only_valid_netrc(m, netrc_b64):
+    m.get('https://databricks.com/api/2.0/endpoint', text=json.dumps({}))
+    client = ApiClient(host="https://databricks.com")
+    client.perform_query("GET", "/endpoint")
+    assert m.request_history[0].headers['Authorization'] == "Basic " + netrc_b64
+
+def test_api_client_auth_no_netrc(m):
+    m.get('https://databricks.com/api/2.0/endpoint', text=json.dumps({}))
+    client = ApiClient(host="https://databricks.com")
+    client.perform_query("GET", "/endpoint")
+    assert "Authorization" not in m.request_history[0].headers


### PR DESCRIPTION
- Python requests library automatically picks up `.netrc` configurations for authentication. (https://github.com/psf/requests/issues/2773)
- This PR disables this behaviour to make it consistent with the docs (https://docs.databricks.com/dev-tools/cli/index.html#set-up-authentication) 
- The fix uses a workaround which should be stable until the API for authentication in requests library changes. 