### PR TITLE
Drop support for Python 2.7

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,16 +9,12 @@ ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends tig python2.7 python2.7-dev
+    && apt-get -y install --no-install-recommends tig
 
 RUN /usr/local/bin/python3 -m pip install --upgrade pip
 COPY requirements.txt /tmp/pip-tmp/
 COPY dev-requirements*.txt /tmp/pip-tmp/
-RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/dev-requirements-py3.txt \
-    && wget https://bootstrap.pypa.io/pip/2.7/get-pip.py \
-    && python2.7 get-pip.py \
-    && rm get-pip.py \
-    && python2.7 -m pip install -r /tmp/pip-tmp/dev-requirements-py2.txt \
+RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/dev-requirements-py3.txt
     && rm -rf /tmp/pip-tmp
 
 # [Optional] Uncomment this line to install global node packages.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,9 @@ Setting up the dev environment
 To isolate dependencies from your global python installation, it is important to use a tool like
 [virtualenv](https://virtualenv.pypa.io/en/stable/). With `virtualenv` you can install the dev environment by doing the following.
 
-Another option would be to use docker directly, i.e. 
+Another option would be to use docker directly, i.e.
 ```bash
 docker run -it -v `echo $PWD`:/root python:3.6.8 bash
-docker run -it -v `echo $PWD`:/root python:2.7.12 bash
 
 ```
 
@@ -28,7 +27,7 @@ Requirements:
 Developing using Github CodeSpaces
 ----------------------------------
 
-The same development container setup used for local VSCode also works with GitHub CodeSpaces. If you have CodeSpaces enabled in your Github account then can just create a CodeSpace from the repoand start coding. 
+The same development container setup used for local VSCode also works with GitHub CodeSpaces. If you have CodeSpaces enabled in your Github account then can just create a CodeSpace from the repoand start coding.
 
 In order to test the CLI against a Databricks cluster you can define the these secrets for your CodeSpace so you don't have to run `databricks init` eacht time you open it:
 
@@ -41,4 +40,3 @@ https://docs.github.com/en/codespaces/managing-your-codespaces/managing-encrypte
 Running Tests
 ----------------
 - `tox`
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:2.7
+FROM python:3.6
 
 WORKDIR /usr/src/databricks-cli
 
 COPY . .
 
 RUN pip install --upgrade pip && \
-    pip install -r dev-requirements-py2.txt && \
+    pip install -r dev-requirements-py3.txt && \
     pip list && \
     ./lint.sh && \
     pip install . && \

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ In addition, please leave bug reports as issues on our `GitHub project <https://
 Requirements
 ------------
 
--  Python Version > 2.7.9 or > 3.6
+-  Python Version > 3.6
 
 Installation
 ---------------
@@ -58,7 +58,7 @@ Using Docker
 
     # run command in docker
     docker run -it databricks-cli fs --help
-    
+
 Documentation
 -------------
 

--- a/databricks_cli/sdk/__init__.py
+++ b/databricks_cli/sdk/__init__.py
@@ -26,7 +26,7 @@ Databricks Python REST Client 2.0 for interacting with various services.
 
 Currently supports services including clusters, clusters policies and jobs.
 
-Requires Python 2.7.9 or above.
+Requires Python 3.6 or above.
 
 To get started, below is an example usage of the Python API client.
 

--- a/dev-requirements-py2.txt
+++ b/dev-requirements-py2.txt
@@ -1,6 +1,0 @@
--r ./dev-requirements.txt
-prospector[with_pyroma]==0.12.7
-pylint-django<2.0
-pep8-naming==0.5.0
-flake8<3.5
-pyflakes<1.6.0,>=1.5.0

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
     classifiers=[
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'License :: OSI Approved :: Apache Software License',
     ],


### PR DESCRIPTION
The GitHub Actions builds no longer work for 2.7 (see #651) and it's been EOL for quite some time.

I ran `git grep 2.7` on the repository and updated each instance.