### PR TITLE
use .ipynb extension if output format is JUPYTER

### DIFF
--- a/databricks_cli/workspace/cli.py
+++ b/databricks_cli/workspace/cli.py
@@ -124,7 +124,8 @@ def export_workspace_cli(api_client, source_path, target_path, format, overwrite
         file_info = WorkspaceApi(api_client).get_status(source_path)
         if not file_info.is_notebook:
             raise RuntimeError('Export can only be called on a notebook.')
-        extension = WorkspaceLanguage.to_extension(file_info.language)
+        jupyter_fmt = (format == "JUPYTER")
+        extension = WorkspaceLanguage.to_extension(file_info.language, jupyter_fmt)
         target_path = os.path.join(target_path, file_info.basename + extension)
     WorkspaceApi(api_client).export_workspace(source_path, target_path, format, overwrite) # NOQA
 

--- a/databricks_cli/workspace/types.py
+++ b/databricks_cli/workspace/types.py
@@ -53,7 +53,9 @@ class WorkspaceLanguage(object):
         return language_and_format
 
     @classmethod
-    def to_extension(cls, language):
+    def to_extension(cls, language, jupyter_fmt=False):
+        if jupyter_fmt:
+            return '.ipynb'
         if language == cls.SCALA:
             return '.scala'
         elif language == cls.PYTHON:


### PR DESCRIPTION
When requesting `JUPYTER` output format, each of the language types properly export in `.ipynb` JSON format, but the file extensions are incorrect. I updated the `.to_extension` method to take an argument for whether the requested output format is `JUPYTER`. If so, the method returns `.ipynb` as the file extension.

![Python-test](https://github.com/databricks/databricks-cli/assets/48223448/6e622aff-8360-4acf-84fa-6bc2f594e030)

![R-test](https://github.com/databricks/databricks-cli/assets/48223448/84e00a76-9130-4641-b2b6-84b971790737)

![Scala-test](https://github.com/databricks/databricks-cli/assets/48223448/caf0e5b5-0549-44e3-9744-acdc32b3ad50)

![SQL-test](https://github.com/databricks/databricks-cli/assets/48223448/b1082a60-276e-4fbd-b220-35d1b105b00d)
