### PR TITLE
Fix ApiClient.get_url() logic for Jobs API URLs

### DIFF
--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -151,7 +151,7 @@ class ApiClient(object):
     def get_url(self, path, version=None):
         if version:
             return self.url + version + path
-        elif self.jobs_api_version and path and path.startswith('/jobs'):
+        elif self.jobs_api_version and path and '/jobs' in path:
             return self.url + self.jobs_api_version + path
         elif path and _is_uc_path(path):
             return self.url + UC_API_VERSION + path


### PR DESCRIPTION
Resolves issue [Logic for jobs API URLs in sdk.ApiClient.get_url() method not evaluating to True #531](https://github.com/databricks/databricks-cli/issues/531)
Elif on line 154 isn't ever evaluating to true in my usage of DBX and databricks-cli.

Jobs API paths don't seem to start with '/jobs', instead following the format 'https://{host}.cloud.databricks.com/api/2.1/jobs/...'