### PR TITLE
Add bdist universal wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,5 +68,6 @@ setup(
         "Programming Language :: Python :: 3.12",
     ],
     keywords='databricks cli',
-    url='https://github.com/databricks/databricks-cli'
+    url='https://github.com/databricks/databricks-cli',
+    options={'bdist_wheel': {'universal': True}},
 )


### PR DESCRIPTION
We can support a universal wheel for the build. This means that users won't need to install a source distribution & run setup.py; they can just download the wheel artifact for use.