### PR TITLE
Make use of the new name filtering in calls to list jobs.

### DIFF
--- a/databricks_cli/jobs/api.py
+++ b/databricks_cli/jobs/api.py
@@ -32,9 +32,10 @@ class JobsApi(object):
                                                 version=version)
 
     def list_jobs(self, job_type=None, expand_tasks=None, offset=None, limit=None, headers=None,
-                  version=None):
+                  version=None, name_filter=None):
         resp = self.client.list_jobs(job_type=job_type, expand_tasks=expand_tasks, offset=offset,
-                                     limit=limit, headers=headers, version=version)
+                                     limit=limit, headers=headers, version=version, 
+                                     name_filter=name_filter)
         if 'jobs' not in resp:
             resp['jobs'] = []
         return resp
@@ -56,6 +57,6 @@ class JobsApi(object):
                                    idempotency_token, headers=headers, version=version)
 
     def _list_jobs_by_name(self, name, headers=None):
-        jobs = self.list_jobs(headers=headers)['jobs']
+        jobs = self.list_jobs(headers=headers, name_filter=name)['jobs']
         result = list(filter(lambda job: job['settings']['name'] == name, jobs))
         return result

--- a/databricks_cli/sdk/service.py
+++ b/databricks_cli/sdk/service.py
@@ -287,7 +287,7 @@ class JobsService(object):
         )
 
     def list_jobs(
-        self, job_type=None, expand_tasks=None, limit=None, offset=None, headers=None, version=None
+        self, job_type=None, expand_tasks=None, limit=None, offset=None, headers=None, version=None, name_filter=None
     ):
         _data = {}
         if job_type is not None:
@@ -298,6 +298,8 @@ class JobsService(object):
             _data['limit'] = limit
         if offset is not None:
             _data['offset'] = offset
+        if name_filter is not None:
+            _data['name'] = name_filter
         return self.client.perform_query(
             'GET', '/jobs/list', data=_data, headers=headers, version=version
         )

--- a/tests/jobs/test_api.py
+++ b/tests/jobs/test_api.py
@@ -126,6 +126,11 @@ def test_list_jobs():
             'GET', '/jobs/list', data={}, headers=None, version='3.0'
         )
 
+        api.list_jobs(version='2.1', name_filter='foo')
+        api_client_mock.perform_query.assert_called_with(
+            'GET', '/jobs/list', data={'name':'foo'}, headers=None, version='2.1'
+        )
+
 
 @provide_conf
 def test_run_now():

--- a/tests/jobs/test_cli.py
+++ b/tests/jobs/test_cli.py
@@ -313,6 +313,14 @@ def test_list_offset(jobs_api_mock):
     assert jobs_api_mock.list_jobs.call_args[1]['offset'] == 1
     assert jobs_api_mock.list_jobs.call_args[1]['version'] == '2.1'
 
+@provide_conf
+def test_list_name(jobs_api_mock):
+    jobs_api_mock.list_jobs.return_value = LIST_RETURN_1
+    runner = CliRunner()
+    result = runner.invoke(cli.list_cli, ['--version=2.1', '--name', 'foo'])
+    assert result.exit_code == 0
+    assert jobs_api_mock.list_jobs.call_args[1]['name_filter'] == 'foo'
+    assert jobs_api_mock.list_jobs.call_args[1]['version'] == '2.1'
 
 @provide_conf
 def test_list_limit(jobs_api_mock):


### PR DESCRIPTION
Tried this out manually:

```
> databricks jobs list --name=test_continuous --version=2.1
371294009417906  test_continuous
```

And with 2.0 instead of 2.1:

```
> databricks jobs list --name=test_continuous
WARN: Your CLI is configured to use Jobs API 2.0. In order to use the latest Jobs features please upgrade to 2.1: 'databricks jobs configure --version=2.1'. Future versions of this CLI will default to the new Jobs API. Learn more at https://docs.databricks.com/dev-tools/cli/jobs-cli.html
ERROR: the options --expand-tasks, --offset, --limit, --all, and --name are only available in API 2.1
```