### PR TITLE
Disable linting for 'missing-timeout'

### DIFF
--- a/prospector.yaml
+++ b/prospector.yaml
@@ -32,6 +32,7 @@ pylint:
     - raise-missing-from
     - redundant-u-string-prefix
     - consider-using-from-import
+    - missing-timeout
 
 mccabe:
   disable:


### PR DESCRIPTION
This was added in pylint==2.15.0 released on 2022-08-26.

It fails in databricks_cli/oauth/oauth.py.