### PR TITLE
Fix api client by switching to replacements for deprecated urllib3 methods

### DIFF
--- a/databricks_cli/sdk/api_client.py
+++ b/databricks_cli/sdk/api_client.py
@@ -103,7 +103,7 @@ class ApiClient(object):
             total=6,
             backoff_factor=1,
             status_forcelist=[429],
-            method_whitelist=set({'POST'}) | set(Retry.DEFAULT_METHOD_WHITELIST),
+            allowed_methods=set({'POST'}) | set(Retry.DEFAULT_ALLOWED_METHODS),
             respect_retry_after_header=True,
             raise_on_status=False # return original response when retries have been exhausted
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ requests>=2.17.3
 tabulate>=0.7.7
 six>=1.10.0
 configparser>=0.3.5;python_version < "3.6"
+urllib3>=1.26.7,<2.0.0

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'tabulate>=0.7.7',
         'six>=1.10.0',
         'configparser>=0.3.5;python_version < "3.6"',
+        'urllib3>=1.26.7,<2.0.0'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
Recently with the release of urllib3 v2.0.0 some deprecated attributes were removed. This PR uses there new replacements and pins the urllib3 version to when the replacements became available

We need to bound the urllib3 version because this issue has not been resolved on the `requests` package side as well and the requests package enforces `urllib3 v1.21 or greater` which does not contain the methods we need

This should fix https://github.com/databricks/databricks-cli/issues/636


Tested manually by:

1. pip3 install requirements.txt
2. python3 databricks_cli/cli.py fs ls dbfs:/

Before:
```
shreyas.goenka@THW32HFW6T databricks-cli % python3 databricks_cli/cli.py fs ls dbfs:/
Error: AttributeError: type object 'Retry' has no attribute 'DEFAULT_METHOD_WHITELIST'
```

After (expected response):
```
shreyas.goenka@THW32HFW6T databricks-cli % python3 databricks_cli/cli.py fs ls dbfs:/
dir1
dir2
dir3
...
```