### PR TITLE
Add add-schema, update-schema, and remove-schema to Delta Sharing CLI

### DIFF
--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -240,7 +240,7 @@ def add_share_schema_cli(api_client, share, schema, comment, json_file, json):
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
-               short_help='Update a shared table.')
+               short_help='Update a shared schema.')
 @click.option('--share', required=True,
               help='Name of the share to update.')
 @create_common_shared_schema_options
@@ -290,7 +290,7 @@ def update_share_schema_cli(api_client, share, schema, comment, json_file, json)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
-               short_help='Update a shared table.')
+               short_help='Update a shared schema.')
 @click.option('--share', required=True,
               help='Name of the share to update.')
 @click.option('--schema', default=None,

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -122,27 +122,6 @@ def update_share_permissions_cli(api_client, name, json_file, json):
     json_cli_base(json_file, json,
                   lambda json: UnityCatalogApi(api_client).update_share_permissions(name, json))
 
-
-def shared_data_object(name=None, comment=None, shared_as=None, 
-                       cdf_enabled=None, partitions=None, start_version=None):
-    val = {
-        'data_object_type': 'TABLE'
-    }
-    if name is not None:
-        val['name'] = name
-    if comment is not None:
-        val['comment'] = comment
-    if shared_as is not None:
-        val['shared_as'] = shared_as
-    if cdf_enabled is not None:
-        val['cdf_enabled'] = cdf_enabled
-    if partitions is not None:
-        val['partitions'] = partitions
-    if start_version is not None:
-        val['start_version'] = start_version
-    return val
-
-
 @click.command(context_settings=CONTEXT_SETTINGS,
                short_help='Update a share.')
 @click.option('--name', required=True,
@@ -180,9 +159,9 @@ def update_share_cli(api_client, name, new_name, comment, owner,
             raise ValueError('Cannot specify JSON if any other update flags are specified')
         updates = []
         for a in add_table:
-            updates.append({'action': 'ADD', 'data_object': shared_data_object(a)})
+            updates.append({'action': 'ADD', 'data_object': shared_table_object(a)})
         for r in remove_table:
-            updates.append({'action': 'REMOVE', 'data_object': shared_data_object(r)})
+            updates.append({'action': 'REMOVE', 'data_object': shared_table_object(r)})
         data = {'name': new_name, 'comment': comment, 'owner': owner, 'updates': updates}
         share_json = UnityCatalogApi(api_client).update_share(name, data)
         click.echo(mc_pretty_format(share_json))
@@ -190,8 +169,183 @@ def update_share_cli(api_client, name, new_name, comment, owner,
         json_cli_base(json_file, json,
                       lambda json: UnityCatalogApi(api_client).update_share(name, json))
 
+def shared_schema_object(name=None, comment=None):
+    val = {
+        'data_object_type': 'SCHEMA'
+    }
+    if name is not None:
+        val['name'] = name
+    if comment is not None:
+        val['comment'] = comment
+    return val
 
-def create_common_shared_data_object_options(f):
+def create_common_shared_schema_options(f):
+    @click.option('--schema', required=True,
+                  help='Full name of the shared schema.')
+    @click.option('--comment', default=None,
+                  help='New comment of the shared schema.')
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        f(*args, **kwargs)
+    return wrapper
+
+@click.command(context_settings=CONTEXT_SETTINGS,
+               short_help='Add a shared schema.')
+@click.option('--share', required=True,
+              help='Name of the share to update.')
+@create_common_shared_schema_options
+@click.option('--json-file', default=None, type=click.Path(),
+              help="Adds a shared table based on shared data object represented in JSON file.")
+@click.option('--json', default=None, type=JsonClickType(),
+              help="Adds a shared table based on shared data object represented in JSON.")
+@debug_option
+@profile_option
+@eat_exceptions
+@provide_api_client
+def add_share_schema_cli(api_client, share, schema, comment, json_file, json):
+    """
+    Adds a shared schema.
+
+    The public specification for the JSON request is in development.
+    """
+    if comment is not None:
+        if (json_file is not None) or (json is not None):
+            raise ValueError('Cannot specify JSON if any other flags are specified')
+        data = { 
+            'updates': [
+                {
+                    'action': 'ADD',
+                    'data_object': shared_schema_object(
+                        name=schema,
+                        comment=comment
+                    )
+                }
+            ]
+        }
+        share_json = UnityCatalogApi(api_client).update_share(share, data)
+        click.echo(mc_pretty_format(share_json))
+    else:
+        json_cli_base(json_file, json, lambda d: UnityCatalogApi(api_client).update_share(share, { 
+            'updates': [
+                {
+                    'action': 'ADD',
+                    'data_object': d,
+                }
+            ]
+        }))
+
+
+@click.command(context_settings=CONTEXT_SETTINGS,
+               short_help='Update a shared table.')
+@click.option('--share', required=True,
+              help='Name of the share to update.')
+@create_common_shared_schema_options
+@click.option('--json-file', default=None, type=click.Path(),
+              help="Updates the shared table to shared data object represented in JSON file.")
+@click.option('--json', default=None, type=JsonClickType(),
+              help="Updates the shared table to shared data object represented in JSON.")
+@debug_option
+@profile_option
+@eat_exceptions
+@provide_api_client
+def update_share_schema_cli(api_client, share, schema, comment, json_file, json):
+    """
+    Updates a shared schema.
+
+    The public specification for the JSON request is in development.
+    """
+    if comment is not None:
+        if (json_file is not None) or (json is not None):
+            raise ValueError('Cannot specify JSON if any other flags are specified')
+        data = { 
+            'updates': [
+                {
+                    'action': 'UPDATE',
+                    'data_object': shared_schema_object(
+                        name=schema,
+                        comment=comment
+                    )
+                }
+            ]
+        }
+        share_json = UnityCatalogApi(api_client).update_share(share, data)
+        click.echo(mc_pretty_format(share_json))
+    else:
+        json_cli_base(json_file, json, lambda d: UnityCatalogApi(api_client).update_share(share, { 
+            'updates': [
+                {
+                    'action': 'UPDATE',
+                    'data_object': d,
+                }
+            ]
+        }))
+
+
+@click.command(context_settings=CONTEXT_SETTINGS,
+               short_help='Update a shared table.')
+@click.option('--share', required=True,
+              help='Name of the share to update.')
+@click.option('--schema', default=None,
+              help='Full name of the schema to remove from share.')
+@click.option('--json-file', default=None, type=click.Path(),
+              help="Removes the shared table based on shared data object represented in JSON file.")
+@click.option('--json', default=None, type=JsonClickType(),
+              help="Removes the shared table based on shared data object represented in JSON.")
+@debug_option
+@profile_option
+@eat_exceptions
+@provide_api_client
+def remove_share_schema_cli(api_client, share, schema, json_file, json):
+    """
+    Removes a shared schema either by full schema name.
+
+    The public specification for the JSON request is in development.
+    """
+    if schema is not None:
+        if (json_file is not None) or (json is not None):
+            raise ValueError('Cannot specify JSON if any other flags are specified')
+        data = { 
+            'updates': [
+                {
+                    'action': 'REMOVE',
+                    'data_object': shared_schema_object(
+                        name=schema,
+                    )
+                }
+            ]
+        }
+        share_json = UnityCatalogApi(api_client).update_share(share, data)
+        click.echo(mc_pretty_format(share_json))
+    else:
+        json_cli_base(json_file, json, lambda d: UnityCatalogApi(api_client).update_share(share, { 
+            'updates': [
+                {
+                    'action': 'REMOVE',
+                    'data_object': d,
+                }
+            ]
+        }))
+
+def shared_table_object(name=None, comment=None, shared_as=None, 
+                       cdf_enabled=None, partitions=None, start_version=None):
+    val = {
+        'data_object_type': 'TABLE'
+    }
+    if name is not None:
+        val['name'] = name
+    if comment is not None:
+        val['comment'] = comment
+    if shared_as is not None:
+        val['shared_as'] = shared_as
+    if cdf_enabled is not None:
+        val['cdf_enabled'] = cdf_enabled
+    if partitions is not None:
+        val['partitions'] = partitions
+    if start_version is not None:
+        val['start_version'] = start_version
+    return val
+
+def create_common_shared_table_options(f):
     @click.option('--table', required=True,
                   help='Full name of the shared table.')
     @click.option('--shared-as', default=None,
@@ -214,7 +368,7 @@ def create_common_shared_data_object_options(f):
                short_help='Add a shared table.')
 @click.option('--share', required=True,
               help='Name of the share to update.')
-@create_common_shared_data_object_options
+@create_common_shared_table_options
 @click.option('--json-file', default=None, type=click.Path(),
               help="Adds a shared table based on shared data object represented in JSON file.")
 @click.option('--json', default=None, type=JsonClickType(),
@@ -238,7 +392,7 @@ def add_share_table_cli(api_client, share, table, shared_as, comment,
             'updates': [
                 {
                     'action': 'ADD',
-                    'data_object': shared_data_object(
+                    'data_object': shared_table_object(
                         name=table,
                         shared_as=shared_as,
                         comment=comment,
@@ -266,7 +420,7 @@ def add_share_table_cli(api_client, share, table, shared_as, comment,
                short_help='Update a shared table.')
 @click.option('--share', required=True,
               help='Name of the share to update.')
-@create_common_shared_data_object_options
+@create_common_shared_table_options
 @click.option('--json-file', default=None, type=click.Path(),
               help="Updates the shared table to shared data object represented in JSON file.")
 @click.option('--json', default=None, type=JsonClickType(),
@@ -290,7 +444,7 @@ def update_share_table_cli(api_client, share, table, shared_as, comment,
             'updates': [
                 {
                     'action': 'UPDATE',
-                    'data_object': shared_data_object(
+                    'data_object': shared_table_object(
                         name=table,
                         shared_as=shared_as,
                         comment=comment,
@@ -319,7 +473,7 @@ def update_share_table_cli(api_client, share, table, shared_as, comment,
 @click.option('--share', required=True,
               help='Name of the share to update.')
 @click.option('--table', default=None,
-              help='Full name of the table to update from share.')
+              help='Full name of the table to remove from share.')
 @click.option('--shared-as', default=None,
               help='New name of the table inside the share.')
 @click.option('--json-file', default=None, type=click.Path(),
@@ -346,7 +500,7 @@ def remove_share_table_cli(api_client, share, table, shared_as, json_file, json)
             'updates': [
                 {
                     'action': 'REMOVE',
-                    'data_object': shared_data_object(
+                    'data_object': shared_table_object(
                         name=table,
                         shared_as=shared_as,
                     )
@@ -722,6 +876,9 @@ def register_shares_commands(cmd_group):
     shares_group.add_command(list_shares_cli, name='list')
     shares_group.add_command(get_share_cli, name='get')
     shares_group.add_command(update_share_cli, name='update')
+    shares_group.add_command(add_share_schema_cli, name='add-schema')
+    shares_group.add_command(update_share_schema_cli, name='update-schema')
+    shares_group.add_command(remove_share_schema_cli, name='remove-schema')
     shares_group.add_command(add_share_table_cli, name='add-table')
     shares_group.add_command(update_share_table_cli, name='update-table')
     shares_group.add_command(remove_share_table_cli, name='remove-table')

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -296,7 +296,8 @@ def update_share_schema_cli(api_client, share, schema, comment, json_file, json)
 @click.option('--schema', default=None,
               help='Full name of the schema to remove from share.')
 @click.option('--json-file', default=None, type=click.Path(),
-              help="Removes the shared schema based on shared data object represented in JSON file.")
+              help="Removes the shared schema based on shared data object" + 
+              "represented in JSON file.")
 @click.option('--json', default=None, type=JsonClickType(),
               help="Removes the shared schema based on shared data object represented in JSON.")
 @debug_option

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -290,7 +290,7 @@ def update_share_schema_cli(api_client, share, schema, comment, json_file, json)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
-               short_help='Update a shared schema.')
+               short_help='Remove a shared schema.')
 @click.option('--share', required=True,
               help='Name of the share to update.')
 @click.option('--schema', default=None,
@@ -491,7 +491,7 @@ def update_share_table_cli(api_client, share, table, shared_as, comment,
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
-               short_help='Update a shared table.')
+               short_help='Remove a shared table.')
 @click.option('--share', required=True,
               help='Name of the share to update.')
 @click.option('--table', default=None,

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -420,7 +420,7 @@ def add_share_table_cli(api_client, share, table, shared_as, comment,
     else:
         def api_call(d):
             if 'data_object_type' in d and d['data_object_type'] != "TABLE":
-                raise ValueError('Must specify data_object_type a "TABLE" '
+                raise ValueError('Must specify data_object_type as "TABLE" '
                                  'or not specify data_object_type at all')
             UnityCatalogApi(api_client).update_share(share, { 
                 'updates': [
@@ -477,7 +477,7 @@ def update_share_table_cli(api_client, share, table, shared_as, comment,
     else:
         def api_call(d):
             if 'data_object_type' in d and d['data_object_type'] != "TABLE":
-                raise ValueError('Must specify data_object_type a "TABLE" '
+                raise ValueError('Must specify data_object_type as "TABLE" '
                                  'or not specify data_object_type at all')
             UnityCatalogApi(api_client).update_share(share, { 
                 'updates': [
@@ -534,7 +534,7 @@ def remove_share_table_cli(api_client, share, table, shared_as, json_file, json)
     else:
         def api_call(d):
             if 'data_object_type' in d and d['data_object_type'] != "TABLE":
-                raise ValueError('Must specify data_object_type a "TABLE" '
+                raise ValueError('Must specify data_object_type as "TABLE" '
                                  'or not specify data_object_type at all')
             UnityCatalogApi(api_client).update_share(share, { 
                 'updates': [

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -306,7 +306,7 @@ def update_share_schema_cli(api_client, share, schema, comment, json_file, json)
 @provide_api_client
 def remove_share_schema_cli(api_client, share, schema, json_file, json):
     """
-    Removes a shared schema either by full schema name.
+    Removes a shared schema by full schema name.
 
     The public specification for the JSON request is in development.
     """
@@ -530,7 +530,7 @@ def remove_share_table_cli(api_client, share, table, shared_as, json_file, json)
             })
         json_cli_base(json_file, json, api_call)
     else:
-        if table is None or shared_as is None:
+        if table is None and shared_as is None:
             raise ValueError('Must specify full or shared as table name when removing shared table')
         data = { 
             'updates': [

--- a/databricks_cli/unity_catalog/delta_sharing_cli.py
+++ b/databricks_cli/unity_catalog/delta_sharing_cli.py
@@ -195,9 +195,9 @@ def create_common_shared_schema_options(f):
               help='Name of the share to update.')
 @create_common_shared_schema_options
 @click.option('--json-file', default=None, type=click.Path(),
-              help="Adds a shared table based on shared data object represented in JSON file.")
+              help="Adds a shared schema based on shared data object represented in JSON file.")
 @click.option('--json', default=None, type=JsonClickType(),
-              help="Adds a shared table based on shared data object represented in JSON.")
+              help="Adds a shared schema based on shared data object represented in JSON.")
 @debug_option
 @profile_option
 @eat_exceptions
@@ -225,14 +225,18 @@ def add_share_schema_cli(api_client, share, schema, comment, json_file, json):
         share_json = UnityCatalogApi(api_client).update_share(share, data)
         click.echo(mc_pretty_format(share_json))
     else:
-        json_cli_base(json_file, json, lambda d: UnityCatalogApi(api_client).update_share(share, { 
-            'updates': [
-                {
-                    'action': 'ADD',
-                    'data_object': d,
-                }
-            ]
-        }))
+        def api_call(d):
+            if 'data_object_type' not in d or d['data_object_type'] != "SCHEMA":
+                raise ValueError('Must specify data_object_type as "SCHEMA"')
+            UnityCatalogApi(api_client).update_share(share, { 
+                'updates': [
+                    {
+                        'action': 'ADD',
+                        'data_object': d,
+                    }
+                ]
+            })
+        json_cli_base(json_file, json, api_call)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
@@ -241,9 +245,9 @@ def add_share_schema_cli(api_client, share, schema, comment, json_file, json):
               help='Name of the share to update.')
 @create_common_shared_schema_options
 @click.option('--json-file', default=None, type=click.Path(),
-              help="Updates the shared table to shared data object represented in JSON file.")
+              help="Updates the shared schema to shared data object represented in JSON file.")
 @click.option('--json', default=None, type=JsonClickType(),
-              help="Updates the shared table to shared data object represented in JSON.")
+              help="Updates the shared schema to shared data object represented in JSON.")
 @debug_option
 @profile_option
 @eat_exceptions
@@ -271,14 +275,18 @@ def update_share_schema_cli(api_client, share, schema, comment, json_file, json)
         share_json = UnityCatalogApi(api_client).update_share(share, data)
         click.echo(mc_pretty_format(share_json))
     else:
-        json_cli_base(json_file, json, lambda d: UnityCatalogApi(api_client).update_share(share, { 
-            'updates': [
-                {
-                    'action': 'UPDATE',
-                    'data_object': d,
-                }
-            ]
-        }))
+        def api_call(d):
+            if 'data_object_type' not in d or d['data_object_type'] != "SCHEMA":
+                raise ValueError('Must specify data_object_type as "SCHEMA"')
+            UnityCatalogApi(api_client).update_share(share, { 
+                'updates': [
+                    {
+                        'action': 'UPDATE',
+                        'data_object': d,
+                    }
+                ]
+            })
+        json_cli_base(json_file, json, api_call)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
@@ -288,9 +296,9 @@ def update_share_schema_cli(api_client, share, schema, comment, json_file, json)
 @click.option('--schema', default=None,
               help='Full name of the schema to remove from share.')
 @click.option('--json-file', default=None, type=click.Path(),
-              help="Removes the shared table based on shared data object represented in JSON file.")
+              help="Removes the shared schema based on shared data object represented in JSON file.")
 @click.option('--json', default=None, type=JsonClickType(),
-              help="Removes the shared table based on shared data object represented in JSON.")
+              help="Removes the shared schema based on shared data object represented in JSON.")
 @debug_option
 @profile_option
 @eat_exceptions
@@ -317,14 +325,18 @@ def remove_share_schema_cli(api_client, share, schema, json_file, json):
         share_json = UnityCatalogApi(api_client).update_share(share, data)
         click.echo(mc_pretty_format(share_json))
     else:
-        json_cli_base(json_file, json, lambda d: UnityCatalogApi(api_client).update_share(share, { 
-            'updates': [
-                {
-                    'action': 'REMOVE',
-                    'data_object': d,
-                }
-            ]
-        }))
+        def api_call(d):
+            if 'data_object_type' not in d or d['data_object_type'] != "SCHEMA":
+                raise ValueError('Must specify data_object_type as "SCHEMA"')
+            UnityCatalogApi(api_client).update_share(share, { 
+                'updates': [
+                    {
+                        'action': 'REMOVE',
+                        'data_object': d,
+                    }
+                ]
+            })
+        json_cli_base(json_file, json, api_call)
 
 def shared_table_object(name=None, comment=None, shared_as=None, 
                        cdf_enabled=None, partitions=None, start_version=None):
@@ -406,14 +418,19 @@ def add_share_table_cli(api_client, share, table, shared_as, comment,
         share_json = UnityCatalogApi(api_client).update_share(share, data)
         click.echo(mc_pretty_format(share_json))
     else:
-        json_cli_base(json_file, json, lambda d: UnityCatalogApi(api_client).update_share(share, { 
-            'updates': [
-                {
-                    'action': 'ADD',
-                    'data_object': d,
-                }
-            ]
-        }))
+        def api_call(d):
+            if 'data_object_type' in d and d['data_object_type'] != "TABLE":
+                raise ValueError('Must specify data_object_type a "TABLE" '
+                                 'or not specify data_object_type at all')
+            UnityCatalogApi(api_client).update_share(share, { 
+                'updates': [
+                    {
+                        'action': 'REMOVE',
+                        'data_object': d,
+                    }
+                ]
+            })
+        json_cli_base(json_file, json, api_call)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
@@ -458,14 +475,19 @@ def update_share_table_cli(api_client, share, table, shared_as, comment,
         share_json = UnityCatalogApi(api_client).update_share(share, data)
         click.echo(mc_pretty_format(share_json))
     else:
-        json_cli_base(json_file, json, lambda d: UnityCatalogApi(api_client).update_share(share, { 
-            'updates': [
-                {
-                    'action': 'UPDATE',
-                    'data_object': d,
-                }
-            ]
-        }))
+        def api_call(d):
+            if 'data_object_type' in d and d['data_object_type'] != "TABLE":
+                raise ValueError('Must specify data_object_type a "TABLE" '
+                                 'or not specify data_object_type at all')
+            UnityCatalogApi(api_client).update_share(share, { 
+                'updates': [
+                    {
+                        'action': 'UPDATE',
+                        'data_object': d,
+                    }
+                ]
+            })
+        json_cli_base(json_file, json, api_call)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,
@@ -510,14 +532,19 @@ def remove_share_table_cli(api_client, share, table, shared_as, json_file, json)
         share_json = UnityCatalogApi(api_client).update_share(share, data)
         click.echo(mc_pretty_format(share_json))
     else:
-        json_cli_base(json_file, json, lambda d: UnityCatalogApi(api_client).update_share(share, { 
-            'updates': [
-                {
-                    'action': 'REMOVE',
-                    'data_object': d,
-                }
-            ]
-        }))
+        def api_call(d):
+            if 'data_object_type' in d and d['data_object_type'] != "TABLE":
+                raise ValueError('Must specify data_object_type a "TABLE" '
+                                 'or not specify data_object_type at all')
+            UnityCatalogApi(api_client).update_share(share, { 
+                'updates': [
+                    {
+                        'action': 'REMOVE',
+                        'data_object': d,
+                    }
+                ]
+            })
+        json_cli_base(json_file, json, api_call)
 
 
 @click.command(context_settings=CONTEXT_SETTINGS,

--- a/tests/unity_catalog/test_delta_sharing_cli.py
+++ b/tests/unity_catalog/test_delta_sharing_cli.py
@@ -214,6 +214,84 @@ def test_update_share_cli(api_mock, echo_mock):
     api_mock.update_share.assert_called_once_with(SHARE_NAME, expected_data)
     echo_mock.assert_called_once_with(mc_pretty_format(SHARE))
 
+@provide_conf
+def test_add_share_schema_cli(api_mock, echo_mock):
+    api_mock.update_share.return_value = SHARE
+    runner = CliRunner()
+    runner.invoke(
+        delta_sharing_cli.add_share_schema_cli,
+        args=[
+            '--share', SHARE_NAME,
+            '--schema', 'catalog.schema',
+            '--comment', 'add.comment',
+        ])
+    expected_data = {
+        'updates': [
+            {
+                'action': 'ADD',
+                'data_object': {
+                    'data_object_type': 'SCHEMA',
+                    'name': 'catalog.schema',
+                    'comment': 'add.comment',
+                }
+            }
+        ]
+    }
+    api_mock.update_share.assert_called_once_with(SHARE_NAME, expected_data)
+    echo_mock.assert_called_once_with(mc_pretty_format(SHARE))
+
+
+@provide_conf
+def test_update_share_schema_cli(api_mock, echo_mock):
+    api_mock.update_share.return_value = SHARE
+    runner = CliRunner()
+    runner.invoke(
+        delta_sharing_cli.update_share_schema_cli,
+        args=[
+            '--share', SHARE_NAME,
+            '--schema', 'catalog.schema',
+            '--comment', 'update.comment',
+        ])
+    expected_data = {
+        'updates': [
+            {
+                'action': 'UPDATE',
+                'data_object': {
+                    'data_object_type': 'SCHEMA',
+                    'name': 'catalog.schema',
+                    'comment': 'update.comment',
+                }
+            }
+        ]
+    }
+    api_mock.update_share.assert_called_once_with(SHARE_NAME, expected_data)
+    echo_mock.assert_called_once_with(mc_pretty_format(SHARE))
+
+
+@provide_conf
+def test_remove_share_schema_cli(api_mock, echo_mock):
+    api_mock.update_share.return_value = SHARE
+    runner = CliRunner()
+    runner.invoke(
+        delta_sharing_cli.remove_share_schema_cli,
+        args=[
+            '--share', SHARE_NAME,
+            '--schema', 'catalog.schema',
+        ])
+    expected_data = {
+        'updates': [
+            {
+                'action': 'REMOVE',
+                'data_object': {
+                    'data_object_type': 'SCHEMA',
+                    'name': 'catalog.schema',
+                }
+            }
+        ]
+    }
+    api_mock.update_share.assert_called_once_with(SHARE_NAME, expected_data)
+    echo_mock.assert_called_once_with(mc_pretty_format(SHARE))
+
 
 @provide_conf
 def test_add_share_table_cli(api_mock, echo_mock):

--- a/tests/unity_catalog/test_delta_sharing_cli.py
+++ b/tests/unity_catalog/test_delta_sharing_cli.py
@@ -215,7 +215,7 @@ def test_update_share_cli(api_mock, echo_mock):
     echo_mock.assert_called_once_with(mc_pretty_format(SHARE))
 
 @provide_conf
-def test_add_share_schema_cli(api_mock, echo_mock):
+def test_add_share_schema_with_comment_cli(api_mock, echo_mock):
     api_mock.update_share.return_value = SHARE
     runner = CliRunner()
     runner.invoke(
@@ -233,6 +233,31 @@ def test_add_share_schema_cli(api_mock, echo_mock):
                     'data_object_type': 'SCHEMA',
                     'name': 'catalog.schema',
                     'comment': 'add.comment',
+                }
+            }
+        ]
+    }
+    api_mock.update_share.assert_called_once_with(SHARE_NAME, expected_data)
+    echo_mock.assert_called_once_with(mc_pretty_format(SHARE))
+
+
+@provide_conf
+def test_add_share_schema_cli(api_mock, echo_mock):
+    api_mock.update_share.return_value = SHARE
+    runner = CliRunner()
+    runner.invoke(
+        delta_sharing_cli.add_share_schema_cli,
+        args=[
+            '--share', SHARE_NAME,
+            '--schema', 'catalog.schema',
+        ])
+    expected_data = {
+        'updates': [
+            {
+                'action': 'ADD',
+                'data_object': {
+                    'data_object_type': 'SCHEMA',
+                    'name': 'catalog.schema',
                 }
             }
         ]


### PR DESCRIPTION
This PR adds the following command to Delta Sharing CLI:
```
databricks unity-catalog shares add-schema 
  --share a 
  --schema b
  --comment "comment to update to"

databricks unity-catalog shares add-schema
  --share a 
  --schema b
  --json "{...}"

databricks unity-catalog shares add-schema
  --share a 
  --schema b
  --json-file /path/to/json/file

databricks unity-catalog shares update-schema 
  --share a 
  --schema b
  --comment "comment to update to"
  
databricks unity-catalog shares update-schema
  --share a 
  --schema b
  --json "{...}"

databricks unity-catalog shares update-schema
  --share a 
  --schema b
  --json-file /path/to/json/file

databricks unity-catalog shares remove-schema
  --share a
  --schema b
```