### PR TITLE
bugfix: replace deprecated DEFAULT_METHOD_WHITELIST with DEFAULT_ALLOWED_METHODS

### DIFF
--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -103,7 +103,7 @@ class ApiClient(object):
             total=6,
             backoff_factor=1,
             status_forcelist=[429],
-            method_whitelist=set({'POST'}) | set(Retry.DEFAULT_METHOD_WHITELIST),
+            method_whitelist=set({'POST'}) | set(Retry.DEFAULT_ALLOWED_METHODS),
             respect_retry_after_header=True,
             raise_on_status=False # return original response when retries have been exhausted
         )


### PR DESCRIPTION
fix for #634 

replaces deprecated `DEFAULT_METHOD_WHITELIST` in `urllib3>=2.0` with `DEFAULT_ALLOWED_METHODS`.

DEFAULT_ALLOWED_METHODS is supported in the latest versions of urrlib3 and requests