### PR TITLE
CLI support for setting Delta Sharing recipient properties

### DIFF
--- a/databricks_cli/unity_catalog/api.py
+++ b/databricks_cli/unity_catalog/api.py
@@ -194,9 +194,9 @@ class UnityCatalogApi(object):
     # Recipient APIs
 
     def create_recipient(self, name, comment, sharing_id,
-                         allowed_ip_addresses, properties):
+                         allowed_ip_addresses, custom_properties):
         return self.client.create_recipient(name, comment, sharing_id,
-                                            allowed_ip_addresses, properties)
+                                            allowed_ip_addresses, custom_properties)
 
     def list_recipients(self):
         return self.client.list_recipients()

--- a/databricks_cli/unity_catalog/api.py
+++ b/databricks_cli/unity_catalog/api.py
@@ -193,8 +193,8 @@ class UnityCatalogApi(object):
 
     # Recipient APIs
 
-    def create_recipient(self, name, comment, sharing_id, allowed_ip_addresses):
-        return self.client.create_recipient(name, comment, sharing_id, allowed_ip_addresses)
+    def create_recipient(self, name, comment, sharing_id, allowed_ip_addresses, properties):
+        return self.client.create_recipient(name, comment, sharing_id, allowed_ip_addresses, properties)
 
     def list_recipients(self):
         return self.client.list_recipients()

--- a/databricks_cli/unity_catalog/api.py
+++ b/databricks_cli/unity_catalog/api.py
@@ -193,8 +193,10 @@ class UnityCatalogApi(object):
 
     # Recipient APIs
 
-    def create_recipient(self, name, comment, sharing_id, allowed_ip_addresses, properties):
-        return self.client.create_recipient(name, comment, sharing_id, allowed_ip_addresses, properties)
+    def create_recipient(self, name, comment, sharing_id,
+                         allowed_ip_addresses, properties):
+        return self.client.create_recipient(name, comment, sharing_id,
+                                            allowed_ip_addresses, properties)
 
     def list_recipients(self):
         return self.client.list_recipients()

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -471,10 +471,10 @@ def get_recipient_cli(api_client, name):
                   'IP allowlist.'))
 @click.option('--property', 'custom_property', default=None, required=False, multiple=True,
               help=(
-                  'Custom properties of the recipient. Key and value should be provided '
+                  'Properties of the recipient. Key and value should be provided '
                   'at the same time separated by an equal sign. '
-                  'Example: --custom-property country=US. '
-                  'Specify a single empty string to remove all custom properties.'))      
+                  'Example: --property country=US. '
+                  'Specify a single empty string to remove all properties.'))
 @click.option('--json-file', default=None, type=click.Path(),
               help=json_file_help(method='PATCH', path='/recipients/{name}'))
 @click.option('--json', default=None, type=JsonClickType(),

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -405,7 +405,7 @@ def parse_recipient_custom_properties(custom_property_list):
               help=(
                   'IP address in CIDR notation that is allowed to use delta sharing. '
                   '(can be specified multiple times).'))
-@click.option('--custom-property', default=None, required=False, multiple=True,
+@click.option('--property', 'custom_property', default=None, required=False, multiple=True,
               help=(
                   'Custom properties of the recipient. Key and value should be provided '
                   'at the same time separated by an equal sign. '
@@ -469,7 +469,7 @@ def get_recipient_cli(api_client, name):
                   'IP address in CIDR notation that is allowed to use delta sharing '
                   '(can be specified multiple times). Specify a single empty string to disable '
                   'IP allowlist.'))
-@click.option('--custom-property', default=None, required=False, multiple=True,
+@click.option('--property', 'custom_property', default=None, required=False, multiple=True,
               help=(
                   'Custom properties of the recipient. Key and value should be provided '
                   'at the same time separated by an equal sign. '

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -408,9 +408,13 @@ def create_recipient_cli(api_client, name, comment, sharing_id,
     """
     Create a new recipient.
     """
-    parsed_custom_properties = [property_str.split('=', 2) for property_str in custom_property]
-    custom_properties = [{"key": property_key, "value": property_value}
-                            for (property_key, property_value) in parsed_custom_properties]
+    custom_properties = []
+    for property_str in custom_property:
+        tokens = property_str.split('=', 2)
+        if len(tokens) != 2:
+            raise ValueError('Invalid format of custom property. '
+                             + 'The format should be <key>=<value>.')
+        custom_properties.append({"key": tokens[0], "value": tokens[1]})
     recipient_json = UnityCatalogApi(api_client).create_recipient(
         name, comment, sharing_id, allowed_ip_address, custom_properties)
     click.echo(mc_pretty_format(recipient_json))
@@ -465,7 +469,7 @@ def get_recipient_cli(api_client, name):
                   'Custom properties of the recipient. Key and value should be provided '
                   'at the same time separated by an equal sign. '
                   'Example: --custom-property country=US'
-                  'Speficy a single empty string to remove all customer properties.'))      
+                  'Specify a single empty string to remove all custom properties.'))      
 @click.option('--json-file', default=None, type=click.Path(),
               help=json_file_help(method='PATCH', path='/recipients/{name}'))
 @click.option('--json', default=None, type=JsonClickType(),
@@ -493,11 +497,14 @@ def update_recipient_cli(api_client, name, new_name, comment, owner,
         if len(custom_property) > 0:
             data['properties_kvpairs'] = {}
             if len(custom_property) != 1 or custom_property[0] != '':
-                parsed_custom_properties = [property_str.split('=', 2)
-                    for property_str in custom_property]
-                data['properties_kvpairs']['properties'] = [{"key": property_key,
-                                                            "value": property_value}
-                    for (property_key, property_value) in parsed_custom_properties]
+                data['properties_kvpairs']['properties'] = []
+                for property_str in custom_property:
+                    tokens = property_str.split('=', 2)
+                    if len(tokens) != 2:
+                        raise ValueError('Invalid format of custom property. '
+                                         + 'The format should be <key>=<value>.')
+                    data['properties_kvpairs']['properties'].append({"key": tokens[0],
+                                                                     "value": tokens[1]})
         recipient_json = UnityCatalogApi(api_client).update_recipient(name, data)
         click.echo(mc_pretty_format(recipient_json))
     else:

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -408,7 +408,7 @@ def create_recipient_cli(api_client, name, comment, sharing_id,
     """
     Create a new recipient.
     """
-    parsed_custom_properties = [property_str.split('=') for property_str in custom_property]
+    parsed_custom_properties = [property_str.split('=', 2) for property_str in custom_property]
     custom_properties = [{"key": property_key, "value": property_value}
                             for (property_key, property_value) in parsed_custom_properties]
     recipient_json = UnityCatalogApi(api_client).create_recipient(
@@ -493,7 +493,7 @@ def update_recipient_cli(api_client, name, new_name, comment, owner,
         if len(custom_property) > 0:
             data['properties_kvpairs'] = {}
             if len(custom_property) != 1 or custom_property[0] != '':
-                parsed_custom_properties = [property_str.split('=')
+                parsed_custom_properties = [property_str.split('=', 2)
                     for property_str in custom_property]
                 data['properties_kvpairs']['properties'] = [{"key": property_key,
                                                             "value": property_value}

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -407,9 +407,9 @@ def parse_recipient_custom_properties(custom_property_list):
                   '(can be specified multiple times).'))
 @click.option('--property', 'custom_property', default=None, required=False, multiple=True,
               help=(
-                  'Custom properties of the recipient. Key and value should be provided '
+                  'Properties of the recipient. Key and value should be provided '
                   'at the same time separated by an equal sign. '
-                  'Example: --custom-property country=US.'))                 
+                  'Example: --property country=US.'))
 @debug_option
 @profile_option
 @eat_exceptions

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -394,16 +394,22 @@ def delete_share_cli(api_client, name):
               help=(
                   'IP address in CIDR notation that is allowed to use delta sharing. '
                   '(can be specified multiple times).'))
+@click.option('--property', default=None, type=JsonClickType(), required=False, multiple=True,
+              help=(
+                  'Custom properties of the recipient. For format should be '
+                  '{"key": "<property-key>", "value": "<property-value>"}. '
+                  'Example: {"key": "country", "value": "US"}'))                  
 @debug_option
 @profile_option
 @eat_exceptions
 @provide_api_client
-def create_recipient_cli(api_client, name, comment, sharing_id, allowed_ip_address):
+def create_recipient_cli(api_client, name, comment, sharing_id, allowed_ip_address, property):
     """
     Create a new recipient.
     """
+    properties = [json_loads(property_str) for property_str in property]
     recipient_json = UnityCatalogApi(api_client).create_recipient(
-        name, comment, sharing_id, allowed_ip_address)
+        name, comment, sharing_id, allowed_ip_address, properties)
     click.echo(mc_pretty_format(recipient_json))
 
 
@@ -451,6 +457,12 @@ def get_recipient_cli(api_client, name):
                   'IP address in CIDR notation that is allowed to use delta sharing '
                   '(can be specified multiple times). Specify a single empty string to disable '
                   'IP allowlist.'))
+@click.option('--property', default=None, type=JsonClickType(), required=False, multiple=True,
+              help=(
+                  'Custom properties of the recipient. The format should be '
+                  '{"key": "<property-key>", "value": "<property-value>"}. '
+                  'Example: {"key": "country", "value": "US"}. '
+                  'Specify a single empty object `{}` to remove all properties.'))               
 @click.option('--json-file', default=None, type=click.Path(),
               help=json_file_help(method='PATCH', path='/recipients/{name}'))
 @click.option('--json', default=None, type=JsonClickType(),
@@ -460,14 +472,14 @@ def get_recipient_cli(api_client, name):
 @eat_exceptions
 @provide_api_client
 def update_recipient_cli(api_client, name, new_name, comment, owner,
-                         allowed_ip_address, json_file, json):
+                         allowed_ip_address, property, json_file, json):
     """
     Update a recipient.
 
     The public specification for the JSON request is in development.
     """
     if ((new_name is not None) or (comment is not None) or (owner is not None) or
-        len(allowed_ip_address) > 0):
+        len(allowed_ip_address) or len(property) > 0):
         if (json_file is not None) or (json is not None):
             raise ValueError('Cannot specify JSON if any other update flags are specified')
         data = {'name': new_name, 'comment': comment, 'owner': owner}
@@ -475,6 +487,10 @@ def update_recipient_cli(api_client, name, new_name, comment, owner,
             data['ip_access_list'] = {}
             if len(allowed_ip_address) != 1 or allowed_ip_address[0] != '':
                 data['ip_access_list']['allowed_ip_addresses'] = allowed_ip_address
+        if len(property) > 0:
+            data['properties_kvpairs'] = {}
+            if len(property) != 1 or json_loads(property[0]) != {}:
+                data['properties_kvpairs']['properties'] = [json_loads(property_str) for property_str in property]
         recipient_json = UnityCatalogApi(api_client).update_recipient(name, data)
         click.echo(mc_pretty_format(recipient_json))
     else:

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -388,7 +388,7 @@ def parse_recipient_custom_properties(custom_property_list):
     for property_str in custom_property_list:
         tokens = property_str.split('=', 2)
         if len(tokens) != 2:
-            raise ValueError('Invalid format of custom property. '
+            raise ValueError('Invalid format for property. '
                              + 'The format should be <key>=<value>.')
         custom_properties.append({"key": tokens[0], "value": tokens[1]})
     return custom_properties    

--- a/databricks_cli/unity_catalog/uc_service.py
+++ b/databricks_cli/unity_catalog/uc_service.py
@@ -379,7 +379,7 @@ class UnityCatalogService(object):
     # Recipient Operations
 
     def create_recipient(self, name, comment=None, sharing_id=None,
-                         allowed_ip_addresses=None, headers=None):
+                         allowed_ip_addresses=None, properties = None, headers=None):
         _data = {
             'name': name,
         }
@@ -393,6 +393,10 @@ class UnityCatalogService(object):
         if allowed_ip_addresses is not None:
             _data['ip_access_list'] = {
                 'allowed_ip_addresses': allowed_ip_addresses,
+            }
+        if properties is not None:
+            _data['properties_kvpairs'] = {
+                'properties': properties
             }
 
         return self.client.perform_query('POST', '/unity-catalog/recipients', data=_data,

--- a/databricks_cli/unity_catalog/uc_service.py
+++ b/databricks_cli/unity_catalog/uc_service.py
@@ -379,7 +379,7 @@ class UnityCatalogService(object):
     # Recipient Operations
 
     def create_recipient(self, name, comment=None, sharing_id=None,
-                         allowed_ip_addresses=None, properties = None, headers=None):
+                         allowed_ip_addresses=None, custom_properties = None, headers=None):
         _data = {
             'name': name,
         }
@@ -394,9 +394,9 @@ class UnityCatalogService(object):
             _data['ip_access_list'] = {
                 'allowed_ip_addresses': allowed_ip_addresses,
             }
-        if properties is not None:
+        if custom_properties is not None:
             _data['properties_kvpairs'] = {
-                'properties': properties
+                'properties': custom_properties
             }
 
         return self.client.perform_query('POST', '/unity-catalog/recipients', data=_data,

--- a/databricks_cli/unity_catalog/uc_service.py
+++ b/databricks_cli/unity_catalog/uc_service.py
@@ -379,7 +379,7 @@ class UnityCatalogService(object):
     # Recipient Operations
 
     def create_recipient(self, name, comment=None, sharing_id=None,
-                         allowed_ip_addresses=None, custom_properties = None, headers=None):
+                         allowed_ip_addresses=None, custom_properties=None, headers=None):
         _data = {
             'name': name,
         }

--- a/tests/unity_catalog/test_delta_sharing_cli.py
+++ b/tests/unity_catalog/test_delta_sharing_cli.py
@@ -463,8 +463,8 @@ def test_create_recipient_cli(api_mock, echo_mock):
             '--comment', 'comment',
             '--allowed-ip-address', '8.8.8.8',
             '--allowed-ip-address', '8.8.4.4',
-            '--custom-property', 'k1=v1',
-            '--custom-property', 'k2=v2'
+            '--property', 'k1=v1',
+            '--property', 'k2=v2'
         ])
     api_mock.create_recipient.assert_called_once_with(
         RECIPIENT_NAME,
@@ -484,7 +484,7 @@ def test_create_recipient_cli_invalid_custom_property(api_mock):
         delta_sharing_cli.create_recipient_cli,
         args=[
             '--name', RECIPIENT_NAME,
-            '--custom-property', 'k1=v1=v2'
+            '--property', 'k1=v1=v2'
         ])
 
     assert not api_mock.create_recipient.called
@@ -538,8 +538,8 @@ def test_update_recipient_cli(api_mock, echo_mock):
             '--owner', 'owner',
             '--allowed-ip-address', '8.8.8.8',
             '--allowed-ip-address', '8.8.4.4',
-            '--custom-property', 'k1=v1',
-            '--custom-property', 'k2=v2'
+            '--property', 'k1=v1',
+            '--property', 'k2=v2'
         ])
     expected_data = {
         'name': 'new_recipient_name',

--- a/tests/unity_catalog/test_delta_sharing_cli.py
+++ b/tests/unity_catalog/test_delta_sharing_cli.py
@@ -463,8 +463,8 @@ def test_create_recipient_cli(api_mock, echo_mock):
             '--comment', 'comment',
             '--allowed-ip-address', '8.8.8.8',
             '--allowed-ip-address', '8.8.4.4',
-            '--property', '{"key": "k1", "value": "v1"}',
-            '--property', '{"key": "k2", "value": "v2"}'
+            '--custom-property', 'k1=v1',
+            '--custom-property', 'k2=v2'
         ])
     api_mock.create_recipient.assert_called_once_with(
         RECIPIENT_NAME,
@@ -524,8 +524,8 @@ def test_update_recipient_cli(api_mock, echo_mock):
             '--owner', 'owner',
             '--allowed-ip-address', '8.8.8.8',
             '--allowed-ip-address', '8.8.4.4',
-            '--property', '{"key": "k1", "value": "v1"}',
-            '--property', '{"key": "k2", "value": "v2"}'
+            '--custom-property', 'k1=v1',
+            '--custom-property', 'k2=v2'
         ])
     expected_data = {
         'name': 'new_recipient_name',

--- a/tests/unity_catalog/test_delta_sharing_cli.py
+++ b/tests/unity_catalog/test_delta_sharing_cli.py
@@ -477,6 +477,20 @@ def test_create_recipient_cli(api_mock, echo_mock):
     
 
 @provide_conf
+def test_create_recipient_cli_invalid_custom_property(api_mock, echo_mock):
+    api_mock.create_recipient.return_value = RECIPIENT
+    runner = CliRunner()
+    runner.invoke(
+        delta_sharing_cli.create_recipient_cli,
+        args=[
+            '--name', RECIPIENT_NAME,
+            '--custom-property', 'k1=v1=v2'
+        ])
+
+    assert not api_mock.create_recipient.called
+
+
+@provide_conf
 def test_create_recipient_cli_with_sharing_id(api_mock, echo_mock):
     api_mock.create_recipient.return_value = RECIPIENT
     runner = CliRunner()

--- a/tests/unity_catalog/test_delta_sharing_cli.py
+++ b/tests/unity_catalog/test_delta_sharing_cli.py
@@ -477,7 +477,7 @@ def test_create_recipient_cli(api_mock, echo_mock):
     
 
 @provide_conf
-def test_create_recipient_cli_invalid_custom_property(api_mock, echo_mock):
+def test_create_recipient_cli_invalid_custom_property(api_mock):
     api_mock.create_recipient.return_value = RECIPIENT
     runner = CliRunner()
     runner.invoke(

--- a/tests/unity_catalog/test_delta_sharing_cli.py
+++ b/tests/unity_catalog/test_delta_sharing_cli.py
@@ -463,9 +463,16 @@ def test_create_recipient_cli(api_mock, echo_mock):
             '--comment', 'comment',
             '--allowed-ip-address', '8.8.8.8',
             '--allowed-ip-address', '8.8.4.4',
+            '--property', '{"key": "k1", "value": "v1"}',
+            '--property', '{"key": "k2", "value": "v2"}'
         ])
     api_mock.create_recipient.assert_called_once_with(
-        RECIPIENT_NAME, 'comment', None, ('8.8.8.8', '8.8.4.4'))
+        RECIPIENT_NAME,
+        'comment',
+        None,
+        ('8.8.8.8', '8.8.4.4'),
+        [{"key": "k1", "value": "v1"}, {"key": "k2", "value": "v2"}]
+    )
     echo_mock.assert_called_once_with(mc_pretty_format(RECIPIENT))
     
 
@@ -480,7 +487,7 @@ def test_create_recipient_cli_with_sharing_id(api_mock, echo_mock):
             '--sharing-id', '123e4567-e89b-12d3-a456-426614174000'
         ])
     api_mock.create_recipient.assert_called_once_with(
-        RECIPIENT_NAME, None, '123e4567-e89b-12d3-a456-426614174000', ())
+        RECIPIENT_NAME, None, '123e4567-e89b-12d3-a456-426614174000', (), [])
     echo_mock.assert_called_once_with(mc_pretty_format(RECIPIENT))
 
 
@@ -516,7 +523,9 @@ def test_update_recipient_cli(api_mock, echo_mock):
             '--comment', 'comment',
             '--owner', 'owner',
             '--allowed-ip-address', '8.8.8.8',
-            '--allowed-ip-address', '8.8.4.4'
+            '--allowed-ip-address', '8.8.4.4',
+            '--property', '{"key": "k1", "value": "v1"}',
+            '--property', '{"key": "k2", "value": "v2"}'
         ])
     expected_data = {
         'name': 'new_recipient_name',
@@ -527,6 +536,12 @@ def test_update_recipient_cli(api_mock, echo_mock):
                 '8.8.8.8',
                 '8.8.4.4'
             )
+        },
+        'properties_kvpairs': {
+            'properties': [
+                {"key": "k1", "value": "v1"}, 
+                {"key": "k2", "value": "v2"}
+            ]
         }
     }
     api_mock.update_recipient.assert_called_once_with(RECIPIENT_NAME, expected_data)


### PR DESCRIPTION
Add `--property` param to both recipient create and update command following the pattern of `allowed_ip_address`