### PR TITLE
Deprecate Stack CLI

### DIFF
--- a/databricks_cli/stack/api.py
+++ b/databricks_cli/stack/api.py
@@ -73,13 +73,13 @@ DBFS_RESOURCE_PATH = 'path'
 DBFS_RESOURCE_IS_DIR = 'is_dir'
 
 
+STACK_CLI_DEPRECATION = '''Stack CLI is deprecated. Please switch to using 
+the generally available Databricks Terraform Provider instead:
+https://docs.databricks.com/dev-tools/terraform/index.html'''
+
 class StackApi(object):
     def __init__(self, api_client):
-        warnings.warn('''Stack CLI is deprecated.
-        
-        Please switch to using the generally available Databricks Terraform Provider instead.
-        https://docs.databricks.com/dev-tools/terraform/index.html
-        ''', DeprecationWarning)
+        warnings.warn(STACK_CLI_DEPRECATION, DeprecationWarning)
         self.jobs_client = JobsApi(api_client)
         self.workspace_client = WorkspaceApi(api_client)
         self.dbfs_client = DbfsApi(api_client)

--- a/databricks_cli/stack/api.py
+++ b/databricks_cli/stack/api.py
@@ -23,6 +23,7 @@
 
 import os
 import json
+import warnings
 from datetime import datetime
 from requests.exceptions import HTTPError
 
@@ -74,6 +75,11 @@ DBFS_RESOURCE_IS_DIR = 'is_dir'
 
 class StackApi(object):
     def __init__(self, api_client):
+        warnings.warn('''Stack CLI is deprecated.
+        
+        Please switch to using the generally available Databricks Terraform Provider instead.
+        https://docs.databricks.com/dev-tools/terraform/index.html
+        ''', DeprecationWarning)
         self.jobs_client = JobsApi(api_client)
         self.workspace_client = WorkspaceApi(api_client)
         self.dbfs_client = DbfsApi(api_client)

--- a/databricks_cli/stack/cli.py
+++ b/databricks_cli/stack/cli.py
@@ -28,7 +28,7 @@ import click
 from databricks_cli.utils import eat_exceptions, CONTEXT_SETTINGS
 from databricks_cli.version import print_version_callback, version
 from databricks_cli.configure.config import provide_api_client, profile_option, debug_option
-from databricks_cli.stack.api import StackApi
+from databricks_cli.stack.api import StackApi, STACK_CLI_DEPRECATION
 
 DEBUG_MODE = True
 
@@ -88,15 +88,18 @@ def _save_json(path, data):
 @provide_api_client
 def deploy(api_client, config_path, **kwargs):
     """
-    Deploy a stack to the databricks workspace given a JSON stack configuration template.
+    [Deprecated] Deploy a stack to the databricks workspace given a JSON stack configuration
+    template.
 
     After deployment, a stack status will be saves at <config_file_name>.deployed.json. Please
     do not edit or move the file as it is generated through the CLI and is used for future
     deployments of the stack. If you run into errors with the stack status at deployment,
-    please delete the stack status file and try the deployment again. If the problem persists,
-    please raise a Github issue on the Databricks CLI repository at
-    https://www.github.com/databricks/databricks-cli/issues
+    please delete the stack status file and try the deployment again.
+
+    Please switch to using the generally available Databricks Terraform Provider instead:
+    https://docs.databricks.com/dev-tools/terraform/index.html
     """
+    click.secho('WARNING: ' + STACK_CLI_DEPRECATION, bg='red', fg='white')
     click.echo('#' * 80)
     click.echo('Deploying stack at: {} with options: {}'.format(config_path, kwargs))
     stack_config = _load_json(config_path)
@@ -127,9 +130,13 @@ def deploy(api_client, config_path, **kwargs):
 @provide_api_client
 def download(api_client, config_path, **kwargs):
     """
-    Download workspace notebooks of a stack to the local filesystem given a JSON stack
+    [Deprecated] Download workspace notebooks of a stack to the local filesystem given a JSON stack
     configuration template.
+
+    Please switch to using the generally available Databricks Terraform Provider instead:
+    https://docs.databricks.com/dev-tools/terraform/index.html
     """
+    click.secho('WARNING: ' + STACK_CLI_DEPRECATION, bg='red', fg='white')
     click.echo('#' * 80)
     click.echo('Downloading stack at: {} with options: {}'.format(config_path, kwargs))
     stack_config = _load_json(config_path)
@@ -149,7 +156,10 @@ def download(api_client, config_path, **kwargs):
 @profile_option
 def stack_group():  # pragma: no cover
     """
-    [Beta] Utility to deploy and download Databricks resource stacks.
+    [Deprecated] Utility to deploy and download Databricks resource stacks.
+
+    Please switch to using the generally available Databricks Terraform Provider instead:
+    https://docs.databricks.com/dev-tools/terraform/index.html
     """
     pass
 


### PR DESCRIPTION
This pull request adds warning messages in:

* StackApi class
* Help messages
* `databricks stack download` and `databricks stack deploy` commands

<img width="592" alt="image" src="https://user-images.githubusercontent.com/259697/197014665-9ac7f285-c7f9-4fa0-acb4-660472359741.png">
<img width="801" alt="image" src="https://user-images.githubusercontent.com/259697/197015872-6a3cde1b-8ca7-4b76-93c8-f276a24879c9.png">
<img width="822" alt="image" src="https://user-images.githubusercontent.com/259697/197016046-95d2753b-17fc-44c6-964b-802e7e64ea63.png">

