### PR TITLE
Replace legacy start api in favor of updates api

### DIFF
--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -1495,7 +1495,7 @@ class DeltaPipelinesService(object):
         _data['cause'] = 'USER_ACTION'
         return self.client.perform_query(
             'POST',
-            '/pipelines/{pipeline_id}/start'.format(pipeline_id=pipeline_id),
+            '/pipelines/{pipeline_id}/updates'.format(pipeline_id=pipeline_id),
             data=_data,
             headers=headers,
         )

--- a/tests/pipelines/test_api.py
+++ b/tests/pipelines/test_api.py
@@ -233,7 +233,7 @@ def test_start_without_refresh(pipelines_api):
     expected_data = {
         "cause": "USER_ACTION"
     }
-    client_mock.assert_called_with('POST', '/pipelines/{}/start'.format(PIPELINE_ID),
+    client_mock.assert_called_with('POST', '/pipelines/{}/updates'.format(PIPELINE_ID),
                                    data=expected_data, headers=None)
 
 
@@ -245,7 +245,7 @@ def test_start_with_refresh(pipelines_api):
         "cause": "USER_ACTION",
         "full_refresh": True,
     }
-    client_mock.assert_called_with('POST', '/pipelines/{}/start'.format(PIPELINE_ID),
+    client_mock.assert_called_with('POST', '/pipelines/{}/updates'.format(PIPELINE_ID),
                                    data=expected_data, headers=None)
 
 


### PR DESCRIPTION
Replace legacy start api in favor of updates api in databricks cli. 
