### PR TITLE
Pin actions to Ubuntu 20.04

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
           - '3.8'
           - '3.9'
           - '3.10'
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-20.04 ]
     env:
       OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -60,7 +60,7 @@ jobs:
           env_vars: OS,PYTHON_VERSION
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version:
@@ -125,7 +125,7 @@ jobs:
 
   compat:
     name: Public API compatibility
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -8,7 +8,7 @@ on:
   
 jobs:
   tag:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/dev-requirements-py3.txt
+++ b/dev-requirements-py3.txt
@@ -9,6 +9,5 @@ flake8-polyfill==1.0.2
 mccabe==0.6.1
 prospector==1.7.7
 pycodestyle==2.8.0
-pydantic==1.10.2
 pyflakes==2.4.0
 pylint==2.15.5

--- a/dev-requirements-py3.txt
+++ b/dev-requirements-py3.txt
@@ -1,7 +1,7 @@
 -r ./dev-requirements.txt
 prospector[with_pyroma]
 
-# Latest versions of the linter introduce rules that make it fail.
+# More recent versions of these linters introduce rules that make it fail.
 # Pin these versions to keep the ruleset fixed.
 dodgy==0.2.1
 flake8==4.0.1

--- a/dev-requirements-py3.txt
+++ b/dev-requirements-py3.txt
@@ -10,4 +10,4 @@ mccabe==0.6.1
 prospector==1.7.7
 pycodestyle==2.8.0
 pyflakes==2.4.0
-pylint==2.15.5
+pylint==2.13.9

--- a/dev-requirements-py3.txt
+++ b/dev-requirements-py3.txt
@@ -1,2 +1,14 @@
 -r ./dev-requirements.txt
 prospector[with_pyroma]
+
+# Latest versions of the linter introduce rules that make it fail.
+# Pin these versions to keep the ruleset fixed.
+dodgy==0.2.1
+flake8==4.0.1
+flake8-polyfill==1.0.2
+mccabe==0.6.1
+prospector==1.7.7
+pycodestyle==2.8.0
+pydantic==1.10.2
+pyflakes==2.4.0
+pylint==2.15.5


### PR DESCRIPTION
The pointer for `ubuntu-latest` was updated to 22.04 on Oct 3 (see https://github.com/actions/runner-images/issues/6399).

We still run tests on 2.7 and 3.6 and should deprecate support separately.