### PR TITLE
Remove pin on "urllib3 < 2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ requests>=2.17.3
 tabulate>=0.7.7
 six>=1.10.0
 configparser>=0.3.5;python_version < "3.6"
-urllib3>=1.26.7,<2.0.0
+urllib3>=1.26.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ requests>=2.17.3
 tabulate>=0.7.7
 six>=1.10.0
 configparser>=0.3.5;python_version < "3.6"
-urllib3>=1.26.7
+urllib3>=1.26.7,<3

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'tabulate>=0.7.7',
         'six>=1.10.0',
         'configparser>=0.3.5;python_version < "3.6"',
-        'urllib3>=1.26.7,<2.0.0'
+        'urllib3>=1.26.7'
     ],
     entry_points='''
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'tabulate>=0.7.7',
         'six>=1.10.0',
         'configparser>=0.3.5;python_version < "3.6"',
-        'urllib3>=1.26.7'
+        'urllib3>=1.26.7,<3'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
Fixes #645

As discussed in #644 the pin may be removed. Deprecated methods have been migrated.

(Why merge this change to the legacy CLI? https://github.com/databricks/databricks-sdk-py is still in beta and not yet declared stable, so in order to to unpin libraries that depend on this (e.g. mlflow) in the near future we need this change to be released. Would appreciate it please!)

Thanks