### PR TITLE
Add update-table command to Delta Sharing CLI

### DIFF
--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -196,9 +196,7 @@ def create_common_shared_data_object_options(f):
                 help='New comment of the table inside the share.')
     @click.option('--partitions', default=None, type=JsonClickType(),
                 help='New partition specification of the table represented in JSON.')
-    @click.option('--cdf', is_flag=True, default=None,
-                help='Enables change data feed of the table inside the share.')
-    @click.option('--no-cdf', is_flag=True, default=None,
+    @click.option('--cdf/--no-cdf', is_flag=True, default=None,
                 help='Enables change data feed of the table inside the share.')
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
@@ -220,23 +218,13 @@ def create_common_shared_data_object_options(f):
 @eat_exceptions
 @provide_api_client
 def add_share_table_cli(api_client, share, table, shared_as, comment,
-                        partitions, cdf, no_cdf, json_file, json):
+                        partitions, cdf, json_file, json):
     """
     Adds a shared table.
 
     The public specification for the JSON request is in development.
     """
-    cdf_enabled = None
-    if cdf is not None and no_cdf is not None:
-        raise ValueError("You can only pass in either --cdf or --no-cdf and not both.")
-    
-    if cdf is not None:
-        cdf_enabled = cdf
-    elif no_cdf is not None:
-        cdf_enabled = no_cdf
-
-    if (shared_as is not None or comment is not None or partitions is not None or
-        cdf is not None or no_cdf is not None):
+    if (shared_as is not None) or (comment is not None) or (partitions is not None) or (cdf is not None):
         if (json_file is not None) or (json is not None):
             raise ValueError('Cannot specify JSON if any other flags are specified')
         data = { 
@@ -247,8 +235,8 @@ def add_share_table_cli(api_client, share, table, shared_as, comment,
                         name=table,
                         shared_as=shared_as,
                         comment=comment,
-                        cdf_enabled=cdf_enabled,
-                        partitions=json_loads(partitions),
+                        cdf_enabled=cdf,
+                        partitions=json_loads(partitions) if partitions is not None else None,
                     )
                 }
             ]
@@ -280,23 +268,13 @@ def add_share_table_cli(api_client, share, table, shared_as, comment,
 @eat_exceptions
 @provide_api_client
 def update_share_table_cli(api_client, share, table, shared_as, comment,
-                           partitions, cdf, no_cdf, json_file, json):
+                           partitions, cdf, json_file, json):
     """
     Updates a shared table.
 
     The public specification for the JSON request is in development.
     """
-    cdf_enabled = None
-    if cdf is not None and no_cdf is not None:
-        raise ValueError("You can only pass in either --cdf or --no-cdf and not both.")
-    
-    if cdf is not None:
-        cdf_enabled = cdf
-    elif no_cdf is not None:
-        cdf_enabled = no_cdf
-
-    if (shared_as is not None or comment is not None or partitions is not None or 
-        cdf is not None or no_cdf is not None):
+    if (shared_as is not None) or (comment is not None) or (partitions is not None) or (cdf is not None):
         if (json_file is not None) or (json is not None):
             raise ValueError('Cannot specify JSON if any other flags are specified')
         data = { 
@@ -307,8 +285,8 @@ def update_share_table_cli(api_client, share, table, shared_as, comment,
                         name=table,
                         shared_as=shared_as,
                         comment=comment,
-                        cdf_enabled=cdf_enabled,
-                        partitions=json_loads(partitions),
+                        cdf_enabled=cdf,
+                        partitions=json_loads(partitions) if partitions is not None else None,
                     )
                 }
             ]

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -150,10 +150,10 @@ def shared_data_object(name=None, comment=None, shared_as=None, cdf_enabled=None
 @click.option('--owner', default=None, required=False,
               help='Owner of the share.')
 @click.option('--add-table', default=None, multiple=True,
-              metavar='NAME',
+              metavar='NAME', hidden=True,
               help='Full name of table to add to share (can be specified multiple times).')
 @click.option('--remove-table', default=None, multiple=True,
-              metavar='NAME',
+              metavar='NAME', hidden=True,
               help='Full name of table to remove from share (can be specified multiple times).')
 @click.option('--json-file', default=None, type=click.Path(),
               help=json_file_help(method='PATCH', path='/shares/{name}'))
@@ -189,15 +189,15 @@ def update_share_cli(api_client, name, new_name, comment, owner,
 
 def create_common_shared_data_object_options(f):
     @click.option('--table', required=True,
-              help='Full name of the table to update from share.')
+                  help='Full name of the shared table.')
     @click.option('--shared-as', default=None,
-                help='New name of the table inside the share.')
+                  help='New name of the table to be shared as.')
     @click.option('--comment', default=None,
-                help='New comment of the table inside the share.')
+                  help='New comment of the shared table.')
     @click.option('--partitions', default=None, type=JsonClickType(),
-                help='New partition specification of the table represented in JSON.')
+                  help='New partition specification of the shared table represented in JSON.')
     @click.option('--cdf/--no-cdf', is_flag=True, default=None,
-                help='Enables change data feed of the table inside the share.')
+                  help='Enables change data feed of the shared table.')
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
         f(*args, **kwargs)

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -220,7 +220,8 @@ def update_share_table_cli(api_client, share, table, shared_as, comment,
     cdf_enabled = None
     if enable_cdf is not None and disable_cdf is not None:
         raise ValueError("You can only pass in either --enable-cdf or --disable-cdf and not both.")
-    elif enable_cdf is not None:
+    
+    if enable_cdf is not None:
         cdf_enabled = enable_cdf
     elif disable_cdf is not None:
         cdf_enabled = disable_cdf

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -152,6 +152,7 @@ def shared_data_object(name=None, comment=None, shared_as=None,
               help='Free-form text description.')
 @click.option('--owner', default=None, required=False,
               help='Owner of the share.')
+# These options are hidden to encourage the usage of the new commands: add-table/update-table
 @click.option('--add-table', default=None, multiple=True,
               metavar='NAME', hidden=True,
               help='Full name of table to add to share (can be specified multiple times).')

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -226,8 +226,8 @@ def add_share_table_cli(api_client, share, table, shared_as, comment,
     elif no_cdf is not None:
         cdf_enabled = no_cdf
 
-    if shared_as is not None or comment is not None or partitions is not None or \
-        cdf is not None or no_cdf is not None:
+    if (shared_as is not None or comment is not None or partitions is not None or
+        cdf is not None or no_cdf is not None):
         if (json_file is not None) or (json is not None):
             raise ValueError('Cannot specify JSON if any other flags are specified')
         data = { 
@@ -297,8 +297,8 @@ def update_share_table_cli(api_client, share, table, shared_as, comment,
     elif no_cdf is not None:
         cdf_enabled = no_cdf
 
-    if shared_as is not None or comment is not None or partitions is not None or \
-        cdf is not None or no_cdf is not None:
+    if (shared_as is not None or comment is not None or partitions is not None or 
+        cdf is not None or no_cdf is not None):
         if (json_file is not None) or (json is not None):
             raise ValueError('Cannot specify JSON if any other flags are specified')
         data = { 

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -195,7 +195,7 @@ def create_common_shared_data_object_options(f):
     @click.option('--comment', default=None,
                 help='New comment of the table inside the share.')
     @click.option('--partitions', default=None, type=JsonClickType(),
-                help='New partition specification of the table inside the share represented in JSON.')
+                help='New partition specification of the table represented in JSON.')
     @click.option('--cdf', is_flag=True, default=None,
                 help='Enables change data feed of the table inside the share.')
     @click.option('--no-cdf', is_flag=True, default=None,

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -208,7 +208,7 @@ def update_share_cli(api_client, name, new_name, comment, owner,
 @profile_option
 @eat_exceptions
 @provide_api_client
-def update_share_table_cli(api_client, name, table, shared_as, comment,
+def update_share_table_cli(api_client, share, table, shared_as, comment,
                      partition_spec, enable_cdf, disable_cdf, json_file, json):
     """
     Updates a shared table.
@@ -243,10 +243,10 @@ def update_share_table_cli(api_client, name, table, shared_as, comment,
                 }
             ]
         }
-        share_json = UnityCatalogApi(api_client).update_share(name, data)
+        share_json = UnityCatalogApi(api_client).update_share(share, data)
         click.echo(mc_pretty_format(share_json))
     else:
-        json_cli_base(json_file, json, lambda d: UnityCatalogApi(api_client).update_share(name, { 
+        json_cli_base(json_file, json, lambda d: UnityCatalogApi(api_client).update_share(share, { 
             'updates': [
                 {
                     'action': 'UPDATE',

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -123,7 +123,8 @@ def update_share_permissions_cli(api_client, name, json_file, json):
                   lambda json: UnityCatalogApi(api_client).update_share_permissions(name, json))
 
 
-def shared_data_object(name=None, comment=None, shared_as=None, cdf_enabled=None, partitions=None):
+def shared_data_object(name=None, comment=None, shared_as=None, 
+                       cdf_enabled=None, partitions=None, start_version=None):
     val = {
         'data_object_type': 'TABLE'
     }
@@ -137,6 +138,8 @@ def shared_data_object(name=None, comment=None, shared_as=None, cdf_enabled=None
         val['cdf_enabled'] = cdf_enabled
     if partitions is not None:
         val['partitions'] = partitions
+    if start_version is not None:
+        val['start_version'] = start_version
     return val
 
 
@@ -197,7 +200,9 @@ def create_common_shared_data_object_options(f):
     @click.option('--partitions', default=None, type=JsonClickType(),
                   help='New partition specification of the shared table represented in JSON.')
     @click.option('--cdf/--no-cdf', is_flag=True, default=None,
-                  help='Enables change data feed of the shared table.')
+                  help='Toggles the change data feed for the shared table.')
+    @click.option('--start-version', default=None, type=int,
+                  help='Specifies the current version of the shared table.')
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
         f(*args, **kwargs)
@@ -218,14 +223,14 @@ def create_common_shared_data_object_options(f):
 @eat_exceptions
 @provide_api_client
 def add_share_table_cli(api_client, share, table, shared_as, comment,
-                        partitions, cdf, json_file, json):
+                        partitions, cdf, start_version, json_file, json):
     """
     Adds a shared table.
 
     The public specification for the JSON request is in development.
     """
     if ((shared_as is not None) or (comment is not None) or (partitions is not None) or 
-        (cdf is not None)):
+        (cdf is not None) or (start_version is not None)):
         if (json_file is not None) or (json is not None):
             raise ValueError('Cannot specify JSON if any other flags are specified')
         data = { 
@@ -238,6 +243,7 @@ def add_share_table_cli(api_client, share, table, shared_as, comment,
                         comment=comment,
                         cdf_enabled=cdf,
                         partitions=json_loads(partitions) if partitions is not None else None,
+                        start_version=start_version,
                     )
                 }
             ]
@@ -269,14 +275,14 @@ def add_share_table_cli(api_client, share, table, shared_as, comment,
 @eat_exceptions
 @provide_api_client
 def update_share_table_cli(api_client, share, table, shared_as, comment,
-                           partitions, cdf, json_file, json):
+                           partitions, cdf, start_version, json_file, json):
     """
     Updates a shared table.
 
     The public specification for the JSON request is in development.
     """
     if ((shared_as is not None) or (comment is not None) or (partitions is not None) or 
-        (cdf is not None)):
+        (cdf is not None) or (start_version is not None)):
         if (json_file is not None) or (json is not None):
             raise ValueError('Cannot specify JSON if any other flags are specified')
         data = { 
@@ -289,6 +295,7 @@ def update_share_table_cli(api_client, share, table, shared_as, comment,
                         comment=comment,
                         cdf_enabled=cdf,
                         partitions=json_loads(partitions) if partitions is not None else None,
+                        start_version=start_version,
                     )
                 }
             ]

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -224,7 +224,8 @@ def add_share_table_cli(api_client, share, table, shared_as, comment,
 
     The public specification for the JSON request is in development.
     """
-    if (shared_as is not None) or (comment is not None) or (partitions is not None) or (cdf is not None):
+    if ((shared_as is not None) or (comment is not None) or (partitions is not None) or 
+        (cdf is not None)):
         if (json_file is not None) or (json is not None):
             raise ValueError('Cannot specify JSON if any other flags are specified')
         data = { 
@@ -274,7 +275,8 @@ def update_share_table_cli(api_client, share, table, shared_as, comment,
 
     The public specification for the JSON request is in development.
     """
-    if (shared_as is not None) or (comment is not None) or (partitions is not None) or (cdf is not None):
+    if ((shared_as is not None) or (comment is not None) or (partitions is not None) or 
+        (cdf is not None)):
         if (json_file is not None) or (json is not None):
             raise ValueError('Cannot specify JSON if any other flags are specified')
         data = { 

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -210,9 +210,9 @@ def create_common_shared_data_object_options(f):
               help='Name of the share to update.')
 @create_common_shared_data_object_options
 @click.option('--json-file', default=None, type=click.Path(),
-              help="Updates the shared table to shared data object represented in JSON file.")
+              help="Adds a shared table based on shared data object represented in JSON file.")
 @click.option('--json', default=None, type=JsonClickType(),
-              help="Updates the shared table to shared data object represented in JSON.")
+              help="Adds a shared table based on shared data object represented in JSON.")
 @debug_option
 @profile_option
 @eat_exceptions
@@ -315,9 +315,9 @@ def update_share_table_cli(api_client, share, table, shared_as, comment,
 @click.option('--shared-as', default=None,
               help='New name of the table inside the share.')
 @click.option('--json-file', default=None, type=click.Path(),
-              help="Updates the shared table to shared data object represented in JSON file.")
+              help="Removes the shared table based on the shared data object represented in JSON file.")
 @click.option('--json', default=None, type=JsonClickType(),
-              help="Updates the shared table to shared data object represented in JSON.")
+              help="Removes the shared table based on the shared data object represented in JSON.")
 @debug_option
 @profile_option
 @eat_exceptions

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -315,9 +315,9 @@ def update_share_table_cli(api_client, share, table, shared_as, comment,
 @click.option('--shared-as', default=None,
               help='New name of the table inside the share.')
 @click.option('--json-file', default=None, type=click.Path(),
-              help="Removes the shared table based on the shared data object represented in JSON file.")
+              help="Removes the shared table based on shared data object represented in JSON file.")
 @click.option('--json', default=None, type=JsonClickType(),
-              help="Removes the shared table based on the shared data object represented in JSON.")
+              help="Removes the shared table based on shared data object represented in JSON.")
 @debug_option
 @profile_option
 @eat_exceptions

--- a/databricks_cli/unity_catalog/utils.py
+++ b/databricks_cli/unity_catalog/utils.py
@@ -21,8 +21,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
-import itertools
 import copy
 
 from databricks_cli.utils import pretty_format
@@ -65,43 +63,3 @@ def json_file_help(method, path):
 def json_string_help(method, path):
     path = "/api/2.0/unity-catalog" + path
     return "JSON string to {} to {}.".format(method, path)
-
-
-def peek(iterable):
-    try:
-        first = next(iterable)
-    except StopIteration:
-        return None
-    return itertools.chain([first], iterable)
-
-
-spec_regex = r"(\w+)\s*(\=|like)\s*'([\w\d\s]+)'[,\s]*"
-partition_regex = r"\((?:%s)+\)[,\s]*" % spec_regex
-
-def parse_partitions(partition_spec):
-    if partition_spec is None:
-        return None
-
-    partitions = []
-
-    trimmed = partition_spec.strip()
-    if len(trimmed) == 0:
-        return partitions
-
-    it = peek(re.finditer(partition_regex, trimmed, re.IGNORECASE))
-    if it is None:
-        raise ValueError("Bad partition specification format")
-
-    for match in it:
-        values = []
-        partition = match.group()
-        for (name, op, value) in re.findall(spec_regex, partition, re.IGNORECASE):
-            values.append({
-                'name': name,
-                'op': 'EQUAL' if op == '=' else 'LIKE',
-                'value': value,
-            })
-        partitions.append({
-            'values': values,
-        })
-    return partitions

--- a/databricks_cli/unity_catalog/utils.py
+++ b/databricks_cli/unity_catalog/utils.py
@@ -21,7 +21,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
+import itertools
 import copy
+import click
 
 from databricks_cli.utils import pretty_format
 
@@ -63,3 +66,43 @@ def json_file_help(method, path):
 def json_string_help(method, path):
     path = "/api/2.0/unity-catalog" + path
     return "JSON string to {} to {}.".format(method, path)
+
+
+def peek(iterable):
+    try:
+        first = next(iterable)
+    except StopIteration:
+        return None
+    return itertools.chain([first], iterable)
+
+
+spec_regex = r"(\w+)\s*(\=|like)\s*'([\w\d\s]+)'[,\s]*"
+partition_regex = r"\((?:%s)+\)[,\s]*" % spec_regex
+
+def parse_partitions(partition_spec):
+    if partition_spec is None:
+        return None
+
+    partitions = []
+
+    trimmed = partition_spec.strip()
+    if len(trimmed) == 0:
+        return partitions
+
+    it = peek(re.finditer(partition_regex, trimmed, re.IGNORECASE))
+    if it is None:
+        raise click.BadParameter("bad partition specification format")
+
+    for match in it:
+        values = []
+        partition = match.group()
+        for (name, op, value) in re.findall(spec_regex, partition, re.IGNORECASE):
+            values.append({
+                'name': name,
+                'op': 'EQUAL' if op == '=' else 'LIKE',
+                'value': value,
+            })
+        partitions.append({
+            'values': values,
+        })
+    return partitions

--- a/databricks_cli/unity_catalog/utils.py
+++ b/databricks_cli/unity_catalog/utils.py
@@ -24,7 +24,6 @@
 import re
 import itertools
 import copy
-import click
 
 from databricks_cli.utils import pretty_format
 
@@ -91,7 +90,7 @@ def parse_partitions(partition_spec):
 
     it = peek(re.finditer(partition_regex, trimmed, re.IGNORECASE))
     if it is None:
-        raise click.BadParameter("bad partition specification format")
+        raise ValueError("Bad partition specification format")
 
     for match in it:
         values = []

--- a/tests/unity_catalog/test_delta_sharing_cli.py
+++ b/tests/unity_catalog/test_delta_sharing_cli.py
@@ -228,6 +228,7 @@ def test_add_share_table_cli(api_mock, echo_mock):
             '--comment', 'add.comment',
             '--partitions', '[{"values": [{"name": "a", "op": "EQUAL", "value": "1"}]}]',
             '--cdf',
+            '--start-version', '1'
         ])
     expected_data = {
         'updates': [
@@ -249,7 +250,8 @@ def test_add_share_table_cli(api_mock, echo_mock):
                                 },
                             ]
                         },
-                    ]
+                    ],
+                    'start_version': 1
                 }
             }
         ]
@@ -271,6 +273,7 @@ def test_update_share_table_cli(api_mock, echo_mock):
             '--comment', 'update.comment',
             '--partitions', '[{"values": [{"name": "a", "op": "EQUAL", "value": "1"}]}]',
             '--cdf',
+            '--start-version', '1'
         ])
     expected_data = {
         'updates': [
@@ -292,7 +295,8 @@ def test_update_share_table_cli(api_mock, echo_mock):
                                 },
                             ]
                         },
-                    ]
+                    ],
+                    'start_version': 1
                 }
             }
         ]

--- a/tests/unity_catalog/test_delta_sharing_cli.py
+++ b/tests/unity_catalog/test_delta_sharing_cli.py
@@ -291,21 +291,21 @@ def test_invalid_partition_syntax():
     err = None
     try:
         parse_partitions('a=1')
-    except click.BadParameter as e:
+    except ValueError as e:
         err = e
     assert err is not None
 
     err = None
     try:
         parse_partitions('(a=1')
-    except click.BadParameter as e:
+    except ValueError as e:
         err = e
     assert err is not None
 
     err = None
     try:
         parse_partitions("(a='\\'', b LIKE 'like LIKE'), (c = '\\(=)')")
-    except click.BadParameter as e:
+    except ValueError as e:
         err = e
     assert err is not None
 

--- a/tests/unity_catalog/test_delta_sharing_cli.py
+++ b/tests/unity_catalog/test_delta_sharing_cli.py
@@ -26,7 +26,7 @@
 import mock
 import pytest
 from click.testing import CliRunner
-from databricks_cli.unity_catalog.utils import mc_pretty_format, parse_partitions
+from databricks_cli.unity_catalog.utils import mc_pretty_format
 
 from databricks_cli.unity_catalog import delta_sharing_cli
 from tests.utils import provide_conf
@@ -215,100 +215,6 @@ def test_update_share_cli(api_mock, echo_mock):
     echo_mock.assert_called_once_with(mc_pretty_format(SHARE))
 
 
-def test_single_partition_value():
-    assert parse_partitions("(a='1')") == [
-        {
-            'values': [
-                {
-                    'name': 'a',
-                    'op': 'EQUAL',
-                    'value': '1'
-                }
-            ]
-        }
-    ]
-
-
-def test_multiple_partition_values():
-    assert parse_partitions("(a='1', b LIKE '3', c like '4')") == [
-        {
-            'values': [
-                {
-                    'name': 'a',
-                    'op': 'EQUAL',
-                    'value': '1'
-                },
-                {
-                    'name': 'b',
-                    'op': 'LIKE',
-                    'value': '3'
-                },
-                {
-                    'name': 'c',
-                    'op': 'LIKE',
-                    'value': '4'
-                }
-            ]
-        }
-    ]
-
-
-def test_multiple_partition_specifications():
-    assert parse_partitions("(a='1'), (b LIKE '3', c like '4')") == [
-        {
-            'values': [
-                {
-                    'name': 'a',
-                    'op': 'EQUAL',
-                    'value': '1'
-                },
-            ]
-        },
-        {
-            'values': [
-                {
-                    'name': 'b',
-                    'op': 'LIKE',
-                    'value': '3'
-                },
-                {
-                    'name': 'c',
-                    'op': 'LIKE',
-                    'value': '4'
-                }
-            ]
-        }
-    ]
-
-
-def test_parse_empty_partitions_properly():
-    assert parse_partitions('') == []
-    assert parse_partitions('  ') == []
-
-
-def test_invalid_partition_syntax():
-    err = None
-    try:
-        parse_partitions('a=1')
-    except ValueError as e:
-        err = e
-    assert err is not None
-
-    err = None
-    try:
-        parse_partitions('(a=1')
-    except ValueError as e:
-        err = e
-    assert err is not None
-
-    err = None
-    try:
-        parse_partitions("(a='\\'', b LIKE 'like LIKE'), (c = '\\(=)')")
-    except ValueError as e:
-        err = e
-    assert err is not None
-
-
 @provide_conf
 def test_update_share_table_cli(api_mock, echo_mock):
     api_mock.update_share.return_value = SHARE
@@ -320,8 +226,8 @@ def test_update_share_table_cli(api_mock, echo_mock):
             '--table', 'update.table',
             '--shared-as', 'catalog.schema.table',
             '--comment', 'update.comment',
-            '--partition-spec', '(a = \'1\', b LIKE \'bob\'), (c = \'2\')',
-            '--enable-cdf'
+            '--partitions', '[{"values": [{"name": "a", "op": "EQUAL", "value": "1"}]}]',
+            '--cdf',
         ])
     expected_data = {
         'updates': [
@@ -340,20 +246,6 @@ def test_update_share_table_cli(api_mock, echo_mock):
                                     'name': 'a',
                                     'op': 'EQUAL',
                                     'value': '1',
-                                },
-                                {
-                                    'name': 'b',
-                                    'op': 'LIKE',
-                                    'value': 'bob',
-                                }
-                            ]
-                        },
-                        {
-                            'values': [
-                                {
-                                    'name': 'c',
-                                    'op': 'EQUAL',
-                                    'value': '2',
                                 },
                             ]
                         },

--- a/tests/unity_catalog/test_delta_sharing_cli.py
+++ b/tests/unity_catalog/test_delta_sharing_cli.py
@@ -25,7 +25,6 @@
 
 import mock
 import pytest
-import click
 from click.testing import CliRunner
 from databricks_cli.unity_catalog.utils import mc_pretty_format, parse_partitions
 

--- a/tests/unity_catalog/test_delta_sharing_cli.py
+++ b/tests/unity_catalog/test_delta_sharing_cli.py
@@ -302,7 +302,7 @@ def test_update_share_table_cli(api_mock, echo_mock):
 
 
 @provide_conf
-def test_remove_share_table_cli(api_mock, echo_mock):
+def test_remove_share_table_cli_by_table(api_mock, echo_mock):
     api_mock.update_share.return_value = SHARE
     runner = CliRunner()
     runner.invoke(
@@ -310,7 +310,6 @@ def test_remove_share_table_cli(api_mock, echo_mock):
         args=[
             '--share', SHARE_NAME,
             '--table', 'remove.table',
-            '--shared-as', 'catalog.schema.table',
         ])
     expected_data = {
         'updates': [
@@ -319,6 +318,30 @@ def test_remove_share_table_cli(api_mock, echo_mock):
                 'data_object': {
                     'data_object_type': 'TABLE',
                     'name': 'remove.table',
+                }
+            }
+        ]
+    }
+    api_mock.update_share.assert_called_once_with(SHARE_NAME, expected_data)
+    echo_mock.assert_called_once_with(mc_pretty_format(SHARE))
+
+
+@provide_conf
+def test_remove_share_table_cli_by_shared_as(api_mock, echo_mock):
+    api_mock.update_share.return_value = SHARE
+    runner = CliRunner()
+    runner.invoke(
+        delta_sharing_cli.remove_share_table_cli,
+        args=[
+            '--share', SHARE_NAME,
+            '--shared-as', 'catalog.schema.table',
+        ])
+    expected_data = {
+        'updates': [
+            {
+                'action': 'REMOVE',
+                'data_object': {
+                    'data_object_type': 'TABLE',
                     'shared_as': 'catalog.schema.table',
                 }
             }
@@ -328,6 +351,18 @@ def test_remove_share_table_cli(api_mock, echo_mock):
     echo_mock.assert_called_once_with(mc_pretty_format(SHARE))
 
 
+@provide_conf
+def test_remove_share_table_cli_asserts_error_if_both_specified(api_mock):
+    runner = CliRunner()
+    runner.invoke(
+        delta_sharing_cli.remove_share_table_cli,
+        args=[
+            '--share', SHARE_NAME,
+            '--table', 'remove.table',
+            '--shared-as', 'catalog.schema.table'
+        ]
+    )
+    assert not api_mock.update_share.called
 
 @provide_conf
 def test_update_share_cli_with_json(api_mock, echo_mock):

--- a/tests/unity_catalog/test_delta_sharing_cli.py
+++ b/tests/unity_catalog/test_delta_sharing_cli.py
@@ -184,29 +184,72 @@ def test_update_share_cli(api_mock, echo_mock):
             {
                 'action': 'ADD',
                 'data_object': {
-                    'name': 'add.table.one',
-                    'data_object_type': 'TABLE'
+                    'data_object_type': 'TABLE',
+                    'name': 'add.table.one'
                 }
             },
             {
                 'action': 'ADD',
                 'data_object': {
-                    'name': 'add.table.two',
-                    'data_object_type': 'TABLE'
+                    'data_object_type': 'TABLE',
+                    'name': 'add.table.two'
                 }
             },
             {
                 'action': 'REMOVE',
                 'data_object': {
-                    'name': 'remove.table.one',
-                    'data_object_type': 'TABLE'
+                    'data_object_type': 'TABLE',
+                    'name': 'remove.table.one'
                 }
             },
             {
                 'action': 'REMOVE',
                 'data_object': {
-                    'name': 'remove.table.two',
-                    'data_object_type': 'TABLE'
+                    'data_object_type': 'TABLE',
+                    'name': 'remove.table.two'
+                }
+            }
+        ]
+    }
+    api_mock.update_share.assert_called_once_with(SHARE_NAME, expected_data)
+    echo_mock.assert_called_once_with(mc_pretty_format(SHARE))
+
+
+@provide_conf
+def test_add_share_table_cli(api_mock, echo_mock):
+    api_mock.update_share.return_value = SHARE
+    runner = CliRunner()
+    runner.invoke(
+        delta_sharing_cli.add_share_table_cli,
+        args=[
+            '--share', SHARE_NAME,
+            '--table', 'add.table',
+            '--shared-as', 'catalog.schema.table',
+            '--comment', 'add.comment',
+            '--partitions', '[{"values": [{"name": "a", "op": "EQUAL", "value": "1"}]}]',
+            '--cdf',
+        ])
+    expected_data = {
+        'updates': [
+            {
+                'action': 'ADD',
+                'data_object': {
+                    'data_object_type': 'TABLE',
+                    'name': 'add.table',
+                    'comment': 'add.comment',
+                    'shared_as': 'catalog.schema.table',
+                    'cdf_enabled': True,
+                    'partitions': [
+                        {
+                            'values': [
+                                {
+                                    'name': 'a',
+                                    'op': 'EQUAL',
+                                    'value': '1',
+                                },
+                            ]
+                        },
+                    ]
                 }
             }
         ]
@@ -234,8 +277,8 @@ def test_update_share_table_cli(api_mock, echo_mock):
             {
                 'action': 'UPDATE',
                 'data_object': {
-                    'name': 'update.table',
                     'data_object_type': 'TABLE',
+                    'name': 'update.table',
                     'comment': 'update.comment',
                     'shared_as': 'catalog.schema.table',
                     'cdf_enabled': True,
@@ -256,6 +299,34 @@ def test_update_share_table_cli(api_mock, echo_mock):
     }
     api_mock.update_share.assert_called_once_with(SHARE_NAME, expected_data)
     echo_mock.assert_called_once_with(mc_pretty_format(SHARE))
+
+
+@provide_conf
+def test_remove_share_table_cli(api_mock, echo_mock):
+    api_mock.update_share.return_value = SHARE
+    runner = CliRunner()
+    runner.invoke(
+        delta_sharing_cli.remove_share_table_cli,
+        args=[
+            '--share', SHARE_NAME,
+            '--table', 'remove.table',
+            '--shared-as', 'catalog.schema.table',
+        ])
+    expected_data = {
+        'updates': [
+            {
+                'action': 'REMOVE',
+                'data_object': {
+                    'data_object_type': 'TABLE',
+                    'name': 'remove.table',
+                    'shared_as': 'catalog.schema.table',
+                }
+            }
+        ]
+    }
+    api_mock.update_share.assert_called_once_with(SHARE_NAME, expected_data)
+    echo_mock.assert_called_once_with(mc_pretty_format(SHARE))
+
 
 
 @provide_conf


### PR DESCRIPTION
This PR adds the following command to Delta Sharing CLI:

```
databricks unity-catalog shares add-table 
  --share a 
  --table b
  --shared-as "catalog.schema.table"
  --comment "comment to update to"
  --partitions '[{"values": [{"name": "a", "op": "EQUAL", "value": "1"}]}]'
  --cdf/--no-cdf
  --start-version 1

databricks unity-catalog shares add-table
  --share a 
  --table b
  --json "{...}"

databricks unity-catalog shares add-table
  --share a 
  --table b
  --json-file /path/to/json/file

databricks unity-catalog shares update-table 
  --share a 
  --table b
  --shared-as "catalog.schema.table"
  --comment "comment to update to"
  --partitions '[{"values": [{"name": "a", "op": "EQUAL", "value": "1"}]}]'
  --cdf/--no-cdf
  --start-version 1
  
databricks unity-catalog shares update-table
  --share a 
  --table b
  --json "{...}"

databricks unity-catalog shares update-table
  --share a 
  --table b
  --json-file /path/to/json/file

databricks unity-catalog shares remove-table
  --share a
  --table b

databricks unity-catalog shares remove-table
  --share a
  --shared-as "catalog.schema.table"

# On the backend, will default to using "catalog.schema.table" to remove the table
databricks unity-catalog shares remove-table
  --share a
  --table b
  --shared-as "catalog.schema.table"

databricks unity-catalog shares remove-table
  --share a 
  --json "{...}"

databricks unity-catalog shares remove-table
  --share a 
  --json-file /path/to/json/file
```

<img width="1305" alt="image" src="https://user-images.githubusercontent.com/113815940/196832950-b394a53d-6750-4f42-ace1-759e48fa3f29.png">

<img width="1232" alt="image" src="https://user-images.githubusercontent.com/113815940/196832987-03808501-b463-4156-8084-2ac520624339.png">


