### PR TITLE
Add optional region arg to "unity-catalog metastores create"

### DIFF
--- a/databricks_cli/unity_catalog/api.py
+++ b/databricks_cli/unity_catalog/api.py
@@ -31,8 +31,8 @@ class UnityCatalogApi(object):
 
     # Metastore APIs
 
-    def create_metastore(self, name, storage_root):
-        return self.client.create_metastore(name, storage_root)
+    def create_metastore(self, name, storage_root, region):
+        return self.client.create_metastore(name, storage_root, region)
 
     def list_metastores(self):
         return self.client.list_metastores()

--- a/databricks_cli/unity_catalog/metastore_cli.py
+++ b/databricks_cli/unity_catalog/metastore_cli.py
@@ -40,7 +40,8 @@ from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS, json_cli_base
 @click.option('--storage-root', required=True,
               help='Storage root URL for the new metastore.')
 @click.option('--region', required=False,
-              help='Region for the new metastore. Only workspaces from same region can be assigned.')
+              help='Region for the new metastore. ' +
+                   'Only workspaces from same region can be assigned to metastore.')
 @debug_option
 @profile_option
 @eat_exceptions

--- a/databricks_cli/unity_catalog/metastore_cli.py
+++ b/databricks_cli/unity_catalog/metastore_cli.py
@@ -39,15 +39,17 @@ from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS, json_cli_base
 @click.option('--name', required=True, help='Name of the new metastore.')
 @click.option('--storage-root', required=True,
               help='Storage root URL for the new metastore.')
+@click.option('--region', required=False,
+              help='Region for the new metastore. Only workspaces from same region can be assigned.')
 @debug_option
 @profile_option
 @eat_exceptions
 @provide_api_client
-def create_metastore_cli(api_client, name, storage_root):
+def create_metastore_cli(api_client, name, storage_root, region):
     """
     Create new metastore.
     """
-    metastore_json = UnityCatalogApi(api_client).create_metastore(name, storage_root)
+    metastore_json = UnityCatalogApi(api_client).create_metastore(name, storage_root, region)
     click.echo(mc_pretty_format(metastore_json))
 
 

--- a/databricks_cli/unity_catalog/metastore_cli.py
+++ b/databricks_cli/unity_catalog/metastore_cli.py
@@ -41,7 +41,7 @@ from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS, json_cli_base
               help='Storage root URL for the new metastore.')
 @click.option('--region', required=False,
               help='Region for the new metastore. ' +
-                   'Only workspaces from same region can be assigned to metastore.')
+                   'Only workspaces located in the same region can be assigned to this metastore.')
 @debug_option
 @profile_option
 @eat_exceptions

--- a/databricks_cli/unity_catalog/uc_service.py
+++ b/databricks_cli/unity_catalog/uc_service.py
@@ -31,11 +31,13 @@ class UnityCatalogService(object):
 
     # Metastore Operations
 
-    def create_metastore(self, name, storage_root, headers=None):
+    def create_metastore(self, name, storage_root, region, headers=None):
         _data = {
             'name': name,
             'storage_root': storage_root,
         }
+        if region is not None:
+            _data['region'] = region
         return self.client.perform_query('POST', '/unity-catalog/metastores', data=_data,
                                          headers=headers)
 


### PR DESCRIPTION
Add optional region arg to `databricks unity-catalog metastores create`
DOC ticket: https://databricks.atlassian.net/browse/DOC-5742

The old API was:
```
databricks --profile uc1 unity-catalog metastores create --name andrew_test --storage-root s3://us-east-1-extdev-managed-catalog-test-bucket-1/e280cd28-dced-4e26-b37a-2d14272e55a9
```
User could not specify region when creating a metastore, and region of metastore is always the same region as the workspace's shard. This means user could never create a metastore in a region that doesn't have a CP shard, for example: `us-west-1`, `az-australiasoutheast`. If user has workspace in these regions, they could never assign these workspaces to any metastore due to the metastore <> region matching constraint.

The new API is:
```
databricks --profile uc1 unity-catalog metastores create --name andrew_test --storage-root s3://us-east-1-extdev-managed-catalog-test-bucket-1/e280cd28-dced-4e26-b37a-2d14272e55a9 --region us-west-2
{
  "name": "andrew_test",
  "storage_root": "s3://us-east-1-extdev-managed-catalog-test-bucket-1/e280cd28-dced-4e26-b37a-2d14272e55a9/1abdb18b-1694-42f4-8fdf-82a4ab4aec3e",
  "delta_sharing_scope": "INTERNAL",
  "owner": "andrew.li+admin@databricks.com",
  "privilege_model_version": "1.0",
  "region": "us-west-2",
  "metastore_id": "1abdb18b-1694-42f4-8fdf-82a4ab4aec3e",
  "created_at": 1661398103199,
  "created_by": "andrew.li+admin@databricks.com",
  "updated_at": 1661398103199,
  "updated_by": "andrew.li+admin@databricks.com",
  "cloud": "aws",
  "global_metastore_id": "aws:us-west-2:1abdb18b-1694-42f4-8fdf-82a4ab4aec3e"
}
```
User can specify arbitrary region in the same cloud when creating metastore, and the created metastore will be located in the region user wants. If user doesn't specify the region, it will be the same as the old behavior. 

This was tested by building the CLI locally and creating a metastore with the region field specified. I also tested without region (old behavior):
```
(databrickscli) andrew.li@RGFV66WTL0 databricks-cli % databricks --profile uc1 unity-catalog metastores create --name andrew_test_2 --storage-root s3://us-east-1-extdev-managed-catalog-test-bucket-1/e280cd28-dced-4e26-b37a-2d14272e55a9
{
  "name": "andrew_test_2",
  "storage_root": "s3://us-east-1-extdev-managed-catalog-test-bucket-1/e280cd28-dced-4e26-b37a-2d14272e55a9/8c775a9a-190d-42a2-b9ee-c403a68073f9",
  "delta_sharing_scope": "INTERNAL",
  "owner": "andrew.li+admin@databricks.com",
  "privilege_model_version": "1.0",
  "region": "us-west-2",
  "metastore_id": "8c775a9a-190d-42a2-b9ee-c403a68073f9",
  "created_at": 1661406944697,
  "created_by": "andrew.li+admin@databricks.com",
  "updated_at": 1661406944697,
  "updated_by": "andrew.li+admin@databricks.com",
  "cloud": "aws",
  "global_metastore_id": "aws:us-west-2:8c775a9a-190d-42a2-b9ee-c403a68073f9"
}
```
HELP display:
```
(databrickscli) andrew.li@RGFV66WTL0 databricks-cli %  databricks --profile uc1 unity-catalog metastores create --help
Usage: databricks unity-catalog metastores create [OPTIONS]

  Create new metastore.

Options:
  --name TEXT          Name of the new metastore.  [required]
  --storage-root TEXT  Storage root URL for the new metastore.  [required]
  --region TEXT        Region for the new metastore. Only workspaces from
                       same region can be assigned to metastore.
  --debug              Debug Mode. Shows full stack trace on error.
  --profile TEXT       CLI connection profile to use. The default profile is
                       "DEFAULT".
  -h, --help           Show this message and exit.
  ```